### PR TITLE
add 'object cover' class to templates that have issues with profile image stretching.

### DIFF
--- a/src/templates/Castform.js
+++ b/src/templates/Castform.js
@@ -32,7 +32,7 @@ const Castform = ({ data }) => {
   const Photo = () =>
     data.profile.photograph !== '' && (
       <img
-        className="w-32 h-32 rounded-full"
+        className="w-32 h-32 rounded-full object-cover"
         style={{
           borderWidth: 6,
           borderColor: data.metadata.colors.background,

--- a/src/templates/Glalie.js
+++ b/src/templates/Glalie.js
@@ -35,7 +35,7 @@ const Glalie = ({ data }) => {
     <div className="grid gap-2 text-center">
       {data.profile.photograph !== '' && (
         <img
-          className="w-40 h-40 rounded-full mx-auto"
+          className="w-40 h-40 rounded-full mx-auto object-cover"
           src={data.profile.photograph}
           alt={data.profile.firstName}
         />


### PR DESCRIPTION
Image without 'object-class' class on profile picture div in template, stretches.
<img width="96" alt="Screen Shot 2022-01-25 at 8 31 53 PM" src="https://user-images.githubusercontent.com/7892604/150931588-1dda6cbd-57f5-4015-8317-e98d569ce9fd.png">

Image with 'object-class' class on profile picture div in template. No stretching.
<img width="96" alt="Screen Shot 2022-01-25 at 8 32 42 PM" src="https://user-images.githubusercontent.com/7892604/150931602-b79c2c24-aff3-4347-8a06-32f0e16c3dda.png">

Only impacting two templates
