### PR TITLE
fix: extra whitespace in Castform header

### DIFF
--- a/client/templates/Castform/widgets/Masthead.tsx
+++ b/client/templates/Castform/widgets/Masthead.tsx
@@ -96,8 +96,12 @@ export const MastheadMain: React.FC = () => {
   const { summary } = useAppSelector((state) => state.resume.present.basics);
 
   return (
-    <div className="px-4 pt-4">
-      <Markdown>{summary}</Markdown>
-    </div>
+    <>
+      {summary && (
+        <div className="px-4 pt-4">
+          <Markdown>{summary}</Markdown>
+        </div>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
Using the Castform template without a summary, still has extra whitespace for the summary. This commit fixes the extra whitespace to not appear when no summary is present.

Closes #1194

Before:
![image](https://user-images.githubusercontent.com/857700/213947198-278cfa81-c34f-4922-8a24-6abb60c913db.png)


After:
![image](https://user-images.githubusercontent.com/857700/213947211-1d5e28cc-2148-4fa4-b4d1-3576f54ce5fd.png)
