### PR TITLE
Fixed Near Overlapping of "Disable" & "Beginner" Label Text in Skills Modal for Desktop Screen

### DIFF
--- a/client/modals/builder/sections/SkillModal.tsx
+++ b/client/modals/builder/sections/SkillModal.tsx
@@ -125,7 +125,7 @@ const SkillModal: React.FC = () => {
             <div className="col-span-2">
               <h4 className="mb-3 font-semibold">{t('builder.common.form.levelNum.label')}</h4>
 
-              <div className="px-10">
+              <div className="px-3">
                 <Slider
                   {...field}
                   marks={[


### PR DESCRIPTION
This is a fix for an Overlapping in the Label "Disable" & "Beginner" text in the Slider Component in Skills Modal Sheet.

The issue was occurring because of more padding around the component.