### PR TITLE
:bug: Fix translate mistake

### DIFF
--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -9,7 +9,7 @@
       "required": "Requis",
       "website": "Site web",
       "date": "Date",
-      "present": "Cadeau",
+      "present": "Aujourd'hui",
       "position": "Poste",
       "startDate": "Début",
       "endDate": "Fin",


### PR DESCRIPTION
In french a "Cadeau" is a gift or a present. We use "Aujourd'hui" instead of "Cadeau" ^^