### PR TITLE
Update fr.json

### DIFF
--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -9,7 +9,7 @@
       "required": "Requis",
       "website": "Site web",
       "date": "Date",
-      "present": "Cadeau",
+      "present": "Aujourd’hui",
       "position": "Poste",
       "startDate": "Début",
       "endDate": "Fin",


### PR DESCRIPTION
"present": "cadeau" -> cadeau means 'gift' in French.
'Aujourd'hui' is more appropriate, it's the term use by LinkedIn in French.
French is my native language.