### PR TITLE
[Bugfix] Save Pending Keyword Input

### DIFF
--- a/apps/client/src/pages/builder/sidebars/left/dialogs/custom-section.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/dialogs/custom-section.tsx
@@ -15,6 +15,7 @@ import {
   RichInput,
 } from "@reactive-resume/ui";
 import { AnimatePresence, motion } from "framer-motion";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -36,6 +37,8 @@ export const CustomSectionDialog = () => {
     resolver: zodResolver(formSchema),
   });
 
+  const [pendingKeyword, setPendingKeyword] = useState("");
+
   if (!payload) return null;
 
   return (
@@ -43,6 +46,7 @@ export const CustomSectionDialog = () => {
       form={form}
       id={payload.id as DialogName}
       defaultValues={defaultCustomSection}
+      pendingKeyword={pendingKeyword}
     >
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <FormField
@@ -144,7 +148,7 @@ export const CustomSectionDialog = () => {
               <FormItem>
                 <FormLabel>{t`Keywords`}</FormLabel>
                 <FormControl>
-                  <BadgeInput {...field} />
+                  <BadgeInput {...field} setPendingKeyword={setPendingKeyword} />
                 </FormControl>
                 <FormDescription>
                   {t`You can add multiple keywords by separating them with a comma or pressing enter.`}

--- a/apps/client/src/pages/builder/sidebars/left/dialogs/interests.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/dialogs/interests.tsx
@@ -14,6 +14,7 @@ import {
   Input,
 } from "@reactive-resume/ui";
 import { AnimatePresence, motion } from "framer-motion";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -29,8 +30,15 @@ export const InterestsDialog = () => {
     resolver: zodResolver(formSchema),
   });
 
+  const [pendingKeyword, setPendingKeyword] = useState("");
+
   return (
-    <SectionDialog<FormValues> id="interests" form={form} defaultValues={defaultInterest}>
+    <SectionDialog<FormValues>
+      id="interests"
+      form={form}
+      defaultValues={defaultInterest}
+      pendingKeyword={pendingKeyword}
+    >
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <FormField
           name="name"
@@ -54,7 +62,7 @@ export const InterestsDialog = () => {
               <FormItem>
                 <FormLabel>{t`Keywords`}</FormLabel>
                 <FormControl>
-                  <BadgeInput {...field} />
+                  <BadgeInput {...field} setPendingKeyword={setPendingKeyword} />
                 </FormControl>
                 <FormDescription>
                   {t`You can add multiple keywords by separating them with a comma or pressing enter.`}

--- a/apps/client/src/pages/builder/sidebars/left/dialogs/projects.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/dialogs/projects.tsx
@@ -15,6 +15,7 @@ import {
   RichInput,
 } from "@reactive-resume/ui";
 import { AnimatePresence, motion } from "framer-motion";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -33,8 +34,15 @@ export const ProjectsDialog = () => {
     resolver: zodResolver(formSchema),
   });
 
+  const [pendingKeyword, setPendingKeyword] = useState("");
+
   return (
-    <SectionDialog<FormValues> id="projects" form={form} defaultValues={defaultProject}>
+    <SectionDialog<FormValues>
+      id="projects"
+      form={form}
+      defaultValues={defaultProject}
+      pendingKeyword={pendingKeyword}
+    >
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <FormField
           name="name"
@@ -121,7 +129,7 @@ export const ProjectsDialog = () => {
               <FormItem>
                 <FormLabel>{t`Keywords`}</FormLabel>
                 <FormControl>
-                  <BadgeInput {...field} />
+                  <BadgeInput {...field} setPendingKeyword={setPendingKeyword} />
                 </FormControl>
                 <FormDescription>
                   {t`You can add multiple keywords by separating them with a comma or pressing enter.`}

--- a/apps/client/src/pages/builder/sidebars/left/dialogs/skills.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/dialogs/skills.tsx
@@ -15,6 +15,7 @@ import {
   Slider,
 } from "@reactive-resume/ui";
 import { AnimatePresence, motion } from "framer-motion";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -30,8 +31,15 @@ export const SkillsDialog = () => {
     resolver: zodResolver(formSchema),
   });
 
+  const [pendingKeyword, setPendingKeyword] = useState("");
+
   return (
-    <SectionDialog<FormValues> id="skills" form={form} defaultValues={defaultSkill}>
+    <SectionDialog<FormValues>
+      id="skills"
+      form={form}
+      defaultValues={defaultSkill}
+      pendingKeyword={pendingKeyword}
+    >
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <FormField
           name="name"
@@ -98,7 +106,7 @@ export const SkillsDialog = () => {
               <FormItem>
                 <FormLabel>{t`Keywords`}</FormLabel>
                 <FormControl>
-                  <BadgeInput {...field} />
+                  <BadgeInput {...field} setPendingKeyword={setPendingKeyword} />
                 </FormControl>
                 <FormDescription>
                   {t`You can add multiple keywords by separating them with a comma or pressing enter.`}

--- a/apps/client/src/pages/builder/sidebars/left/sections/shared/section-dialog.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/sections/shared/section-dialog.tsx
@@ -31,6 +31,7 @@ type Props<T extends SectionItem> = {
   id: DialogName;
   form: UseFormReturn<T>;
   defaultValues: T;
+  pendingKeyword?: string;
   children: React.ReactNode;
 };
 
@@ -38,6 +39,7 @@ export const SectionDialog = <T extends SectionItem>({
   id,
   form,
   defaultValues,
+  pendingKeyword,
   children,
 }: Props<T>) => {
   const { isOpen, mode, close, payload } = useDialog<T>(id);
@@ -61,6 +63,9 @@ export const SectionDialog = <T extends SectionItem>({
     if (!section) return;
 
     if (isCreate || isDuplicate) {
+      if (pendingKeyword && values.keywords) {
+        values.keywords.push(pendingKeyword);
+      }
       setValue(
         `sections.${id}.items`,
         produce(section.items, (draft: T[]): void => {
@@ -71,6 +76,10 @@ export const SectionDialog = <T extends SectionItem>({
 
     if (isUpdate) {
       if (!payload.item?.id) return;
+
+      if (pendingKeyword && values.keywords) {
+        values.keywords.push(pendingKeyword);
+      }
 
       setValue(
         `sections.${id}.items`,

--- a/libs/ui/src/components/badge-input.tsx
+++ b/libs/ui/src/components/badge-input.tsx
@@ -1,14 +1,15 @@
-import { forwardRef, useCallback, useEffect, useState } from "react";
+import { Dispatch, forwardRef, SetStateAction, useCallback, useEffect, useState } from "react";
 
 import { Input, InputProps } from "./input";
 
 type BadgeInputProps = Omit<InputProps, "value" | "onChange"> & {
   value: string[];
   onChange: (value: string[]) => void;
+  setPendingKeyword?: Dispatch<SetStateAction<string>>;
 };
 
 export const BadgeInput = forwardRef<HTMLInputElement, BadgeInputProps>(
-  ({ value, onChange, ...props }, ref) => {
+  ({ value, onChange, setPendingKeyword, ...props }, ref) => {
     const [label, setLabel] = useState("");
 
     const processInput = useCallback(() => {
@@ -26,6 +27,10 @@ export const BadgeInput = forwardRef<HTMLInputElement, BadgeInputProps>(
         processInput();
       }
     }, [label, processInput]);
+
+    useEffect(() => {
+      if (setPendingKeyword) setPendingKeyword(label);
+    }, [label, setPendingKeyword]);
 
     const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
       if (event.key === "Enter") {


### PR DESCRIPTION
This PR is intended to try and address my suggestion here: https://github.com/AmruthPillai/Reactive-Resume/issues/1720

## Preamble

For each of the `dialog` components that allow a `Keyword` to be input, including:

* [custom-section](https://github.com/AmruthPillai/Reactive-Resume/blob/main/apps/client/src/pages/builder/sidebars/left/dialogs/custom-section.tsx)
* [interests](https://github.com/AmruthPillai/Reactive-Resume/blob/main/apps/client/src/pages/builder/sidebars/left/dialogs/interests.tsx)
* [projects](https://github.com/AmruthPillai/Reactive-Resume/blob/main/apps/client/src/pages/builder/sidebars/left/dialogs/projects.tsx)
* [skills](https://github.com/AmruthPillai/Reactive-Resume/blob/main/apps/client/src/pages/builder/sidebars/left/dialogs/skills.tsx)

If an input was typed by the user, but `Enter` was not pressed, their input will be lost.

### Disclaimer

If the suggested code changes are antithetical to the code style of this codebase, I am open to suggestions on how to better architect this suggestion, if it is a desired fix.

### Before PR Code Changes

![lost-keyword](https://github.com/AmruthPillai/Reactive-Resume/assets/16601729/b9944303-3d89-4daa-89ff-b55651aa74dd)

If the user went through the process of inputting a value into the `Keyword` field, I reckon they intend for it to be saved.

### After PR Code Changes

![keyword-not-lost](https://github.com/AmruthPillai/Reactive-Resume/assets/16601729/18f0b224-531d-4406-8d23-925408217d08)
