### PR TITLE
Support arm64 docker image

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -29,12 +29,16 @@ jobs:
           registry: ghcr.io
           username: $GITHUB_REPOSITORY_OWNER
           password: ${{ secrets.GH_TOKEN }}
-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build and Push Client Image
         uses: docker/build-push-action@v3.1.1
         with:
           context: .
           push: true
+          platforms: linux/amd64, linux/arm64
           file: client/Dockerfile
           tags: |
             amruthpillai/reactive-resume:client-latest
@@ -66,12 +70,16 @@ jobs:
           registry: ghcr.io
           username: $GITHUB_REPOSITORY_OWNER
           password: ${{ secrets.GH_TOKEN }}
-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build and Push Server Image
         uses: docker/build-push-action@v3.1.1
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           file: server/Dockerfile
           tags: |
             amruthpillai/reactive-resume:server-latest

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -32,7 +32,7 @@ FROM mcr.microsoft.com/playwright:focal as production
 WORKDIR /app
 
 RUN apt-get update \
-  && apt-get install -y curl \
+  && apt-get install -y g++ make curl \
   && curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm
 
 COPY --from=builder /app/pnpm-*.yaml ./


### PR DESCRIPTION
- related issue #934

## when docker build on m1
```bash
❯ docker build -t test -f server/Dockerfile .
[+] Building 257.2s (26/27)
 => [internal] load build definition from Dockerfile                                             0.0s
 => => transferring dockerfile: 1.49kB                                                           0.0s
 => [internal] load .dockerignore                                                                0.0s
 => => transferring context: 35B                                                                 0.0s
 => [internal] load metadata for mcr.microsoft.com/playwright:focal                              0.6s
 => [internal] load metadata for docker.io/library/node:lts-alpine                               2.7s
 => [auth] library/node:pull token for registry-1.docker.io                                      0.0s
 => [dependencies 1/7] FROM docker.io/library/node:lts-alpine@sha256:2c405ed42fc0fd6aacbe573004  0.0s
 => [internal] load build context                                                                0.0s
 => => transferring context: 120.10kB                                                            0.0s
 => [production 1/8] FROM mcr.microsoft.com/playwright:focal@sha256:b9f45da0e102e5e40c206fc48  233.9s
 => => resolve mcr.microsoft.com/playwright:focal@sha256:b9f45da0e102e5e40c206fc48f65035999e74f  0.0s
 => => sha256:8a3716cfb7b0c1ad6ea1cbf4c760ba7c7bc55a35e165cf8c2139e05b3032fd6a 2.15MB / 2.15MB   2.2s
 => => sha256:e1a367ceee4f6df8d6de086ad6ad3bd6c659ffa299018ed4dbb18ff05e1 501.90MB / 501.90MB  222.9s
 => => sha256:b9f45da0e102e5e40c206fc48f65035999e74f6e73b8e5f191f73c1159fbc14e 772B / 772B       0.0s
 => => sha256:918beabcdf40c6dc30987c68145b4f4de65d62cb0768327ef304465343dd9a31 1.17kB / 1.17kB   0.0s
 => => sha256:c9015678764ebc9df9578135dedf92127e8bd90112ecfccf47ee83e7803516db 4.42kB / 4.42kB   0.0s
 => => sha256:5f92af518494fcd8365c3b0d2159d79e2a677bd4ba30b282f87ab4c28488a2 85.63MB / 85.63MB  62.2s
 => => extracting sha256:5f92af518494fcd8365c3b0d2159d79e2a677bd4ba30b282f87ab4c28488a23a        2.0s
 => => extracting sha256:8a3716cfb7b0c1ad6ea1cbf4c760ba7c7bc55a35e165cf8c2139e05b3032fd6a        0.0s
 => => extracting sha256:e1a367ceee4f6df8d6de086ad6ad3bd6c659ffa299018ed4dbb18ff05e1bf5b1       10.8s
 => CACHED [dependencies 2/7] RUN apk add --no-cache g++ curl make python3   && curl -f https:/  0.0s
 => CACHED [dependencies 3/7] WORKDIR /app                                                       0.0s
 => CACHED [dependencies 4/7] COPY package.json pnpm-*.yaml ./                                   0.0s
 => CACHED [dependencies 5/7] COPY ./schema/package.json ./schema/package.json                   0.0s
 => CACHED [dependencies 6/7] COPY ./server/package.json ./server/package.json                   0.0s
 => [dependencies 7/7] RUN pnpm install --frozen-lockfile                                      144.5s
 => [builder 4/9] COPY . .                                                                       0.2s
 => [builder 5/9] COPY --from=dependencies /app/node_modules ./node_modules                      3.5s
 => [builder 6/9] COPY --from=dependencies /app/schema/node_modules ./schema/node_modules        0.0s
 => [builder 7/9] COPY --from=dependencies /app/server/node_modules ./server/node_modules        0.0s
 => [builder 8/9] RUN pnpm run build:schema                                                      1.5s
 => [builder 9/9] RUN pnpm run build:server                                                     10.4s
 => [production 2/8] WORKDIR /app                                                                0.5s
 => [production 3/8] RUN apt-get update   && apt-get install -y curl   && curl -f https://get.  10.3s
 => [production 4/8] COPY --from=builder /app/pnpm-*.yaml ./                                     0.5s
 => [production 5/8] COPY --from=builder /app/package.json ./                                    0.0s
 => [production 6/8] COPY --from=builder /app/server/package.json ./server/package.json          0.0s
 => ERROR [production 7/8] RUN pnpm install -F server --frozen-lockfile --prod                   9.2s
------
 > [production 7/8] RUN pnpm install -F server --frozen-lockfile --prod:
#26 0.420 Lockfile is up to date, resolution step is skipped
#26 0.445 Progress: resolved 1, reused 0, downloaded 0, added 0
#26 0.485 .                                        | +400 ++++++++++++++++++++++++++++++++
#26 0.626 Packages are hard linked from the content-addressable store to the virtual store.
#26 0.626   Content-addressable store is at: /root/.local/share/pnpm/store/v3
#26 0.626   Virtual store is at:             node_modules/.pnpm
#26 1.447 Progress: resolved 400, reused 0, downloaded 12, added 11
#26 2.448 Progress: resolved 400, reused 0, downloaded 43, added 43
#26 3.449 Progress: resolved 400, reused 0, downloaded 73, added 73
#26 4.448 Progress: resolved 400, reused 0, downloaded 229, added 229
#26 5.448 Progress: resolved 400, reused 0, downloaded 335, added 334
#26 6.449 Progress: resolved 400, reused 0, downloaded 391, added 391
#26 7.449 Progress: resolved 400, reused 0, downloaded 400, added 400, done
#26 7.452 .../node_modules/playwright-chromium install$ node install.js
#26 7.453 .../bcrypt@5.0.1/node_modules/bcrypt install$ node-pre-gyp install --fallback-to-build
#26 7.476 .../node_modules/@nestjs/core postinstall$ opencollective || exit 0
#26 7.522 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp info it worked if it ends with ok
#26 7.523 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp info using node-pre-gyp@1.0.9
#26 7.523 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp info using node@16.16.0 | linux | arm64
#26 7.563 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp info check checked for "/app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt/lib/binding/napi-v3/bcrypt_lib.node" (not found)
#26 7.564 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp http GET https://github.com/kelektiv/node.bcrypt.js/releases/download/v5.0.1/bcrypt_lib-v5.0.1-napi-v3-linux-arm64-glibc.tar.gz
#26 7.595 .../node_modules/playwright-chromium install: Done
#26 7.725 .../node_modules/@nestjs/core postinstall:                            Thanks for installing nest
#26 7.725 .../node_modules/@nestjs/core postinstall:                  Please consider donating to our open collective
#26 7.725 .../node_modules/@nestjs/core postinstall:                         to help us maintain this package.
#26 7.725 .../node_modules/@nestjs/core postinstall:
#26 7.725 .../node_modules/@nestjs/core postinstall:                             Number of contributors: 0
#26 7.725 .../node_modules/@nestjs/core postinstall:                               Number of backers: 813
#26 7.738 .../node_modules/@nestjs/core postinstall:                              Annual budget: $168,105
#26 7.738 .../node_modules/@nestjs/core postinstall:                              Current balance: $2,743
#26 7.739 .../node_modules/@nestjs/core postinstall:
#26 7.739 .../node_modules/@nestjs/core postinstall:              Become a partner: https://opencollective.com/nest/donate
#26 7.739 .../node_modules/@nestjs/core postinstall:
#26 7.741 .../node_modules/@nestjs/core postinstall: Done
#26 7.870 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! install response status 404 Not Found on https://github.com/kelektiv/node.bcrypt.js/releases/download/v5.0.1/bcrypt_lib-v5.0.1-napi-v3-linux-arm64-glibc.tar.gz
#26 7.871 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp WARN Pre-built binaries not installable for bcrypt@5.0.1 and node@16.16.0 (node-v93 ABI, glibc) (falling back to source compile with node-gyp)
#26 7.871 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp WARN Hit error response status 404 Not Found on https://github.com/kelektiv/node.bcrypt.js/releases/download/v5.0.1/bcrypt_lib-v5.0.1-napi-v3-linux-arm64-glibc.tar.gz
#26 7.915 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info it worked if it ends with ok
#26 7.916 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info using node-gyp@9.1.0
#26 7.916 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info using node@16.16.0 | linux | arm64
#26 7.922 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info ok
#26 7.963 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info it worked if it ends with ok
#26 7.964 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info using node-gyp@9.1.0
#26 7.964 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info using node@16.16.0 | linux | arm64
#26 8.000 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
#26 8.051 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp http GET https://nodejs.org/download/release/v16.16.0/node-v16.16.0-headers.tar.gz
#26 8.233 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp http 200 https://nodejs.org/download/release/v16.16.0/node-v16.16.0-headers.tar.gz
#26 8.727 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp http GET https://nodejs.org/download/release/v16.16.0/SHASUMS256.txt
#26 8.782 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp http 200 https://nodejs.org/download/release/v16.16.0/SHASUMS256.txt
#26 8.788 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn /usr/bin/python3
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args [
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '/usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   'binding.gyp',
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-f',
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   'make',
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-I',
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '/app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt/build/config.gypi',
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-I',
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '/usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-I',
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '/root/.cache/node-gyp/16.16.0/include/node/common.gypi',
#26 8.789 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-Dlibrary=shared_library',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-Dvisibility=default',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-Dnode_root_dir=/root/.cache/node-gyp/16.16.0',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-Dnode_gyp_dir=/usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/node-gyp',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-Dnode_lib_file=/root/.cache/node-gyp/16.16.0/<(target_arch)/node.lib',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-Dmodule_root_dir=/app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-Dnode_engine=v8',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '--depth=.',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '--no-parallel',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '--generator-output',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   'build',
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args   '-Goutput_dir=.'
#26 8.790 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info spawn args ]
#26 8.898 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info ok
#26 8.947 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info it worked if it ends with ok
#26 8.948 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info using node-gyp@9.1.0
#26 8.948 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp info using node@16.16.0 | linux | arm64
#26 8.957 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! build error
#26 8.957 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack Error: not found: make
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack     at getNotFoundError (/usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/which/which.js:10:17)
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack     at /usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/which/which.js:57:18
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack     at new Promise (<anonymous>)
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack     at step (/usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/which/which.js:54:21)
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack     at /usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/which/which.js:71:22
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack     at new Promise (<anonymous>)
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack     at subStep (/usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/which/which.js:69:33)
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack     at /usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/which/which.js:80:22
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack     at /usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/isexe/index.js:42:5
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! stack     at /usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/isexe/mode.js:8:5
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! System Linux 5.10.104-linuxkit
#26 8.958 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! command "/usr/bin/node" "/usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--module=/app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt/lib/binding/napi-v3/bcrypt_lib.node" "--module_name=bcrypt_lib" "--module_path=/app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt/lib/binding/napi-v3" "--napi_version=8" "--node_abi_napi=napi" "--napi_build_version=3" "--node_napi_label=napi-v3"
#26 8.959 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! cwd /app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt
#26 8.959 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! node -v v16.16.0
#26 8.959 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! node-gyp -v v9.1.0
#26 8.959 .../bcrypt@5.0.1/node_modules/bcrypt install: gyp ERR! not ok
#26 8.961 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! build error
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! stack Error: Failed to execute '/usr/bin/node /usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt/lib/binding/napi-v3/bcrypt_lib.node --module_name=bcrypt_lib --module_path=/app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt/lib/binding/napi-v3 --napi_version=8 --node_abi_napi=napi --napi_build_version=3 --node_napi_label=napi-v3' (1)
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/app/node_modules/.pnpm/@mapbox+node-pre-gyp@1.0.9/node_modules/@mapbox/node-pre-gyp/lib/util/compile.js:89:23)
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! stack     at ChildProcess.emit (node:events:527:28)
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! stack     at maybeClose (node:internal/child_process:1092:16)
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:302:5)
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! System Linux 5.10.104-linuxkit
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! command "/usr/bin/node" "/app/node_modules/.pnpm/@mapbox+node-pre-gyp@1.0.9/node_modules/@mapbox/node-pre-gyp/bin/node-pre-gyp" "install" "--fallback-to-build"
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! cwd /app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! node -v v16.16.0
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! node-pre-gyp -v v1.0.9
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: node-pre-gyp ERR! not ok
#26 8.962 .../bcrypt@5.0.1/node_modules/bcrypt install: Failed to execute '/usr/bin/node /usr/pnpm-global/5/node_modules/.pnpm/pnpm@7.9.3/node_modules/pnpm/dist/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt/lib/binding/napi-v3/bcrypt_lib.node --module_name=bcrypt_lib --module_path=/app/node_modules/.pnpm/bcrypt@5.0.1/node_modules/bcrypt/lib/binding/napi-v3 --napi_version=8 --node_abi_napi=napi --napi_build_version=3 --node_napi_label=napi-v3' (1)
#26 8.965 .../bcrypt@5.0.1/node_modules/bcrypt install: Failed
#26 8.966  ELIFECYCLE  Command failed with exit code 1.
------
executor failed running [/bin/sh -c pnpm install -F server --frozen-lockfile --prod]: exit code: 1
```
## github action test
- https://github.com/kbc8894/Reactive-Resume/actions/runs/2895177789

Signed-off-by: Byungchan Kim <kbc8894@gmail.com>