### PR TITLE
Correcting typos in pl.json

### DIFF
--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -44,8 +44,8 @@
   },
   "dashboard": {
     "title": "Panel",
-    "createResume": "Utwórz Cv",
-    "editResume": "Edytuj Cv",
+    "createResume": "Utwórz CV",
+    "editResume": "Edytuj CV",
     "lastUpdated": "Ostatnia aktualizacja {{timestamp}}",
     "toasts": {
       "deleted": "{{name}} usunięto pomyślnie"
@@ -54,12 +54,12 @@
       "duplicate": "Duplikat",
       "rename": "Zmień nazwę"
     },
-    "helpText": "Zaczynasz tworzenie Cv od zera, ale najpierw, nadaj mu identyfikator. Co może być identyfikatorem? Na przykład stanowisko, o które chcesz się ubiegać lub, jeśli tworzysz Cv dla przyjaciela, identyfikatorem może być Cv Michała."
+    "helpText": "Zaczynasz tworzenie CV od zera, ale najpierw, nadaj mu identyfikator. Co może być identyfikatorem? Na przykład stanowisko, o które chcesz się ubiegać lub, jeśli tworzysz Cv dla przyjaciela, identyfikatorem może być Cv Michała."
   },
   "builder": {
     "toasts": {
       "formErrors": "Musisz wypełnić wszystkie wymagane pola przed przesłaniem tego formularza.",
-      "doesNotExist": "Cv którego szukałeś(aś) już nie istnieje... a może nigdy nie istniało?",
+      "doesNotExist": "CV którego szukałeś(aś) już nie istnieje... a może nigdy nie istniało?",
       "loadDemoData": "Nie jesteś pewien, gdzie rozpocząć? Spróbuj załadować demo, aby zobaczyć, co Reactive Resume może Ci zaoferować.",
       "printError": "Wystąpiły problemy z funkcją chmury, spróbuj ponownie później lub użyj funkcji drukowania w przeglądarce."
     },
@@ -69,9 +69,9 @@
       "social": "Media społecznościowe",
       "objective": "Cele",
       "work": "Doświadczenie zawodowe",
-      "education": "Wyksztłacenie",
+      "education": "Wykształcenie",
       "project": "Projekt",
-      "projects": "Ptojekty",
+      "projects": "Projekty",
       "award": "Nagroda",
       "awards": "Nagrody",
       "certification": "Certyfikat",
@@ -144,7 +144,7 @@
     "actions": {
       "import": {
         "heading": "Importuj swoje CV",
-        "text": "Możesz zaimportować  informacje z różnych źródeł, takich jak JSON Resume lub LinkedIn w celu autouzupełniania danych do Twojego CV.",
+        "text": "Możesz zaimportować informacje z różnych źródeł, takich jak JSON Resume lub LinkedIn w celu autouzupełniania danych do Twojego CV.",
         "button": "Importuj"
       },
       "export": {


### PR DESCRIPTION
Corrected a few minor mistakes such as too many whitespaces or typos, e.g.
**Projects** - Ptojekty (should be Projekty)
**Education** - Wyksztłacenie (should be Wykształcenie)
"CV" should be written in capital letters, it was inconsistent