### PR TITLE
fix: overflow-y-auto

### DIFF
--- a/client/components/build/LeftSidebar/LeftSidebar.tsx
+++ b/client/components/build/LeftSidebar/LeftSidebar.tsx
@@ -108,7 +108,7 @@ const LeftSidebar = () => {
       variant={isDesktop ? 'persistent' : 'temporary'}
     >
       <div className={styles.container}>
-        <nav className="overflow-y-scroll">
+        <nav className="overflow-y-auto">
           <div>
             <Link href="/dashboard">
               <Logo size={40} />

--- a/client/components/build/RightSidebar/RightSidebar.tsx
+++ b/client/components/build/RightSidebar/RightSidebar.tsx
@@ -43,7 +43,7 @@ const RightSidebar = () => {
       variant={isDesktop ? 'persistent' : 'temporary'}
     >
       <div className={styles.container}>
-        <nav className="overflow-y-scroll">
+        <nav className="overflow-y-auto">
           <div>
             <Avatar size={40} />
             <Divider />


### PR DESCRIPTION
If "Show scroll bars" is set to "Always" in the mac settings. Sidebars scroll horizontally all the time. Setting overflow: auto fixes the bug
<img width="69" alt="Screenshot 2022-12-29 at 19 41 22" src="https://user-images.githubusercontent.com/25247802/209990309-f9c3a0d4-0321-4a6f-9ff2-17ccdc194a6e.png">
