### PR TITLE
Delete Account: fix for Firebase cloud function and error handling improvements

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -19,8 +19,9 @@ const deleteUserFunctionHandler = async (_, { auth }) => {
   }
 
   try {
-    // 1. Delete user resumes
     const userId = auth.uid;
+    const updates = {};
+
     const userResumesDataSnapshot = await admin
       .database()
       .ref('resumes')
@@ -30,18 +31,21 @@ const deleteUserFunctionHandler = async (_, { auth }) => {
     const userResumes = userResumesDataSnapshot.val();
     if (userResumes) {
       Object.keys(userResumes).forEach(async (resumeId) => {
-        await admin.database().ref(`resumes/${resumeId}`).remove();
+        updates[`resumes/${resumeId}`] = null;
       });
     }
 
-    // 2. Delete user
     const userDataSnapshot = await admin
       .database()
       .ref(`users/${userId}`)
       .once('value');
     const user = userDataSnapshot.val();
     if (user) {
-      await admin.database().ref(`users/${userId}`).remove();
+      updates[`users/${userId}`] = null;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await admin.database().ref().update(updates);
     }
 
     return true;

--- a/src/components/builder/right/sections/Settings.js
+++ b/src/components/builder/right/sections/Settings.js
@@ -35,7 +35,7 @@ const Settings = ({ id }) => {
     dispatch({ type: 'change_language', payload: lang });
   };
 
-  const handleDeleteAccount = () => {
+  const handleDeleteAccount = async () => {
     if (deleteText === t('builder.settings.dangerZone.button')) {
       setDeleteText(t('shared.buttons.confirmation'));
       return;
@@ -43,18 +43,12 @@ const Settings = ({ id }) => {
 
     setDeleteText(t('shared.buttons.loading'));
 
-    setTimeout(
-      () =>
-        deleteAccount()
-          .then(() => {
-            setDeleteText('Buh bye! :(');
-          })
-          .catch((error) => {
-            toast.error(error.message);
-            setDeleteText(t('builder.settings.dangerZone.button'));
-          }),
-      500,
-    );
+    try {
+      await deleteAccount();
+    } catch (error) {
+      toast.error('An error occurred deleting your account');
+      setDeleteText(t('builder.settings.dangerZone.button'));
+    }
   };
 
   return (

--- a/src/components/builder/right/sections/Settings.js
+++ b/src/components/builder/right/sections/Settings.js
@@ -1,6 +1,7 @@
 import React, { memo, useContext, useState } from 'react';
 import { FaAngleDown } from 'react-icons/fa';
 import { useTranslation, Trans } from 'react-i18next';
+import { toast } from 'react-toastify';
 import UserContext from '../../../../contexts/UserContext';
 import Button from '../../../shared/Button';
 import Heading from '../../../shared/Heading';
@@ -40,10 +41,20 @@ const Settings = ({ id }) => {
       return;
     }
 
-    setDeleteText('Buh bye! :(');
-    setTimeout(() => {
-      deleteAccount();
-    }, 500);
+    setDeleteText(t('shared.buttons.loading'));
+
+    setTimeout(
+      () =>
+        deleteAccount()
+          .then(() => {
+            setDeleteText('Buh bye! :(');
+          })
+          .catch((error) => {
+            toast.error(error.message);
+            setDeleteText(t('builder.settings.dangerZone.button'));
+          }),
+      500,
+    );
   };
 
   return (

--- a/src/components/builder/right/sections/Settings.js
+++ b/src/components/builder/right/sections/Settings.js
@@ -46,7 +46,7 @@ const Settings = ({ id }) => {
     try {
       await deleteAccount();
     } catch (error) {
-      toast.error('An error occurred deleting your account');
+      toast.error('An error occurred deleting your account.');
       setDeleteText(t('builder.settings.dangerZone.button'));
     }
   };

--- a/src/components/builder/right/sections/Settings.js
+++ b/src/components/builder/right/sections/Settings.js
@@ -18,6 +18,9 @@ const Settings = ({ id }) => {
   const [deleteText, setDeleteText] = useState(
     t('builder.settings.dangerZone.button'),
   );
+  const [isDeleteAccountInProgress, setDeleteAccountInProgress] = useState(
+    false,
+  );
 
   const dispatch = useDispatch();
   const { deleteAccount } = useContext(UserContext);
@@ -41,12 +44,13 @@ const Settings = ({ id }) => {
       return;
     }
 
-    setDeleteText(t('shared.buttons.loading'));
+    setDeleteAccountInProgress(true);
 
     try {
       await deleteAccount();
     } catch (error) {
       toast.error('An error occurred deleting your account.');
+      setDeleteAccountInProgress(false);
       setDeleteText(t('builder.settings.dangerZone.button'));
     }
   };
@@ -101,7 +105,11 @@ const Settings = ({ id }) => {
         <p className="leading-loose">{t('builder.settings.dangerZone.text')}</p>
 
         <div className="mt-4 flex">
-          <Button isDelete onClick={handleDeleteAccount}>
+          <Button
+            isDelete
+            onClick={handleDeleteAccount}
+            isLoading={isDeleteAccountInProgress}
+          >
             {deleteText}
           </Button>
         </div>

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -76,13 +76,13 @@ const UserProvider = ({ children }) => {
   const deleteAccount = async () => {
     const { currentUser } = firebase.auth();
     const deleteUser = firebase.functions().httpsCallable('deleteUser');
-    deleteUser();
+
+    await deleteUser();
 
     try {
-      deleteUser();
       await currentUser.delete();
-    } catch (e) {
-      if (e.code === 'auth/requires-recent-login') {
+    } catch (error) {
+      if (error.code === 'auth/requires-recent-login') {
         await loginWithGoogle();
         await currentUser.delete();
       }


### PR DESCRIPTION
Fixes #466 
<br>
Changes applied to the `deleteUser` Firebase cloud function:
- Performance improvement: filtering by userId when retrieving the resumes from the database
- Added removal of the user node
- Deletions of resumes and user done through a single atomic update (all or nothing)

Changes applied to the UserContext `deleteAccount` function:
- Performing user re-authentication, if user is signed in with Google, as a very first step. This is done to prevent possible 'auth/requires-recent-login' errors later on, when `currentUser.delete()` is called. Should an error occur in the re-authentication, then the app will notify the user and will not proceed further
- Using `await` when calling the `deleteUser` Firebase cloud function. Should an error occur in the cloud function then the app will notify the user and will not proceed further

Changes applied to the Settings `handleDeleteAccount` function:
- Call to the UserContext `deleteAccount` function is done using `await` and with `try...catch` block in order to notify the user of any error