### PR TITLE
fix(gengar template): link of personal project was overflowing outside.

### DIFF
--- a/apps/artboard/src/styles/main.css
+++ b/apps/artboard/src/styles/main.css
@@ -21,5 +21,5 @@
 }
 
 .wysiwyg {
-  @apply prose max-w-none text-current prose-headings:mt-0 prose-headings:mb-2 prose-p:mt-0 prose-p:mb-2 prose-ul:mt-0 prose-ul:mb-2 prose-li:mt-0 prose-li:mb-2 prose-ol:mt-0 prose-ol:mb-2 prose-img:mt-0 prose-img:mb-2 prose-hr:mt-0 prose-hr:mb-2 prose-p:leading-normal prose-li:leading-normal;
+  @apply prose max-w-none text-current prose-headings:mt-0 prose-headings:mb-2 prose-p:mt-0 prose-p:mb-2 prose-ul:mt-0 prose-ul:mb-2 prose-li:mt-0 prose-li:mb-2 prose-ol:mt-0 prose-ol:mb-2 prose-img:mt-0 prose-img:mb-2 prose-hr:mt-0 prose-hr:mb-2 prose-p:leading-normal prose-li:leading-normal prose-a:break-all;
 }


### PR DESCRIPTION
In Gengar template the link for personal project was overflowing out of sidebar so added a little CSS to fix the issue 
please see images attached below to get more clarity on issue and fix

This PR is for issue #1764 

Issue:
![image](https://github.com/AmruthPillai/Reactive-Resume/assets/63059063/5f5b00ec-f708-4208-a73f-886805006a84)

Fix:
![image](https://github.com/AmruthPillai/Reactive-Resume/assets/63059063/b9bd12c0-fffc-4ec0-85e9-414cc79876b5)
