### PR TITLE
fix: Work Modal Datepicker popup

### DIFF
--- a/client/modals/builder/sections/WorkModal.tsx
+++ b/client/modals/builder/sections/WorkModal.tsx
@@ -151,14 +151,11 @@ const WorkModal: React.FC = () => {
               label={t('builder.common.form.start-date.label')}
               value={dayjs(field.value)}
               views={['year', 'month', 'day']}
-              slots={{
-                textField: (params) => (
-                  <TextField
-                    {...params}
-                    error={!!fieldState.error}
-                    helperText={fieldState.error?.message || params.inputProps?.placeholder}
-                  />
-                ),
+              slotProps={{
+                textField: {
+                  error: !!fieldState.error,
+                  helperText: fieldState.error?.message || t('builder.common.form.start-date.help-text')
+                },
               }}
               onChange={(date: dayjs.Dayjs | null) => {
                 date && dayjs(date).isValid() && field.onChange(dayjs(date).format('YYYY-MM-DD'));
@@ -177,14 +174,11 @@ const WorkModal: React.FC = () => {
               label={t('builder.common.form.end-date.label')}
               value={dayjs(field.value)}
               views={['year', 'month', 'day']}
-              slots={{
-                textField: (params) => (
-                  <TextField
-                    {...params}
-                    error={!!fieldState.error}
-                    helperText={fieldState.error?.message || t('builder.common.form.end-date.help-text')}
-                  />
-                ),
+              slotProps={{
+                textField: {
+                  error: !!fieldState.error,
+                  helperText: fieldState.error?.message || t('builder.common.form.end-date.help-text')
+                },
               }}
               onChange={(date: dayjs.Dayjs | null) => {
                 date && dayjs(date).isValid() && field.onChange(dayjs(date).format('YYYY-MM-DD'));


### PR DESCRIPTION
Expected behavior: In the work modal, the user should be able to select a year, then a month, and then a day. Also should change the date through the keyboard.

Found behavior: After selecting the year it breaks the UI, renders the calendar in the corner of the screen instead of rendering with respect to the Date Range element and the user can't select the follow-up month and date properly.
Also when changing the date by arrow key, it stopped working after the first time and remove the focus from the element.

<img width="1282" alt="Screenshot 2023-07-31 at 3 05 54 PM" src="https://github.com/AmruthPillai/Reactive-Resume/assets/23460641/eac2b99d-5afa-4ce7-a2c2-7f69a5f10f32">
