### PR TITLE
fix typo in placeholder dates

### DIFF
--- a/src/modals/sections/EducationModal.js
+++ b/src/modals/sections/EducationModal.js
@@ -80,14 +80,14 @@ const EducationModal = () => {
             <Input
               type="date"
               label={t('shared.forms.startDate')}
-              placeholder="6th August 2008"
+              placeholder="6th August 2018"
               {...getFieldProps(formik, schema, 'startDate')}
             />
 
             <Input
               type="date"
               label={t('shared.forms.endDate')}
-              placeholder="6th August 2008"
+              placeholder="6th August 2018"
               {...getFieldProps(formik, schema, 'endDate')}
             />
 

--- a/src/modals/sections/EducationModal.js
+++ b/src/modals/sections/EducationModal.js
@@ -80,14 +80,14 @@ const EducationModal = () => {
             <Input
               type="date"
               label={t('shared.forms.startDate')}
-              placeholder="6th August 208"
+              placeholder="6th August 2008"
               {...getFieldProps(formik, schema, 'startDate')}
             />
 
             <Input
               type="date"
               label={t('shared.forms.endDate')}
-              placeholder="6th August 208"
+              placeholder="6th August 2008"
               {...getFieldProps(formik, schema, 'endDate')}
             />
 

--- a/src/modals/sections/ProjectModal.js
+++ b/src/modals/sections/ProjectModal.js
@@ -53,14 +53,14 @@ const ProjectModal = () => {
             <Input
               type="date"
               label={t('shared.forms.startDate')}
-              placeholder="6th August 208"
+              placeholder="6th August 2008"
               {...getFieldProps(formik, schema, 'date')}
             />
 
             <Input
               type="date"
               label={t('shared.forms.endDate')}
-              placeholder="6th August 208"
+              placeholder="6th August 2008"
               {...getFieldProps(formik, schema, 'endDate')}
             />
 

--- a/src/modals/sections/ProjectModal.js
+++ b/src/modals/sections/ProjectModal.js
@@ -53,14 +53,14 @@ const ProjectModal = () => {
             <Input
               type="date"
               label={t('shared.forms.startDate')}
-              placeholder="6th August 2008"
+              placeholder="6th August 2018"
               {...getFieldProps(formik, schema, 'date')}
             />
 
             <Input
               type="date"
               label={t('shared.forms.endDate')}
-              placeholder="6th August 2008"
+              placeholder="6th August 2018"
               {...getFieldProps(formik, schema, 'endDate')}
             />
 

--- a/src/modals/sections/WorkModal.js
+++ b/src/modals/sections/WorkModal.js
@@ -71,14 +71,14 @@ const WorkModal = () => {
             <Input
               type="date"
               label={t('shared.forms.startDate')}
-              placeholder="6th August 208"
+              placeholder="6th August 2008"
               {...getFieldProps(formik, schema, 'startDate')}
             />
 
             <Input
               type="date"
               label={t('shared.forms.endDate')}
-              placeholder="6th August 208"
+              placeholder="6th August 2008"
               {...getFieldProps(formik, schema, 'endDate')}
             />
 

--- a/src/modals/sections/WorkModal.js
+++ b/src/modals/sections/WorkModal.js
@@ -71,14 +71,14 @@ const WorkModal = () => {
             <Input
               type="date"
               label={t('shared.forms.startDate')}
-              placeholder="6th August 2008"
+              placeholder="6th August 2018"
               {...getFieldProps(formik, schema, 'startDate')}
             />
 
             <Input
               type="date"
               label={t('shared.forms.endDate')}
-              placeholder="6th August 2008"
+              placeholder="6th August 2018"
               {...getFieldProps(formik, schema, 'endDate')}
             />
 


### PR DESCRIPTION
We could probably even update this to something a bit more recent like 2018, depending on the context, but happy to leave the decision up to you.