### PR TITLE
Fix link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You have complete control over what goes into your resume, how it looks, what co
 ## Table of Contents
 
 - [Reactive Resume](#reactive-resume)
-  - [Go to App Docs](https://docs.rxresu.me)](#go-to-app--docs)
+  - [Go to App Docs](https://docs.rxresu.me)
   - [Table of Contents](#table-of-contents)
   - [Features](#features)
   - [Languages](#languages)


### PR DESCRIPTION
Bad practice on my part for last commit - did not check before push. Link under table of contents fixed and now directs to the [documentation](https://docs.rxresu.me).
### Table of Contents
`- [Go to App Docs](https://docs.rxresu.me)](#go-to-app--docs)`
Is now
`- [Go to App Docs](https://docs.rxresu.me)`

My apologies.