### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,29 @@
-FROM node as builder
-
+FROM node:alpine as builder
 WORKDIR /app
-COPY ./ /app/
 
-RUN npm install
+RUN apk update \
+    && apk add --no-cache \
+        g++ \
+        yasm \
+        make \
+        automake \
+        autoconf \
+        libtool \
+        vips-dev
+
+COPY package*.json ./
+RUN npm ci
+
+ARG FIREBASE_APIKEY
+ARG FIREBASE_APPID
+ARG FIREBASE_AUTHDOMAIN
+ARG FIREBASE_DATABASEURL
+ARG FIREBASE_MEASUREMENTID
+ARG FIREBASE_MESSAGINGSENDERID
+ARG FIREBASE_PROJECTID
+ARG FIREBASE_STORAGEBUCKET
+
+COPY . ./
 RUN npm run build
 
 FROM nginx:alpine


### PR DESCRIPTION
- Add missing build dependencies for `sharp` node module (dependency of
  `gatsby-plugin-sharp`).
- Add ARG instructions for firebase variables, allowing them to be set
  via --build-arg flags when building the image.
- Use `npm ci` instead of `npm install`, and execute it after copying
  only package*.json. This prevents having to fetch all dependencies if
  package*.json hasn't changed between builds.
- Use `node:alpine` instead of `node` - not an improvement per-se,
  but I happen to be more familiar with adding build dependecies in the
  alpine based node image.