### PR TITLE
Fixing unconditional ```http://``` prefix.

### DIFF
--- a/client/utils/template.ts
+++ b/client/utils/template.ts
@@ -20,7 +20,7 @@ export const formatLocation = (location?: Location): string => {
 };
 
 export const addHttp = (url: string) => {
-  if (url.search(/^http[s]?:\/\//) == -1) {
+  if (url.search(/^http[s]?:\/\//) == -1 && url.search(/^mailto:/) == -1 && url.search(/^tel:/) == -1) {
     url = 'http://' + url;
   }
 


### PR DESCRIPTION
First time contribution (ever, woo!).

Fixes issue: #1165

Adds a check in ```addHttp()``` to see if ```mailto:``` or ```tel:``` is present before attempting to append ```http://```.

Thanks!