### PR TITLE
Fix for #1431

### DIFF
--- a/client/services/resume.ts
+++ b/client/services/resume.ts
@@ -64,7 +64,7 @@ export const fetchResumeByIdentifier = async ({
 }: FetchResumeByIdentifierParams) => {
   if (!isBrowser) {
     const serverUrl = env('SERVER_URL');
-    const secretKey = options.secretKey;
+    const secretKey = encodeURIComponent(options.secretKey ?? '');
 
     return fetch(`${serverUrl}/resume/${username}/${slug}?secretKey=${secretKey}`).then((response) => response.json());
   }

--- a/server/src/printer/printer.service.ts
+++ b/server/src/printer/printer.service.ts
@@ -96,8 +96,9 @@ export class PrinterService implements OnModuleInit, OnModuleDestroy {
       const pdfDeletionTime = this.configService.get<number>('cache.pdfDeletionTime');
 
       const page = await this.browser.newPage();
-
-      await page.goto(`${url}/${username}/${slug}/printer?secretKey=${secretKey}`, { waitUntil: 'networkidle' });
+      await page.goto(`${url}/${username}/${slug}/printer?secretKey=${encodeURIComponent(secretKey)}`, {
+        waitUntil: 'networkidle',
+      });
       await page.waitForSelector('html.wf-active', { state: 'visible' });
 
       const pageFormat: PageConfig['format'] = await page.$$eval(


### PR DESCRIPTION
A partial fix for #1431, addresses some of the issues I found in #1431

I implemented url encoding for the secret key that `printer.service.ts` supplies to the Client when generating a pdf version of a resume.

I generated my secret key using `openssl rand -base64 32` which appends an = at the end.
Anyone else also using special characters would also encounter this issue.

The secret key not being encoded caused the Client to not accept it, therefore it refused to display a private resume which ultimately caused a 504 Gateway timeout error.


