### PR TITLE
Improvement of polish translations

### DIFF
--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -31,7 +31,7 @@
       "edit": "Edytuj",
       "cancel": "Anuluj",
       "delete": "Usuń",
-      "loading": "Ładuję...",
+      "loading": "Wczytywanie...",
       "confirmation": "Na pewno?",
       "login": "Login",
       "logout": "Wyloguj"
@@ -71,7 +71,7 @@
       "work": "Doświadczenie zawodowe",
       "education": "Wyksztłacenie",
       "project": "Projekt",
-      "projects": "Ptojekty",
+      "projects": "Projekty",
       "award": "Nagroda",
       "awards": "Nagrody",
       "certification": "Certyfikat",
@@ -96,7 +96,7 @@
       "photograph": "Fotografia",
       "firstName": "Imię",
       "lastName": "Nazwisko",
-      "birthDate": "Data urodzin",
+      "birthDate": "Data urodzenia",
       "address": {
         "line1": "Pole adresowe 1",
         "line2": "Pole adresowe 2",


### PR DESCRIPTION
- projects: typo fix
- birthDate: second word was incorrect
- technically it is correct, but "Wczytywanie" is more common translation for this