### PR TITLE
Fix-Gengar Theme MastHead Icons Disappear on Theme/Primary Color Change

### DIFF
--- a/client/templates/Gengar/Gengar.tsx
+++ b/client/templates/Gengar/Gengar.tsx
@@ -1,5 +1,7 @@
+import { css } from '@emotion/css';
 import { alpha } from '@mui/material';
 import { Theme } from '@reactive-resume/schema';
+import clsx from 'clsx';
 import get from 'lodash/get';
 import { useMemo } from 'react';
 
@@ -19,12 +21,16 @@ const Gengar: React.FC<PageProps> = ({ page }) => {
   const theme: Theme = useAppSelector((state) => get(state.resume, 'metadata.theme', {}));
   const contrast = useMemo(() => getContrastColor(theme.primary), [theme.primary]);
   const backgroundColor: string = useMemo(() => alpha(theme.primary, 0.15), [theme.primary]);
+  const color = useMemo(() => (contrast === 'dark' ? theme.text : theme.background), [theme, contrast]);
 
   return (
     <div className={styles.page}>
       <div className={styles.container}>
         <div className={styles.sidebar}>
-          <div style={{ color: contrast === 'dark' ? theme.text : theme.background, backgroundColor: theme.primary }}>
+          <div
+            className={clsx(css(`svg { color: ${color} } --primary-color: ${color}`))}
+            style={{ color: contrast === 'dark' ? theme.text : theme.background, backgroundColor: theme.primary }}
+          >
             {isFirstPage && <MastheadSidebar />}
           </div>
 


### PR DESCRIPTION
This is a Fix for a UI Bug which can be Observed in Gengar Template where Icons disappear on Primary Color Change

Follow Steps below to Replicate:

1- Select Template Gengar
2- Fill Email, Mobile details
3- Now Change the Primary Color
4- Keep the Background Color as #ffffff

You will observe that the Icons for Email, Mobile, etc in the MastHead will disappear

Reason: The Icon Color is being overwritten by the Background Color