### PR TITLE
feat: additional work sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ node_modules
 
 # Turbo
 .turbo
+
+# Intellij
+.idea

--- a/client/config/sections.tsx
+++ b/client/config/sections.tsx
@@ -23,7 +23,7 @@ import {
   VolunteerActivism,
   Work,
 } from '@mui/icons-material';
-import { Section as SectionRecord } from '@reactive-resume/schema';
+import { Section as SectionRecord, SectionType } from '@reactive-resume/schema';
 import isEmpty from 'lodash/isEmpty';
 
 import Basics from '@/components/build/LeftSidebar/sections/Basics';
@@ -60,59 +60,69 @@ export const left: SidebarSection[] = [
   {
     id: 'work',
     icon: <Work />,
-    component: <Section path="sections.work" titleKey="name" subtitleKey="position" isEditable isHideable />,
+    component: (
+      <Section
+        type={'work'}
+        addMore={true}
+        path="sections.work"
+        titleKey="name"
+        subtitleKey="position"
+        isEditable
+        isHideable
+      />
+    ),
   },
   {
     id: 'education',
     icon: <School />,
-    component: <Section path="sections.education" titleKey="institution" subtitleKey="area" isEditable isHideable />,
+    component: <Section type={"education"} path="sections.education" titleKey="institution" subtitleKey="area" isEditable isHideable />,
   },
   {
     id: 'awards',
     icon: <EmojiEvents />,
-    component: <Section path="sections.awards" titleKey="title" subtitleKey="awarder" isEditable isHideable />,
+    component: <Section type={"awards"} path="sections.awards" titleKey="title" subtitleKey="awarder" isEditable isHideable />,
   },
   {
     id: 'certifications',
     icon: <CardGiftcard />,
-    component: <Section path="sections.certifications" titleKey="name" subtitleKey="issuer" isEditable isHideable />,
+    component: <Section type={"certifications"} path="sections.certifications" titleKey="name" subtitleKey="issuer" isEditable isHideable />,
   },
   {
     id: 'publications',
     icon: <MenuBook />,
-    component: <Section path="sections.publications" titleKey="name" subtitleKey="publisher" isEditable isHideable />,
+    component: <Section type={"publications"} path="sections.publications" titleKey="name" subtitleKey="publisher" isEditable isHideable />,
   },
   {
     id: 'skills',
     icon: <Architecture />,
-    component: <Section path="sections.skills" titleKey="name" subtitleKey="level" isEditable isHideable />,
+    component: <Section type={"skills"} path="sections.skills" titleKey="name" subtitleKey="level" isEditable isHideable />,
   },
   {
     id: 'languages',
     icon: <Language />,
-    component: <Section path="sections.languages" titleKey="name" subtitleKey="level" isEditable isHideable />,
+    component: <Section type={"languages"} path="sections.languages" titleKey="name" subtitleKey="level" isEditable isHideable />,
   },
   {
     id: 'interests',
     icon: <Sailing />,
-    component: <Section path="sections.interests" titleKey="name" subtitleKey="keywords" isEditable isHideable />,
+    component: <Section type={"interests"} path="sections.interests" titleKey="name" subtitleKey="keywords" isEditable isHideable />,
   },
   {
     id: 'volunteer',
     icon: <VolunteerActivism />,
     component: (
-      <Section path="sections.volunteer" titleKey="organization" subtitleKey="position" isEditable isHideable />
+      <Section type={"volunteer"} path="sections.volunteer" titleKey="organization" subtitleKey="position" isEditable isHideable />
     ),
   },
   {
     id: 'projects',
     icon: <Coffee />,
-    component: <Section path="sections.projects" titleKey="name" subtitleKey="description" isEditable isHideable />,
+    component: <Section type={"projects"} path="sections.projects" titleKey="name" subtitleKey="description" isEditable isHideable />,
   },
   {
     id: 'references',
     icon: <Groups />,
-    component: <Section path="sections.references" titleKey="name" subtitleKey="relationship" isEditable isHideable />,
+    component: <Section type={"references"} path="sections.references" titleKey="name" subtitleKey="relationship" isEditable isHideable />,
   },
 ];
 
