### PR TITLE
fix: adjust padding on left/right sidebars

### DIFF
--- a/client/components/build/LeftSidebar/LeftSidebar.module.scss
+++ b/client/components/build/LeftSidebar/LeftSidebar.module.scss
@@ -5,7 +5,7 @@
 
   nav {
     @apply absolute inset-y-0 left-0;
-    @apply w-14 py-4 md:w-16 md:px-2;
+    @apply w-14 py-4 md:w-16 md:px-1;
     @apply bg-neutral-100 shadow dark:bg-neutral-800;
     @apply flex flex-col items-center justify-between;
 

--- a/client/components/build/RightSidebar/RightSidebar.module.scss
+++ b/client/components/build/RightSidebar/RightSidebar.module.scss
@@ -5,7 +5,7 @@
 
   nav {
     @apply absolute inset-y-0 right-0;
-    @apply w-12 py-4 md:w-16 md:px-2;
+    @apply w-12 py-4 md:w-16 md:px-1;
     @apply bg-neutral-100 shadow dark:bg-neutral-800;
     @apply flex flex-col items-center justify-between;
 


### PR DESCRIPTION
When I use the app using windows there are horizontal scrollbars unnecessarily displaying on the left/right sidebars. As shown in here

![before](https://user-images.githubusercontent.com/47825356/197136870-d4691071-8862-439a-833f-c85b291a30e3.png)


This is due to excess padding adjustment in these side bars. I fixed this by adjusting the padding of left/right sidebars. Here is the result

![after](https://user-images.githubusercontent.com/47825356/197136947-6caa1953-5871-46f3-9fc8-dd6cdd5474e1.png)
