### PR TITLE
Fix - Work Experience Website Link Redirects to 404 if manually entered without http/https

### DIFF
--- a/client/templates/Castform/widgets/Section.tsx
+++ b/client/templates/Castform/widgets/Section.tsx
@@ -9,7 +9,7 @@ import { useAppSelector } from '@/store/hooks';
 import { SectionProps } from '@/templates/sectionMap';
 import DataDisplay from '@/templates/shared/DataDisplay';
 import { formatDateString } from '@/utils/date';
-import { parseListItemPath } from '@/utils/template';
+import { addHttp, parseListItemPath } from '@/utils/template';
 
 import Heading from './Heading';
 
@@ -86,7 +86,7 @@ const Section: React.FC<SectionProps> = ({
               {summary && <Markdown>{summary}</Markdown>}
 
               {url && (
-                <DataDisplay icon={<Link />} link={url}>
+                <DataDisplay icon={<Link />} link={url && addHttp(url)}>
                   {url}
                 </DataDisplay>
               )}

--- a/client/templates/Castform/widgets/Section.tsx
+++ b/client/templates/Castform/widgets/Section.tsx
@@ -86,7 +86,7 @@ const Section: React.FC<SectionProps> = ({
               {summary && <Markdown>{summary}</Markdown>}
 
               {url && (
-                <DataDisplay icon={<Link />} link={url && addHttp(url)}>
+                <DataDisplay icon={<Link />} link={addHttp(url)}>
                   {url}
                 </DataDisplay>
               )}

--- a/client/templates/Gengar/widgets/Section.tsx
+++ b/client/templates/Gengar/widgets/Section.tsx
@@ -9,7 +9,7 @@ import { useAppSelector } from '@/store/hooks';
 import { SectionProps } from '@/templates/sectionMap';
 import DataDisplay from '@/templates/shared/DataDisplay';
 import { formatDateString } from '@/utils/date';
-import { parseListItemPath } from '@/utils/template';
+import { addHttp, parseListItemPath } from '@/utils/template';
 
 import Heading from './Heading';
 
@@ -87,7 +87,7 @@ const Section: React.FC<SectionProps> = ({
               {summary && <Markdown>{summary}</Markdown>}
 
               {url && (
-                <DataDisplay icon={<Link />} link={url}>
+                <DataDisplay icon={<Link />} link={url && addHttp(url)}>
                   {url}
                 </DataDisplay>
               )}

--- a/client/templates/Gengar/widgets/Section.tsx
+++ b/client/templates/Gengar/widgets/Section.tsx
@@ -87,7 +87,7 @@ const Section: React.FC<SectionProps> = ({
               {summary && <Markdown>{summary}</Markdown>}
 
               {url && (
-                <DataDisplay icon={<Link />} link={url && addHttp(url)}>
+                <DataDisplay icon={<Link />} link={addHttp(url)}>
                   {url}
                 </DataDisplay>
               )}

--- a/client/templates/Glalie/widgets/Section.tsx
+++ b/client/templates/Glalie/widgets/Section.tsx
@@ -9,7 +9,7 @@ import { useAppSelector } from '@/store/hooks';
 import { SectionProps } from '@/templates/sectionMap';
 import DataDisplay from '@/templates/shared/DataDisplay';
 import { formatDateString } from '@/utils/date';
-import { parseListItemPath } from '@/utils/template';
+import { addHttp, parseListItemPath } from '@/utils/template';
 
 import BadgeDisplay from './BadgeDisplay';
 import Heading from './Heading';
@@ -80,7 +80,7 @@ const Section: React.FC<SectionProps> = ({
               {summary && <Markdown>{summary}</Markdown>}
 
               {url && (
-                <DataDisplay icon={<Link />} link={url}>
+                <DataDisplay icon={<Link />} link={url && addHttp(url)}>
                   {url}
                 </DataDisplay>
               )}

--- a/client/templates/Glalie/widgets/Section.tsx
+++ b/client/templates/Glalie/widgets/Section.tsx
@@ -80,7 +80,7 @@ const Section: React.FC<SectionProps> = ({
               {summary && <Markdown>{summary}</Markdown>}
 
               {url && (
-                <DataDisplay icon={<Link />} link={url && addHttp(url)}>
+                <DataDisplay icon={<Link />} link={addHttp(url)}>
                   {url}
                 </DataDisplay>
               )}

--- a/client/templates/Kakuna/widgets/Section.tsx
+++ b/client/templates/Kakuna/widgets/Section.tsx
@@ -8,7 +8,7 @@ import Markdown from '@/components/shared/Markdown';
 import { useAppSelector } from '@/store/hooks';
 import { SectionProps } from '@/templates/sectionMap';
 import { formatDateString } from '@/utils/date';
-import { parseListItemPath } from '@/utils/template';
+import { addHttp, parseListItemPath } from '@/utils/template';
 
 import BadgeDisplay from './BadgeDisplay';
 import Heading from './Heading';
@@ -84,7 +84,7 @@ const Section: React.FC<SectionProps> = ({
 
               {url && (
                 <div className="inline-flex justify-center">
-                  <a href={url} target="_blank" rel="noreferrer">
+                  <a href={url && addHttp(url)} target="_blank" rel="noreferrer">
                     {url}
                   </a>
                 </div>

--- a/client/templates/Kakuna/widgets/Section.tsx
+++ b/client/templates/Kakuna/widgets/Section.tsx
@@ -84,7 +84,7 @@ const Section: React.FC<SectionProps> = ({
 
               {url && (
                 <div className="inline-flex justify-center">
-                  <a href={url && addHttp(url)} target="_blank" rel="noreferrer">
+                  <a href={addHttp(url)} target="_blank" rel="noreferrer">
                     {url}
                   </a>
                 </div>

--- a/client/templates/Onyx/widgets/Section.tsx
+++ b/client/templates/Onyx/widgets/Section.tsx
@@ -9,7 +9,7 @@ import { useAppSelector } from '@/store/hooks';
 import { SectionProps } from '@/templates/sectionMap';
 import DataDisplay from '@/templates/shared/DataDisplay';
 import { formatDateString } from '@/utils/date';
-import { parseListItemPath } from '@/utils/template';
+import { addHttp, parseListItemPath } from '@/utils/template';
 
 import Heading from './Heading';
 
@@ -87,7 +87,7 @@ const Section: React.FC<SectionProps> = ({
               {summary && <Markdown>{summary}</Markdown>}
 
               {url && (
-                <DataDisplay icon={<Link />} link={url} className="text-xs">
+                <DataDisplay icon={<Link />} link={url && addHttp(url)} className="text-xs">
                   {url}
                 </DataDisplay>
               )}

--- a/client/templates/Onyx/widgets/Section.tsx
+++ b/client/templates/Onyx/widgets/Section.tsx
@@ -87,7 +87,7 @@ const Section: React.FC<SectionProps> = ({
               {summary && <Markdown>{summary}</Markdown>}
 
               {url && (
-                <DataDisplay icon={<Link />} link={url && addHttp(url)} className="text-xs">
+                <DataDisplay icon={<Link />} link={addHttp(url)} className="text-xs">
                   {url}
                 </DataDisplay>
               )}

--- a/client/templates/Pikachu/widgets/Section.tsx
+++ b/client/templates/Pikachu/widgets/Section.tsx
@@ -79,7 +79,7 @@ const Section: React.FC<SectionProps> = ({
               {summary && <Markdown>{summary}</Markdown>}
 
               {url && (
-                <DataDisplay icon={<Link />} link={url && addHttp(url)}>
+                <DataDisplay icon={<Link />} link={addHttp(url)}>
                   {url}
                 </DataDisplay>
               )}

--- a/client/templates/Pikachu/widgets/Section.tsx
+++ b/client/templates/Pikachu/widgets/Section.tsx
@@ -9,7 +9,7 @@ import { useAppSelector } from '@/store/hooks';
 import { SectionProps } from '@/templates/sectionMap';
 import DataDisplay from '@/templates/shared/DataDisplay';
 import { formatDateString } from '@/utils/date';
-import { parseListItemPath } from '@/utils/template';
+import { addHttp, parseListItemPath } from '@/utils/template';
 
 import Heading from './Heading';
 
@@ -79,7 +79,7 @@ const Section: React.FC<SectionProps> = ({
               {summary && <Markdown>{summary}</Markdown>}
 
               {url && (
-                <DataDisplay icon={<Link />} link={url}>
+                <DataDisplay icon={<Link />} link={url && addHttp(url)}>
                   {url}
                 </DataDisplay>
               )}


### PR DESCRIPTION
Issue - When user enters the "Website" in Work Experience and enters it without http or https, on clicking on that link, the user gets routed to 404 Page

This issue exists in all 6 templates currently

Fix- Added addHttp(url) in link prop in Section.tsx files of all the 6 templates