### PR TITLE
Add Vietnamese to the list as "Tiếng Việt"

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -54,6 +54,10 @@ const languages = [
     code: 'es',
     name: 'Spanish',
   },
+  {
+    code: 'vi',
+    name: 'Tiếng Việt'
+  }
 ];
 
 i18n


### PR DESCRIPTION
I suggest using the language names as written in their own languages, e.g. German -> Deutsch, Korean -> 한국어, Vietnamese -> Tiếng Việt, etc.