### PR TITLE
update Project data model to use "Present" if no end date selected

### DIFF
--- a/src/modals/sections/ProjectModal.js
+++ b/src/modals/sections/ProjectModal.js
@@ -10,7 +10,8 @@ import ModalEvents from '../../constants/ModalEvents';
 const initialValues = {
   title: '',
   link: '',
-  date: '',
+  startDate: '',
+  endDate: '',
   summary: '',
 };
 
@@ -20,7 +21,13 @@ const ProjectModal = () => {
   const schema = Yup.object().shape({
     title: Yup.string().required(t('shared.forms.validation.required')),
     link: Yup.string().url(t('shared.forms.validation.url')),
-    date: Yup.date().max(new Date()),
+    startDate: Yup.date(),
+    endDate: Yup.date().when(
+      'startDate',
+      (startDate, yupSchema) =>
+        startDate &&
+        yupSchema.min(startDate, t('shared.forms.validation.dateRange')),
+    ),
     summary: Yup.string(),
   });
 
@@ -54,7 +61,7 @@ const ProjectModal = () => {
               type="date"
               label={t('shared.forms.startDate')}
               placeholder="6th August 208"
-              {...getFieldProps(formik, schema, 'date')}
+              {...getFieldProps(formik, schema, 'startDate')}
             />
 
             <Input

--- a/src/templates/blocks/Projects/ProjectsA.js
+++ b/src/templates/blocks/Projects/ProjectsA.js
@@ -17,12 +17,12 @@ const ProjectItem = ({ item, language }) => {
             </a>
           )}
         </div>
-        {item.date && (
+        {item.startDate && (
           <h6 className="text-xs font-medium text-right">
             (
             {formatDateRange(
               {
-                startDate: item.date,
+                startDate: item.startDate,
                 endDate: item.endDate,
                 language,
               },


### PR DESCRIPTION
Sometimes, projects are ongoing, and it would be helpful to be able to show that, similar to how it's done in the Work section.

This is what's expected in the `formatDateRange` function, and it's more consistent with the way things are done in other parts of the application.