### PR TITLE
Add latin-ext subset to fix special characters missing in webfonts

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -44,34 +44,42 @@ module.exports = {
             {
               family: 'Lato',
               variants: ['400', '700'],
+              subsets: ['latin-ext'],
             },
             {
               family: 'Montserrat',
               variants: ['400', '500', '600', '700'],
+              subsets: ['latin-ext'],
             },
             {
               family: 'Nunito',
               variants: ['400', '600', '700'],
+              subsets: ['latin-ext'],
             },
             {
               family: 'Open Sans',
               variants: ['400', '600', '700'],
+              subsets: ['latin-ext'],
             },
             {
               family: 'Raleway',
               variants: ['400', '500', '700'],
+              subsets: ['latin-ext'],
             },
             {
               family: 'Rubik',
               variants: ['400', '500', '700'],
+              subsets: ['latin-ext'],
             },
             {
               family: 'Source Sans Pro',
               variants: ['400', '600', '700'],
+              subsets: ['latin-ext'],
             },
             {
               family: 'Titillium Web',
               variants: ['400', '600', '700'],
+              subsets: ['latin-ext'],
             },
           ],
         },


### PR DESCRIPTION
You can see that second letter in each group looks slightly different because glyphs are missing and it's falling back to default font.
![image](https://user-images.githubusercontent.com/4274691/105046881-eaa9e200-5a69-11eb-86da-4acc5ba3b60d.png)

After adding latin-ext glyphs it looks much better:
![image](https://user-images.githubusercontent.com/4274691/105046945-01e8cf80-5a6a-11eb-8ef1-369931da3da9.png)
