### PR TITLE
fix: Education Date picker modal UI component

### DIFF
--- a/client/modals/builder/sections/EducationModal.tsx
+++ b/client/modals/builder/sections/EducationModal.tsx
@@ -172,14 +172,11 @@ const EducationModal: React.FC = () => {
               label={t('builder.common.form.start-date.label')}
               value={dayjs(field.value)}
               views={['year', 'month', 'day']}
-              slots={{
-                textField: (params) => (
-                  <TextField
-                    {...params}
-                    error={!!fieldState.error}
-                    helperText={fieldState.error?.message || params.inputProps?.placeholder}
-                  />
-                ),
+              slotProps={{
+                textField: {
+                  error: !!fieldState.error,
+                  helperText: fieldState.error?.message || t('builder.common.form.start-date.help-text')
+                },
               }}
               onChange={(date: dayjs.Dayjs | null) => {
                 date && dayjs(date).isValid() && field.onChange(dayjs(date).format('YYYY-MM-DD'));
@@ -198,14 +195,11 @@ const EducationModal: React.FC = () => {
               label={t('builder.common.form.end-date.label')}
               value={dayjs(field.value)}
               views={['year', 'month', 'day']}
-              slots={{
-                textField: (params) => (
-                  <TextField
-                    {...params}
-                    error={!!fieldState.error}
-                    helperText={fieldState.error?.message || t('builder.common.form.end-date.help-text')}
-                  />
-                ),
+              slotProps={{
+                textField: {
+                  error: !!fieldState.error,
+                  helperText: fieldState.error?.message || t('builder.common.form.end-date.help-text')
+                },
               }}
               onChange={(date: dayjs.Dayjs | null) => {
                 date && dayjs(date).isValid() && field.onChange(dayjs(date).format('YYYY-MM-DD'));


### PR DESCRIPTION
Expected behavior: In the education modal, the user should be able to select a year, then a month, and then a day. Also should change the date through the keyboard.

Found behavior: After selecting the year it breaks the UI, renders the calendar in the corner of the screen instead of rendering with respect to the Date Range element and the user can't select the follow-up month and date properly.
Also when changing the date by arrow key, it stopped working after the first time and remove the focus from the element.

<img width="1004" alt="Screenshot 2023-07-24 at 6 30 57 PM" src="https://github.com/AmruthPillai/Reactive-Resume/assets/23460641/1f943cd7-3f00-411a-809a-1aef603d3abe">