### PR TITLE
Fixed date selection by selecting month after year

### DIFF
--- a/client/components/shared/ResumeInput.tsx
+++ b/client/components/shared/ResumeInput.tsx
@@ -59,7 +59,7 @@ const ResumeInput: React.FC<Props> = ({ type = 'text', label, path, className, m
         label={label}
         value={dayjs(value)}
         views={['year', 'month', 'day']}
-        slots={{ textField: (params) => <TextField {...params} error={false} className={className} /> }}
+        className={className}
         onChange={(date: dayjs.Dayjs | null) => {
           if (!date) return onChangeValue('');
           if (dayjs(date).isValid()) return onChangeValue(dayjs(date).format('YYYY-MM-DD'));

--- a/client/components/shared/ResumeInput.tsx
+++ b/client/components/shared/ResumeInput.tsx
@@ -58,6 +58,7 @@ const ResumeInput: React.FC<Props> = ({ type = 'text', label, path, className, m
         openTo="year"
         label={label}
         value={dayjs(value)}
+        views={['year', 'month', 'day']}
         slots={{ textField: (params) => <TextField {...params} error={false} className={className} /> }}
         onChange={(date: dayjs.Dayjs | null) => {
           if (!date) return onChangeValue('');


### PR DESCRIPTION
Closes [1371](https://github.com/AmruthPillai/Reactive-Resume/issues/1371)

**Expected behavior:** User should be able to select a year, then a month, and then a day. Also should change the date through keyboard.

**Found behavior:** After selecting the year it breaks the UI, renders the calendar in the corner of the screen instead of rendering with respect to the `Date of Birth` element and the user can't select the follow-up month and date properly.
Also when changing the date by arrow key, it stopped working after the first time and remove the focus from the element.

<img width="467" alt="Screenshot 2023-07-21 at 3 17 09 PM" src="https://github.com/AmruthPillai/Reactive-Resume/assets/23460641/5ae2a774-92a7-4eaa-90df-8f7ec1ba280a">
