### PR TITLE
fix(#1750): fixed downloaded PDF have issue(s) with Typography options

### DIFF
--- a/apps/artboard/src/pages/artboard.tsx
+++ b/apps/artboard/src/pages/artboard.tsx
@@ -49,17 +49,10 @@ export const ArtboardPage = () => {
 
   // Typography Options
   useEffect(() => {
-    if (metadata.typography.hideIcons) {
-      document.querySelector("#root")!.classList.add("hide-icons");
-    } else {
-      document.querySelector("#root")!.classList.remove("hide-icons");
-    }
-
-    if (metadata.typography.underlineLinks) {
-      document.querySelector("#root")!.classList.add("underline-links");
-    } else {
-      document.querySelector("#root")!.classList.remove("underline-links");
-    }
+    document.querySelectorAll(`[data-page]`).forEach((el) => {
+      el.classList.toggle("hide-icons", metadata.typography.hideIcons);
+      el.classList.toggle("underline-links", metadata.typography.underlineLinks);
+    });
   }, [metadata]);
 
   return <Outlet />;

--- a/apps/artboard/src/styles/main.css
+++ b/apps/artboard/src/styles/main.css
@@ -12,11 +12,11 @@
   @apply antialiased;
 }
 
-#root.hide-icons .ph {
+[data-page].hide-icons .ph {
   @apply hidden;
 }
 
-#root.underline-links a {
+[data-page].underline-links a {
   @apply underline underline-offset-2;
 }
 


### PR DESCRIPTION
The typography option toggle class were added in the DOM #root but when the server is printing the resume, a child section of the DOM #root is cloned and inserted for pdf processing which misses out the Typography option toggle class in the parent DOM, resulting in the bug, Thus, the same class were added to each cloned DOM node (a node for each page DOM with [data-page] attribute). 