### PR TITLE
[v4]docs: Add example of oauth callback url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,12 +61,12 @@ REDIS_URL=redis://default:password@localhost:6379
 CROWDIN_PROJECT_ID=
 CROWDIN_ACCESS_TOKEN=
 
-# GitHub (OAuth, Optional)
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
-GITHUB_CALLBACK_URL=
+# GitHub (OAuth, Optional) Uncomment to enable
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# GITHUB_CALLBACK_URL=http://localhost:5173/api/auth/github/callback
 
-# Google (OAuth, Optional)
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-GOOGLE_CALLBACK_URL=
+# Google (OAuth, Optional) Uncomment to enable
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+# GOOGLE_CALLBACK_URL=http://localhost:5173/api/auth/google/callback


### PR DESCRIPTION
Add examples for `GITHUB_CALLBACK_URL` and `GOOGLE_CALLBACK_URL`

Took me a while to figure them out.