@@ -163,6 +173,21 @@ export const right: SidebarSection[] = [
     component: <Links />,
   },
 ];
+
+export const getSectionsByType = (
+  sections: Record<string, SectionRecord>,
+  type: SectionType
+): Array<Required<SectionRecord>> => {
+  if (isEmpty(sections)) return [];
+
+  return Object.entries(sections).reduce((acc, [id, section]) => {
+    if (section.type.startsWith(type) && section.isDuplicated) {
+      return [...acc, { ...section, id }];
+    }
+
+    return acc;
+  }, [] as Array<Required<SectionRecord>>);
+};
 
 export const getCustomSections = (sections: Record<string, SectionRecord>): Array<Required<SectionRecord>> => {
   if (isEmpty(sections)) return [];

--- a/client/modals/auth/LoginModal.tsx
+++ b/client/modals/auth/LoginModal.tsx
@@ -169,7 +169,8 @@ const LoginModal: React.FC = () => {
 
       <p className="text-xs">
         <Trans t={t} i18nKey="modals.auth.login.recover-text">
-          In case you have forgotten your password, you can <a onClick={handleRecoverAccount}>recover your account here.</a>
+          In case you have forgotten your password, you can{' '}
+          <a onClick={handleRecoverAccount}>recover your account here.</a>
         </Trans>
       </p>
     </BaseModal>

--- a/client/modals/builder/sections/WorkModal.tsx
+++ b/client/modals/builder/sections/WorkModal.tsx
@@ -2,7 +2,7 @@ import { joiResolver } from '@hookform/resolvers/joi';
 import { Add, DriveFileRenameOutline } from '@mui/icons-material';
 import { Button, TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
-import { SectionPath, WorkExperience } from '@reactive-resume/schema';
+import { WorkExperience } from '@reactive-resume/schema';
 import dayjs from 'dayjs';
 import Joi from 'joi';
 import get from 'lodash/get';
@@ -19,8 +19,6 @@ import { setModalState } from '@/store/modal/modalSlice';
 import { addItem, editItem } from '@/store/resume/resumeSlice';
 
 type FormData = WorkExperience;
-
-const path: SectionPath = 'sections.work';
 
 const defaultState: FormData = {
   name: '',
@@ -51,9 +49,11 @@ const WorkModal: React.FC = () => {
   const dispatch = useAppDispatch();
 
   const heading = useAppSelector((state) => get(state.resume.present, `${path}.name`));
-  const { open: isOpen, payload } = useAppSelector((state) => state.modal[`builder.${path}`]);
 
+  const { open: isOpen, payload } = useAppSelector((state) => state.modal['builder.sections.work']);
+  const path: string = get(payload, 'path', 'sections.work');
   const item: FormData = get(payload, 'item', null);
+
   const isEditMode = useMemo(() => !!item, [item]);
 
   const addText = useMemo(() => t<string>('builder.common.actions.add', { token: heading }), [t, heading]);
@@ -77,7 +77,7 @@ const WorkModal: React.FC = () => {
   const handleClose = () => {
     dispatch(
       setModalState({
-        modal: `builder.${path}`,
+        modal: 'builder.sections.work',
         state: { open: false },
       })
     );

--- a/client/public/locales/en/builder.json
+++ b/client/public/locales/en/builder.json
@@ -3,7 +3,8 @@
     "actions": {
       "add": "Add New {{token}}",
       "delete": "Delete {{token}}",
-      "edit": "Edit {{token}}"
+      "edit": "Edit {{token}}",
+      "duplicate": "Duplicate Section"
     },
     "columns": {
       "heading": "Columns",

--- a/client/store/modal/modalSlice.ts
+++ b/client/store/modal/modalSlice.ts
@@ -9,6 +9,7 @@ export type ModalName =
   | 'dashboard.import-external'
   | 'dashboard.rename-resume'
   | 'builder.sections.profile'
+  | 'builder.sections.work'
   | `builder.sections.${string}`;
 
 export type ModalState = {

--- a/client/store/resume/resumeSlice.ts
+++ b/client/store/resume/resumeSlice.ts
@@ -1,4 +1,4 @@
-import { ListItem, Profile, Resume, Section } from '@reactive-resume/schema';
+import { ListItem, Profile, Resume, Section, SectionType } from '@reactive-resume/schema';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
@@ -6,6 +6,8 @@ import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import set from 'lodash/set';
 import { v4 as uuidv4 } from 'uuid';
+
+import { getSectionsByType } from '@/config/sections';
 
 type SetResumeStatePayload = { path: string; value: unknown };
 
@@ -17,7 +19,7 @@ type DuplicateItemPayload = { path: string; value: ListItem };
 
 type DeleteItemPayload = { path: string; value: ListItem };
 
-type AddSectionPayload = { value: Section };
+type AddSectionPayload = { value: Section; type: SectionType };
 
 type DeleteSectionPayload = { path: string };
 
@@ -80,6 +82,15 @@ export const resumeSlice = createSlice({
       state.sections[id] = value;
       state.metadata.layout[0][0].push(id);
     },
+    duplicateSection: (state: Resume, action: PayloadAction<AddSectionPayload>) => {
+      const { value, type } = action.payload;
+
+      const id = getSectionsByType(state.sections, type).length + 1;
+      value.name = value.name + '-' + id;
+
+      state.sections[`${type}-${id}`] = value;
+      state.metadata.layout[0][0].push(`${type}-${id}`);
+    },
     deleteSection: (state: Resume, action: PayloadAction<DeleteSectionPayload>) => {
       const { path } = action.payload;
       const id = path.split('.')[1];
@@ -119,6 +130,7 @@ export const {
   duplicateItem,
   deleteItem,
   addSection,
+  duplicateSection,
   deleteSection,
   addPage,
   deletePage,

--- a/client/templates/sectionMap.tsx
+++ b/client/templates/sectionMap.tsx
@@ -1,3 +1,4 @@
+import { find } from 'lodash';
 import get from 'lodash/get';
 import React from 'react';
 import { validate } from 'uuid';
@@ -44,11 +45,21 @@ const sectionMap = (Section: React.FC<SectionProps>): Record<string, JSX.Element
 });
 
 export const getSectionById = (id: string, Section: React.FC<SectionProps>): JSX.Element => {
+  // Check if section id is a custom section (an uuid)
   if (validate(id)) {
     return <Section key={id} path={`sections.${id}`} />;
   }
 
-  return get(sectionMap(Section), id);
+  // Check if section id is a predefined seciton in config
+  const predefinedSection = get(sectionMap(Section), id);
+
+  if(predefinedSection) {
+    return predefinedSection;
+  }
+
+  // Other ways section should be a cloned section
+  const section = find(sectionMap(Section), (element, key) => id.includes(key));
+  return React.cloneElement(section!, { path: `sections.${id}` });
 };
 
 export default sectionMap;

--- a/schema/src/section.ts
+++ b/schema/src/section.ts
@@ -125,7 +125,22 @@ export type ListItem =
   | WorkExperience
   | Custom;
 
-export type SectionType = 'basic' | 'custom';
+export type SectionType =
+  | 'basic'
+  | 'location'
+  | 'profiles'
+  | 'education'
+  | 'awards'
+  | 'certifications'
+  | 'publications'
+  | 'skills'
+  | 'languages'
+  | 'interests'
+  | 'volunteer'
+  | 'projects'
+  | 'references'
+  | 'custom'
+  | 'work';
 
 export type SectionPath = `sections.${string}`;
 
@@ -136,4 +151,5 @@ export type Section = {
   columns: number;
   visible: boolean;
   items: ListItem[];
+  isDuplicated: boolean;
 };

--- a/server/src/resume/data/defaultState.ts
+++ b/server/src/resume/data/defaultState.ts
@@ -38,7 +38,7 @@ const defaultState: Partial<Resume> = {
     work: {
       id: 'work',
       name: 'Work Experience',
-      type: 'basic',
+      type: 'work',
       columns: 2,
       visible: true,
       items: [],


### PR DESCRIPTION
I would like to open this PR as a discussion on how to better arrange work experiences along multiple pages.

I have added a button "Add new section" under the current "work" section that adds a work-1, work-2 and so on sections.
I have modified the WorkModal to work with changing path (similar to the custom sections).

Please let me know what you think.

https://gfycat.com/thesesecretamericanratsnake


