### PR TITLE
"Download PDF" action: basic retry mechanism - "Delete Account" action: deletion of uploaded photographs

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -54,42 +54,100 @@ const deleteUserFunctionHandler = async (_, { auth }) => {
   }
 };
 
-exports.deleteUser = functions
-  .runWith({ memory: '256MB' })
-  .https.onCall(deleteUserFunctionHandler);
+/**
+ * Tries to navigate the page to a given URL.
+ *
+ * @param {puppeteer.Page} page Page.
+ * @param {string} url URL to navigate page to.
+ * @param {puppeteer.PuppeteerLifeCycleEvent} waitUntil When to consider navigation succeeded.
+ * @returns {Promise<string>} Returns null if no error occurred, otherwise returns the error message.
+ */
+const tryGotoPage = async (page, url, waitUntil) => {
+  let httpResponse;
 
-exports.printResume = functions
-  .runWith({ memory: '1GB' })
-  .https.onCall(async ({ id, type }, { auth }) => {
-    if (!id) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'The function must be called with argument "id" containing the resume ID.',
-      );
+  try {
+    httpResponse = await page.goto(url, {
+      waitUntil,
+    });
+  } catch (error) {
+    return `page.goto (waitUntil: "${waitUntil}") threw an error with message "${error.message}"`;
+  }
+
+  if (httpResponse === null) {
+    return `page.goto (waitUntil: "${waitUntil}") returned a null response`;
+  }
+
+  if (!httpResponse.ok()) {
+    return `page.goto (waitUntil: "${waitUntil}") returned a response with HTTP status ${httpResponse.status()} "${httpResponse.statusText()}"`;
+  }
+
+  return null;
+};
+
+/**
+ * Creates a page and navigates to a given URL.
+ *
+ * @param {puppeteer.Browser} browser Browser.
+ * @param {string} url URL to navigate to.
+ * @returns {Promise<{page: puppeteer.Page, errors: string[]}>} Returns an object with the page if no error occurred, otherwise returns an object with the list of error messages.
+ */
+const gotoPage = async (browser, url) => {
+  const errors = [];
+
+  const waitUntilArray = ['networkidle0', 'networkidle2'];
+  for (let index = 0; index < waitUntilArray.length; index++) {
+    /* eslint-disable no-await-in-loop */
+    const waitUntil = waitUntilArray[index];
+
+    const page = await browser.newPage();
+    await page.setCacheEnabled(false);
+
+    const error = await tryGotoPage(page, url, waitUntil);
+    if (!error) {
+      return { page, errors: null };
     }
 
-    if (!type) {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'The function must be called with argument "type" containing the type of resume.',
-      );
-    }
+    errors.push(error);
+    await page.close();
+  }
 
-    if (!auth) {
-      throw new functions.https.HttpsError(
-        'failed-precondition',
-        'The function must be called while authenticated.',
-      );
-    }
+  return { page: null, errors };
+};
 
+const printResumeFunctionHandler = async ({ id, type }, { auth }) => {
+  if (!id) {
+    throw new functions.https.HttpsError(
+      'invalid-argument',
+      'The function must be called with argument "id" containing the resume ID.',
+    );
+  }
+
+  if (!type) {
+    throw new functions.https.HttpsError(
+      'invalid-argument',
+      'The function must be called with argument "type" containing the type of resume.',
+    );
+  }
+
+  if (!auth) {
+    throw new functions.https.HttpsError(
+      'failed-precondition',
+      'The function must be called while authenticated.',
+    );
+  }
+
+  try {
     const browser = await puppeteer.launch({
       headless: true,
       args: ['--no-sandbox'],
     });
-    const page = await browser.newPage();
-    await page.goto(BASE_URL + id, {
-      waitUntil: 'networkidle0',
-    });
+
+    const url = BASE_URL + id;
+    const { page, errors } = await gotoPage(browser, url);
+    if (errors && errors.length > 0) {
+      throw new Error(errors.join(' - '));
+    }
+
     await timeout(6000);
     await page.emulateMediaType('print');
     let pdf;
@@ -124,4 +182,15 @@ exports.printResume = functions
 
     await browser.close();
     return Buffer.from(pdf).toString('base64');
-  });
+  } catch (error) {
+    throw new functions.https.HttpsError('internal', error.message);
+  }
+};
+
+exports.deleteUser = functions
+  .runWith({ memory: '256MB' })
+  .https.onCall(deleteUserFunctionHandler);
+
+exports.printResume = functions
+  .runWith({ memory: '1GB' })
+  .https.onCall(printResumeFunctionHandler);


### PR DESCRIPTION
1. "Download PDF" action: basic retry mechanism

This hopefully resolves #487, resolves #484, resolves #483, resolves #452, resolves #409, resolves #399, resolves #383, resolves #361.

I could reproduce the issue with the "Download PDF" action in my local tests. I was getting the "The cloud function is running into some trouble..." toast and in the browser console the "Access to fetch ... blocked by CORS policy ..." error, as mentioned in #487.
For me, changing the Puppeteer call `page.goto(url, { waitUntil: 'networkidle0' })` to `page.goto(url, { waitUntil: 'networkidle2' })` made it work. So the `printResume` Firebase cloud function has been modified to perform a basic retry mechanism: first try with `waitUntil` parameter set to `networkidle0`, if that fails try with `waitUntil` parameter set to `networkidle2`. In my environment, the first call to `page.goto` with `networkidle0` always hangs until timeout (30 seconds). However I've left that call in place as the first try as it might work for other users, or in network environments different from mine. This could be reviewed at a later stage based on the outcome of the testing in the production environment.
Also the error handling in the `printResume` function has been enhanced to return more detailed information.

---

2. "Delete Account" action: deletion of uploaded photographs

This resolves #488.

The `deleteUser` Firebase cloud function has been modified to also perform the deletion of the user folder from Storage.

Ideally, I would have liked to perform this delete in an atomic way, similar to how the data in the Realtime Database is deleted, but until now I could not find a way to accomplish this.