### PR TITLE
Add option to skip storage bucket check & creation in storage service

### DIFF
--- a/apps/server/src/config/schema.ts
+++ b/apps/server/src/config/schema.ts
@@ -39,6 +39,10 @@ export const configSchema = z.object({
     .string()
     .default("false")
     .transform((s) => s !== "false" && s !== "0"),
+  STORAGE_SKIP_CREATE_BUCKET: z
+    .string()
+    .default("false")
+    .transform((s) => s !== "false" && s !== "0"),
 
   // Redis
   REDIS_URL: z.string().url().startsWith("redis://").optional(),

--- a/apps/server/src/storage/storage.service.ts
+++ b/apps/server/src/storage/storage.service.ts
@@ -44,6 +44,8 @@ export class StorageService implements OnModuleInit {
   private client: Client;
   private bucketName: string;
 
+  private skipCreateBucket: boolean;
+
   constructor(
     private readonly configService: ConfigService<Config>,
     private readonly minioService: MinioService,
@@ -55,6 +57,12 @@ export class StorageService implements OnModuleInit {
   async onModuleInit() {
     this.client = this.minioService.client;
     this.bucketName = this.configService.getOrThrow<string>("STORAGE_BUCKET");
+    this.skipCreateBucket = this.configService.getOrThrow<boolean>("STORAGE_SKIP_CREATE_BUCKET");
+
+    if (this.skipCreateBucket) {
+      this.logger.log("Skipping the creation of the storage bucket.");
+      return;
+    }
 
     try {
       // Create a storage bucket if it doesn't exist

--- a/apps/server/src/storage/storage.service.ts
+++ b/apps/server/src/storage/storage.service.ts
@@ -61,6 +61,10 @@ export class StorageService implements OnModuleInit {
 
     if (this.skipCreateBucket) {
       this.logger.log("Skipping the creation of the storage bucket.");
+      this.logger.warn("Make sure that the following paths are publicly accessible: ");
+      this.logger.warn("- /pictures/*");
+      this.logger.warn("- /previews/*");
+      this.logger.warn("- /resumes/*");
       return;
     }
 


### PR DESCRIPTION
I've implemented an `STORAGE_SKIP_CREATE_BUCKET` env variable to skip the process of checking if the storage bucket exists.

For self-hosting I wanted to provide very limited S3 credentials to the api. However, doing `this.client.bucketExists()` requires at least `s3:HeadBucket` permissions. This would be straightforward in AWS or Minio, but this becomes problematic when using a [Cloudflare R2](https://developers.cloudflare.com/r2/) bucket which doesn't provide granular permission controls. This also might be the case for other S3 compatible providers.
Furthermore, if the bucket is manually provisioned beforehand the check is redundant.

Not quite sure if `STORAGE_SKIP_CREATE_BUCKET` would be the correct name though, `STORAGE_SKIP_BUCKET_CHECK` could be better. I would appreciate feedback on the naming or other solutions altogether.