### PR TITLE
Fix - Left SideBar Photo Filters Button & Full Name Field Overlapping in iOS Devices

### DIFF
--- a/client/components/build/LeftSidebar/sections/Basics.tsx
+++ b/client/components/build/LeftSidebar/sections/Basics.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 
 import Heading from '@/components/shared/Heading';
 import ResumeInput from '@/components/shared/ResumeInput';
+import isiOS from '@/utils/isiOS';
 
 import PhotoFilters from './PhotoFilters';
 import PhotoUpload from './PhotoUpload';
@@ -22,6 +23,8 @@ const Basics = () => {
     setAnchorEl(null);
   };
 
+  const mediaMatch = window.matchMedia('(max-width: 640px)');
+  const isIosDevice = isiOS();
   return (
     <>
       <Heading path="sections.basics" name={t('builder.leftSidebar.sections.basics.heading')} />
@@ -33,7 +36,12 @@ const Basics = () => {
           <div className="flex w-full flex-col-reverse gap-4 sm:flex-col sm:gap-2">
             <ResumeInput label={t('builder.leftSidebar.sections.basics.name.label')} path="basics.name" />
 
-            <Button variant="outlined" startIcon={<PhotoFilter />} onClick={handleClick}>
+            <Button
+              variant="outlined"
+              startIcon={<PhotoFilter />}
+              onClick={handleClick}
+              style={{ marginBottom: isIosDevice && mediaMatch.matches ? '1rem' : 'none' }}
+            >
               {t('builder.leftSidebar.sections.basics.actions.photo-filters')}
             </Button>
 

--- a/client/utils/isiOS.ts
+++ b/client/utils/isiOS.ts
@@ -1,0 +1,6 @@
+export default function iOS() {
+  return (
+    ['iPad Simulator', 'iPhone Simulator', 'iPod Simulator', 'iPad', 'iPhone', 'iPod'].includes(navigator.platform) ||
+    (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+  );
+}


### PR DESCRIPTION
**Issue** - On iOS devices (iPhone, iPad, iPod) it was observed as shown in image below, that the Full Name (ResumeInput Component) and Photo Filter Button were overlapping because the CSS was not behaving as expected.

You will be able to replicate this issue on Safari in Mac by Activating "Enter Responsive Design Mode" or on an iPhone ( Tested and verified on iPhone 11 and 8 Plus )

This fix will be only reflected on the iOS device and _not_ on Safari in Mac for obvious reasons (check isiOS util Function)

<img width="351" alt="Screenshot 2022-03-14 at 11 29 27 AM" src="https://user-images.githubusercontent.com/27367779/158127984-929278bb-fb10-4397-af6f-804f6f1ed5b8.png">