### PR TITLE
[Workaround] Gengar: Break line when CertificationItem p content is too long.

### DIFF
--- a/src/templates/gengar/Gengar.js
+++ b/src/templates/gengar/Gengar.js
@@ -117,7 +117,7 @@ const Gengar = () => {
     <div key={x.title} className="mb-3">
       <h6 className="font-semibold">{x.title}</h6>
       <p className="text-xs">{x.subtitle}</p>
-      <ReactMarkdown className="mt-2 text-sm" source={x.description} />
+      <ReactMarkdown className="mt-2 text-sm break-words" source={x.description} />
     </div>
   );
 


### PR DESCRIPTION
Hey there! Cool app, I'm already making use of it.

Regarding Gengar theme. Content in CertificationItem wont wrap if too long, which results in ugly looks, if you put something too long there, like an URL for instance.
As a work around, I've put tailwind's "break-words" there, which seems to fix for CertificationItem. 

Original:
![Original](https://user-images.githubusercontent.com/8449810/78107379-b9253480-73cb-11ea-818f-7bac1f7b5080.png)
Fixed:
![Fixed](https://user-images.githubusercontent.com/8449810/78107397-c2160600-73cb-11ea-8efb-47afc892ea96.png)

