### PR TITLE
Fix- Publication Modal Label text

### DIFF
--- a/client/modals/builder/sections/PublicationModal.tsx
+++ b/client/modals/builder/sections/PublicationModal.tsx
@@ -115,7 +115,7 @@ const PublicationModal: React.FC = () => {
           render={({ field, fieldState }) => (
             <TextField
               required
-              label="{t('builder.leftSidebar.sections.publications.form.publisher.label')}"
+              label={t('builder.leftSidebar.sections.publications.form.publisher.label')}
               error={!!fieldState.error}
               helperText={fieldState.error?.message}
               {...field}


### PR DESCRIPTION
Issue- Publication Modal Screen Label Text Incorrect as in the Image Below

Fix- Removed the Double Quotes wrapping the Variable

<img width="543" alt="Screenshot 2022-03-16 at 11 14 58 AM" src="https://user-images.githubusercontent.com/27367779/158526011-2c9d3b79-2d6f-46a0-b2b3-d45b1e752ab6.png">

