### PR TITLE
Use initial state for section missing in an import.

### DIFF
--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -112,6 +112,13 @@ const reducer = (state, { type, payload }) => {
       return state;
     case 'import_data':
       if (payload === null) return initialState;
+
+      for(const section of Object.keys(initialState.data)){
+        if(!(section in payload.data)){
+          payload.data[section] = initialState.data[section];
+        }
+      }
+      
       return {
         ...state,
         data: payload.data,


### PR DESCRIPTION
This fixes  issue #9 by using the data from the initial state for sections missing in the imported data.