### PR TITLE
Fix-Pikachu Masthead Basic Details looks asymmetric Due to Centred Alignment

### DIFF
--- a/client/templates/Pikachu/widgets/Masthead.tsx
+++ b/client/templates/Pikachu/widgets/Masthead.tsx
@@ -15,7 +15,7 @@ export const MastheadSidebar: React.FC = () => {
   const { name, photo, email, phone, website, location, profiles } = useAppSelector((state) => state.resume.basics);
 
   return (
-    <div className="col-span-2 grid justify-items-center gap-4">
+    <div className="col-span-2 grid justify-items-left gap-4">
       {photo.visible && !isEmpty(photo.url) && (
         <div className="relative aspect-square h-full w-full">
           <img alt={name} src={photo.url} className={getPhotoClassNames(photo.filters)} />


### PR DESCRIPTION
Issue - Pikachu Theme Basic Details - Phone number, Email & Website are Center Justified as Shown Below which looks Asymmetric

Fix- Changed the css to _justify-items-left_ from _justify-items-center_

<img width="352" alt="Screenshot 2022-03-14 at 7 36 22 PM" src="https://user-images.githubusercontent.com/27367779/158189677-9360168c-bb70-4494-982c-44bb336c15eb.png">
