### PR TITLE
fix: update the `updatedAt` field while deleting/uploading images

### DIFF
--- a/client/components/build/LeftSidebar/sections/PhotoUpload.tsx
+++ b/client/components/build/LeftSidebar/sections/PhotoUpload.tsx
@@ -32,7 +32,8 @@ const PhotoUpload: React.FC = () => {
     if (fileInputRef.current) {
       if (!isEmpty(photo.url)) {
         try {
-          await deleteMutation({ id });
+          const resume = await deleteMutation({ id });
+          dispatch(setResumeState({ path: 'updatedAt', value: get(resume, 'updatedAt', '') }));
         } finally {
           dispatch(setResumeState({ path: 'basics.photo.url', value: '' }));
         }
@@ -56,6 +57,7 @@ const PhotoUpload: React.FC = () => {
       const resume = await uploadMutation({ id, file });
 
       dispatch(setResumeState({ path: 'basics.photo.url', value: get(resume, 'basics.photo.url', '') }));
+      dispatch(setResumeState({ path: 'updatedAt', value: get(resume, 'updatedAt', '') }));
     }
   };
 

--- a/server/src/resume/resume.service.ts
+++ b/server/src/resume/resume.service.ts
@@ -268,6 +268,7 @@ export class ResumeService {
         await fs.writeFile(path + filename, file.buffer);
 
         updatedResume = set(resume, 'basics.photo.url', `${serverUrl}/assets/uploads/${userId}/${id}/` + filename);
+        updatedResume = set(updatedResume, 'updatedAt', new Date());
       } catch (error) {
         throw new HttpException(
           'Something went wrong. Please try again later, or raise an issue on GitHub if the problem persists.',
@@ -303,7 +304,8 @@ export class ResumeService {
       if (isValidFile) await fs.unlink(filePath);
     }
 
-    const updatedResume = set(resume, 'basics.photo.url', '');
+    let updatedResume = set(resume, 'basics.photo.url', '');
+    updatedResume = set(updatedResume, 'updatedAt', new Date());
 
     return this.resumeRepository.save<Resume>(updatedResume);
   }


### PR DESCRIPTION
This pull request addresses problem #1460 by modifying the `updatedAt` value within the resume table. It now gets updated whenever a user deletes or uploads their resume photo. Additionally, the front-end also synchronizes with this change. Consequently, whenever a change in the image occurs, the `lastUpdatedAt` query parameter in the API is automatically adjusted, triggering the generation of a new PDF download.