### PR TITLE
Fix- Language Modal Slider Component Label Text Overlapping

### DIFF
--- a/client/modals/builder/sections/LanguageModal.tsx
+++ b/client/modals/builder/sections/LanguageModal.tsx
@@ -122,7 +122,7 @@ const LanguageModal: React.FC = () => {
             <div className="col-span-2">
               <h4 className="mb-3 font-semibold">{t('builder.common.form.levelNum.label')}</h4>
 
-              <div className="px-10">
+              <div className="px-3">
                 <Slider
                   {...field}
                   marks={[


### PR DESCRIPTION
Issue- As Shown in the Image Below

Fix- Similar to #667 

<img width="266" alt="Screenshot 2022-03-16 at 11 15 33 AM" src="https://user-images.githubusercontent.com/27367779/158524815-5e8474d5-9898-4b9e-bc60-8fd88de1826a.png">
