### PR TITLE
Update docusaurus to prevent crash with client

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "docusaurus serve --port 3200",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },


### PR DESCRIPTION
on `pnpm dev` , docusaurus not conflicted with client because it set port on launch.
`docusaurus start --no-open --port 3200`

But on `pnpm start` client and docusaurus conflict each other, as the command not define port.
`docusaurus serve`

this PR add port to docusaurus, so `pnpm start` can run correctly.
`docusaurus serve --port 3200`