### PR TITLE
Update break line description when page size is changed

### DIFF
--- a/client/components/build/RightSidebar/sections/Settings.tsx
+++ b/client/components/build/RightSidebar/sections/Settings.tsx
@@ -200,7 +200,13 @@ const Settings = () => {
           <ListItem>
             <ListItemText
               primary={t('builder.rightSidebar.sections.settings.page.break-line.primary')}
-              secondary={t('builder.rightSidebar.sections.settings.page.break-line.secondary')}
+              secondary= {
+                locale == 'en' ? (
+                pageConfig?.format == "Letter"
+                  ? t('builder.rightSidebar.sections.settings.page.break-line.secondary.letter')
+                  : t('builder.rightSidebar.sections.settings.page.break-line.secondary.A4')) 
+                : (t('builder.rightSidebar.sections.settings.page.break-line.secondary'))
+              }
             />
             <Switch color="secondary" checked={breakLine} onChange={() => dispatch(togglePageBreakLine())} />
           </ListItem>

--- a/client/public/locales/en/builder.json
+++ b/client/public/locales/en/builder.json
@@ -301,7 +301,10 @@
         "page": {
           "break-line": {
             "primary": "Break Line",
-            "secondary": "Show a line on all pages to mark the height of an A4 page"
+            "secondary": {
+              "letter": "Show a line on all pages to mark the height of a Letter page",
+              "A4": "Show a line on all pages to mark the height of an A4 page"
+            }
           },
           "format": {
             "primary": "Paper Size",


### PR DESCRIPTION
This pull request addresses the feature request mentioned in #1458 by improving the description of page breaks. Previously, page breaks were displayed correctly for both Letter size and A4 size, but this information was not reflected to the user when a different page format was selected. This update only fixes it for English language.

Changes in this pull request:
- Improved the description of page breaks to indicate the size of the page (Letter or A4).