### PR TITLE
fix: Gengar two cols bug

### DIFF
--- a/client/templates/Gengar/widgets/Section.tsx
+++ b/client/templates/Gengar/widgets/Section.tsx
@@ -75,7 +75,7 @@ const Section: React.FC<SectionProps> = ({
                       {Array.from(Array(8).keys()).map((_, index) => (
                         <div
                           key={index}
-                          className="mr-1 h-2 w-4 rounded-sm border"
+                          className="mr-1 h-2 w-full max-w-[1rem] rounded-sm border"
                           style={{
                             borderColor: primaryColor,
                             backgroundColor: levelNum / (10 / 8) > index ? primaryColor : '',


### PR DESCRIPTION
There seems to be a small bug in the Gengar template. If I select skills in two columns, I see the following picture
<img width="295" alt="Screenshot 2022-12-31 at 09 50 03" src="https://user-images.githubusercontent.com/25247802/210129973-7c261d9b-7690-4548-8be5-0a93ac397452.png">
This seems to be a better option
<img width="295" alt="Screenshot 2022-12-31 at 09 57 42" src="https://user-images.githubusercontent.com/25247802/210129988-8449b3af-cdc8-47b2-b4e8-24027b65bdce.png">
