### PR TITLE
[Bugfix] Instantiate Link with inclusive set to false

### DIFF
--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -440,7 +440,7 @@ export const RichInput = forwardRef<Editor, RichInputProps>(
         Image,
         Underline,
         Highlight,
-        Link.configure({ openOnClick: false }),
+        Link.extend({ inclusive: false }).configure({ openOnClick: false }),
         TextAlign.configure({ types: ["heading", "paragraph"] }),
       ],
       editorProps: {


### PR DESCRIPTION
If the maintainers of Reactive Resume agree with the points raised in my issue here:

https://github.com/AmruthPillai/Reactive-Resume/issues/1726

This PR will configure [Tiptap](https://tiptap.dev/) to behave similar to other text editors when adding hyperlinks.

### Before

![reactive-resume](https://github.com/AmruthPillai/Reactive-Resume/assets/16601729/60d51cb0-010a-4609-af15-44e63c6e7048)

### After

![reactive-resume-change](https://github.com/AmruthPillai/Reactive-Resume/assets/16601729/8615eb4f-ff0d-43e6-83ed-5248c02b5d7f)

---

## ⚠️Possible Undesired Side Effect

I will note that this may negatively impact users who wish to add text _after_ adding a hyperlink to the editor:

### Before

![link-after-text before](https://github.com/AmruthPillai/Reactive-Resume/assets/16601729/4f73038f-2dad-4638-a538-a57cfc80029b)

### After

![link-after-text after](https://github.com/AmruthPillai/Reactive-Resume/assets/16601729/bf66c1bf-f327-493e-8e8e-8efc8558027e)

And as such, I will understand if the Reactive Resume maintainers see this as an overall negative change.