### PR TITLE
Set contact icons for phone, website, and email

### DIFF
--- a/src/templates/blocks/Contact/ContactA.js
+++ b/src/templates/blocks/Contact/ContactA.js
@@ -37,16 +37,19 @@ const ContactA = () => {
       <ContactItem
         label={t('shared.forms.phone')}
         value={data.profile.phone}
+        icon="phone"
         link={`tel:${data.profile.phone}`}
       />
       <ContactItem
         label={t('shared.forms.website')}
         value={data.profile.website}
+        icon="website"
         link={data.profile.website}
       />
       <ContactItem
         label={t('shared.forms.email')}
         value={data.profile.email}
+        icon="email"
         link={`mailto:${data.profile.email}`}
       />
 

--- a/src/templates/blocks/Contact/ContactB.js
+++ b/src/templates/blocks/Contact/ContactB.js
@@ -37,16 +37,19 @@ const ContactB = () => {
       <ContactItem
         label={t('shared.forms.phone')}
         value={data.profile.phone}
+        icon="phone"
         link={`tel:${data.profile.phone}`}
       />
       <ContactItem
         label={t('shared.forms.website')}
         value={data.profile.website}
+        icon="website"
         link={data.profile.website}
       />
       <ContactItem
         label={t('shared.forms.email')}
         value={data.profile.email}
+        icon="email"
         link={`mailto:${data.profile.email}`}
       />
 


### PR DESCRIPTION
The icons for phone, website, and email were already imported into the application and ready to use, but they hadn't been applied to the contact slots. I've added them in the same contact areas the other icons are used (such as GitHub, Twitter, etc.)