### PR TITLE
Fix app crashes after setting date range

### DIFF
--- a/src/components/builder/lists/List.js
+++ b/src/components/builder/lists/List.js
@@ -21,7 +21,7 @@ const List = ({
   hasDate,
   event,
 }) => {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const items = useSelector(path, []);
   const { emitter } = useContext(ModalContext);
 
@@ -49,7 +49,7 @@ const List = ({
                     startDate: x.startDate,
                     endDate: x.endDate,
                     language: i18n.language,
-                  }))
+                  }, t))
               }
               text={text || get(x, textPath, '')}
               onEdit={() => handleEdit(x)}

--- a/src/modals/DataModal.js
+++ b/src/modals/DataModal.js
@@ -85,7 +85,7 @@ const DataModal = ({
   };
 
   const getTitle = isEmpty(title)
-    ? getModalText(isEditMode, name)
+    ? getModalText(isEditMode, name, t)
     : isEditMode
     ? title.edit
     : title.create;

--- a/src/templates/blocks/Education/EducationA.js
+++ b/src/templates/blocks/Education/EducationA.js
@@ -1,37 +1,41 @@
 import React, { memo, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import PageContext from '../../../contexts/PageContext';
 import { formatDateRange, safetyCheck } from '../../../utils';
 
-const EducationItem = ({ item, language }) => (
-  <div>
-    <div className="flex justify-between items-center">
-      <div className="flex flex-col text-left mr-2">
-        <h6 className="font-semibold">{item.institution}</h6>
-        <span className="text-xs">
-          <strong>{item.degree}</strong> {item.field}
-        </span>
+const EducationItem = ({ item, language }) => {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <div className="flex justify-between items-center">
+        <div className="flex flex-col text-left mr-2">
+          <h6 className="font-semibold">{item.institution}</h6>
+          <span className="text-xs">
+            <strong>{item.degree}</strong> {item.field}
+          </span>
+        </div>
+        <div className="flex flex-col items-end text-right">
+          {item.startDate && (
+            <h6 className="text-xs font-medium mb-1">
+              (
+              {formatDateRange({
+                startDate: item.startDate,
+                endDate: item.endDate,
+                language,
+              }, t)}
+              )
+            </h6>
+          )}
+          <span className="text-sm font-medium">{item.gpa}</span>
+        </div>
       </div>
-      <div className="flex flex-col items-end text-right">
-        {item.startDate && (
-          <h6 className="text-xs font-medium mb-1">
-            (
-            {formatDateRange({
-              startDate: item.startDate,
-              endDate: item.endDate,
-              language,
-            })}
-            )
-          </h6>
-        )}
-        <span className="text-sm font-medium">{item.gpa}</span>
-      </div>
+      {item.summary && (
+        <ReactMarkdown className="markdown mt-2 text-sm" source={item.summary} />
+      )}
     </div>
-    {item.summary && (
-      <ReactMarkdown className="markdown mt-2 text-sm" source={item.summary} />
-    )}
-  </div>
-);
+  );
+};
 
 const EducationA = () => {
   const { data, heading: Heading } = useContext(PageContext);

--- a/src/templates/blocks/Work/WorkA.js
+++ b/src/templates/blocks/Work/WorkA.js
@@ -1,32 +1,36 @@
 import React, { memo, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import PageContext from '../../../contexts/PageContext';
 import { formatDateRange, safetyCheck } from '../../../utils';
 
-const WorkItem = ({ item, language }) => (
-  <div>
-    <div className="flex justify-between items-center">
-      <div className="flex flex-col text-left mr-2">
-        <h6 className="font-semibold">{item.company}</h6>
-        <span className="text-xs">{item.position}</span>
+const WorkItem = ({ item, language }) => {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <div className="flex justify-between items-center">
+        <div className="flex flex-col text-left mr-2">
+          <h6 className="font-semibold">{item.company}</h6>
+          <span className="text-xs">{item.position}</span>
+        </div>
+        {item.startDate && (
+          <h6 className="text-xs font-medium text-right">
+            (
+            {formatDateRange({
+              startDate: item.startDate,
+              endDate: item.endDate,
+              language,
+            }, t)}
+            )
+          </h6>
+        )}
       </div>
-      {item.startDate && (
-        <h6 className="text-xs font-medium text-right">
-          (
-          {formatDateRange({
-            startDate: item.startDate,
-            endDate: item.endDate,
-            language,
-          })}
-          )
-        </h6>
+      {item.summary && (
+        <ReactMarkdown className="markdown mt-2 text-sm" source={item.summary} />
       )}
     </div>
-    {item.summary && (
-      <ReactMarkdown className="markdown mt-2 text-sm" source={item.summary} />
-    )}
-  </div>
-);
+  );
+};
 
 const WorkA = () => {
   const { data, heading: Heading } = useContext(PageContext);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,9 +1,7 @@
 import dayjs from 'dayjs';
 import { get, isEmpty } from 'lodash';
-import { useTranslation } from 'react-i18next';
 
-export const getModalText = (isEditMode, type) => {
-  const { t } = useTranslation();
+export const getModalText = (isEditMode, type, t) => {
   return isEditMode
     ? `${t('shared.buttons.edit')} ${type}`
     : `${t('shared.buttons.add')} ${type}`;
@@ -26,8 +24,7 @@ export const formatDate = ({ date, language = 'en' }) => {
   return dayjs(date).locale(language.substr(0, 2)).format('MMMM YYYY');
 };
 
-export const formatDateRange = ({ startDate, endDate, language = 'en' }) => {
-  const { t } = useTranslation();
+export const formatDateRange = ({ startDate, endDate, language = 'en' }, t) => {
   const start = `${dayjs(startDate)
     .locale(language.substr(0, 2))
     .format('MMMM YYYY')}`;


### PR DESCRIPTION
Fixes #336, #331, #301 

Hooks should only be called from the [top-level of React Function Components or custom Hooks](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level), which is why there have been various crash issues reported.

This PR is a quick-fix to prevent severe crashes, but there is likely a more elegant solution that can be submitted in a follow-up PR