### PR TITLE
Fix scaling for large monitor

### DIFF
--- a/src/components/builder/center/Artboard.js
+++ b/src/components/builder/center/Artboard.js
@@ -34,6 +34,7 @@ const Artboard = () => {
         className={styles.container}
         style={{
           transform: `scale(${width / 1680})`,
+          transformOrigin: `${width / 1680 > 1.0 ? `top left` : ``}`,
         }}
       >
         {template === 'onyx' && <Onyx data={state} />}


### PR DESCRIPTION
Fix #248

It seems to cut off the text if it over resolution width 1680.
So if over 1680, add `transform-origin`.

I'm beginner of frontend development.
Please do not hesitate fix this PR.