### PR TITLE
Fix - Pikachu User Image upload, uncontrolled Image Size

### DIFF
--- a/client/templates/Pikachu/widgets/Masthead.tsx
+++ b/client/templates/Pikachu/widgets/Masthead.tsx
@@ -17,9 +17,13 @@ export const MastheadSidebar: React.FC = () => {
   return (
     <div className="col-span-2 grid justify-items-left gap-4">
       {photo.visible && !isEmpty(photo.url) && (
-        <div className="relative aspect-square h-full w-full">
-          <img alt={name} src={photo.url} className={getPhotoClassNames(photo.filters)} />
-        </div>
+        <img
+          alt={name}
+          src={photo.url}
+          width={photo.filters.size}
+          height={photo.filters.size}
+          className={getPhotoClassNames(photo.filters)}
+        />
       )}
 
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
Issue- Pikachu Theme Image Uploaded gets overflowed over the other content and does't have a fixed size as in the Image below

Fix- Added width and height prop in the image tag with values as  {photos.filters.size}

<img width="496" alt="Screenshot 2022-03-15 at 6 04 03 AM" src="https://user-images.githubusercontent.com/27367779/158283145-2894985b-cf49-4ef1-8119-6a452f3cfd99.png">
 