### PR TITLE
Fixed Date entered on any <Date> field is one day earlier

### DIFF
--- a/client/utils/date.ts
+++ b/client/utils/date.ts
@@ -41,12 +41,12 @@ export const formatDateString = (date: string | DateRange, formatStr: string): s
   if (!dayjs(date.start).isValid()) return null;
 
   if (dayjs(date.start).isSame(date.end)) {
-    return dayjs.utc(date.start).local().format(formatStr);
+    return dayjs.utc(date.start).format(formatStr);
   }
 
   if (!isEmpty(date.end) && dayjs(date.end).isValid()) {
-    return `${dayjs.utc(date.start).local().format(formatStr)} - ${dayjs.utc(date.end).local().format(formatStr)}`;
+    return `${dayjs.utc(date.start).format(formatStr)} - ${dayjs.utc(date.end).format(formatStr)}`;
   }
 
-  return `${dayjs.utc(date.start).local().format(formatStr)} - ${presentString}`;
+  return `${dayjs.utc(date.start).format(formatStr)} - ${presentString}`;
 };


### PR DESCRIPTION
Fixes https://github.com/AmruthPillai/Reactive-Resume/issues/1388

**Expected behavior:** When entering a date on any given Date Field, it should show date as it was selected.

**Found behavior:** Selected date is being converted to local date string.