### PR TITLE
Fix-Bug#702-Text Veering from Artboard (Sidebar)

### DIFF
--- a/client/templates/Castform/Castform.tsx
+++ b/client/templates/Castform/Castform.tsx
@@ -27,7 +27,7 @@ const Castform: React.FC<PageProps> = ({ page }) => {
       <div className={styles.container}>
         <div
           className={clsx(styles.sidebar, css(`svg { color: ${color} } --primary-color: ${color}`))}
-          style={{ color, backgroundColor: theme.primary }}
+          style={{ color, backgroundColor: theme.primary, wordBreak: 'break-word' }}
         >
           {isFirstPage && <MastheadSidebar />}
 

--- a/client/templates/Gengar/Gengar.tsx
+++ b/client/templates/Gengar/Gengar.tsx
@@ -34,7 +34,7 @@ const Gengar: React.FC<PageProps> = ({ page }) => {
             {isFirstPage && <MastheadSidebar />}
           </div>
 
-          <div className={styles.inner} style={{ backgroundColor }}>
+          <div className={styles.inner} style={{ backgroundColor, wordBreak: 'break-word' }}>
             {layout[1].map((key) => getSectionById(key, Section))}
           </div>
         </div>

--- a/client/templates/Glalie/Glalie.tsx
+++ b/client/templates/Glalie/Glalie.tsx
@@ -19,7 +19,7 @@ const Glalie: React.FC<PageProps> = ({ page }) => {
   return (
     <div className={styles.page}>
       <div className={styles.container}>
-        <div className={styles.sidebar} style={{ backgroundColor: alpha(primaryColor, 0.15) }}>
+        <div className={styles.sidebar} style={{ backgroundColor: alpha(primaryColor, 0.15), wordBreak: 'break-word' }}>
           {isFirstPage && <MastheadSidebar />}
 
           {layout[1].map((key) => getSectionById(key, Section))}

--- a/client/templates/Pikachu/Pikachu.tsx
+++ b/client/templates/Pikachu/Pikachu.tsx
@@ -15,7 +15,7 @@ const Pikachu: React.FC<PageProps> = ({ page }) => {
   return (
     <div className={styles.page}>
       <div className={styles.container}>
-        <div className={styles.sidebar}>
+        <div className={styles.sidebar} style={{ wordBreak: 'break-word' }}>
           {isFirstPage && <MastheadSidebar />}
 
           {layout[1].map((key) => getSectionById(key, Section))}


### PR DESCRIPTION
Issue- #702 (This issue exists on the whole sidebar content, and not limited to certifications)

Fix- I tried using tailwind's "break-words" utility in *template*.module.scss files but it seems to fail when some Website Url is entered (Certificate Section). Therefore using {wordBreak:"break-word"}  in inline styles works as expected. And the issue looks fixed. 

Please suggest if there is a better way.