### PR TITLE
Removed unnecessary workspaces declaration from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,6 @@
     "format": "prettier --write .",
     "lint": "turbo run lint"
   },
-  "workspaces": [
-    "schema",
-    "client",
-    "server"
-  ],
   "dependencies": {
     "cross-env": "^7.0.3",
     "cross-var": "^1.1.0",


### PR DESCRIPTION
Sir,

Workspaces declaration is not required in the root "package.json" in case you are using `pnpm` as the package manager for your monorepo. Workspaces declaration is only required inside `pnpm-workspace.yaml` which is already there.

We declare workspaces in "package.json" only if we are using `npm` as the package manager for our monorepo.

I have thus removed it from the root "package.json". Kindly have a look.

Reference:- https://turbo.build/repo/docs/handbook/workspaces

Wishing you success,

Muhammad