### PR TITLE
Removed Self Referring Link in Docs

### DIFF
--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -14,7 +14,7 @@ import TOCInline from '@theme/TOCInline';
 [![Docker Pulls](https://img.shields.io/docker/pulls/amruthpillai/reactive-resume?style=flat-square)](https://hub.docker.com/r/amruthpillai/reactive-resume)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FAmruthPillai%2FReactive-Resume.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FAmruthPillai%2FReactive-Resume?ref=badge_shield)
 
-## [Go to App](https://rxresu.me) | [Docs](https://docs.rxresu.me)
+## [Go to App](https://rxresu.me) | [GitHub Repo](https://github.com/AmruthPillai/Reactive-Resume)
 
 ## Summary
 


### PR DESCRIPTION
Doc had a link to itself probably because it's a copy of README.

Modified & linked to the GitHub Repo so that they can check out this repo.

If you got some other important link, feel free to change. 🙂