### PR TITLE
fix translation error for language Japanese

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For those of you familiar with the Crowdin Platform, you could do that too and j
 - Hindi (हिंदी)
 - Indonesian (Bahasa Indonesia)
 - Italian (Italiano)
-- Japanese (日本人)
+- Japanese (日本語)
 - Kannada (ಕನ್ನಡ)
 - Lithuanian (Lietuvių)
 - Norwegian (Norsk)

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -69,7 +69,7 @@ const languages = [
   },
   {
     code: 'ja',
-    name: 'Japanese (日本人)',
+    name: 'Japanese (日本語)',
   },
   {
     code: 'kn',


### PR DESCRIPTION
Fix translation of "Japanese" in the language support list.

日本人 means Japanese person/people
日本語 means the Japanese language