### PR TITLE
Fixed broken link to LICENSE

### DIFF
--- a/apps/client/src/components/copyright.tsx
+++ b/apps/client/src/components/copyright.tsx
@@ -18,7 +18,7 @@ export const Copyright = ({ className }: Props) => (
         <a
           target="_blank"
           rel="noopener noreferrer nofollow"
-          href="https://github.com/AmruthPillai/Reactive-Resume/blob/main/LICENSE"
+          href="https://github.com/AmruthPillai/Reactive-Resume/blob/main/LICENSE.md"
         >
           MIT
         </a>


### PR DESCRIPTION
In Reactive-Resume/apps/client/src/components/copyright.tsx , there is a broken link to the projects readme. I changed it from https://github.com/AmruthPillai/Reactive-Resume/blob/main/LICENSE to https://github.com/AmruthPillai/Reactive-Resume/blob/main/LICENSE.md .

I found this issue using [link-inspector](https://github.com/justindhillon/link-inspector). If you found this PR useful, give the repo a star ⭐