### PR TITLE
fix issue where PDF downloads fail on compose setup

### DIFF
--- a/tools/compose/simple.yml
+++ b/tools/compose/simple.yml
@@ -66,7 +66,7 @@ services:
 
       # -- URLs --
       PUBLIC_URL: http://localhost:3000
-      STORAGE_URL: http://localhost:9000
+      STORAGE_URL: http://localhost:9000/default
 
       # -- Printer (Chrome) --
       CHROME_TOKEN: chrome_token


### PR DESCRIPTION
Implements the fix proposed in #1754 

This PR updates the`STORAGE_URL` for the `simple.yaml` Compose setup that has no reverse proxy, by adding the bucket name as a URL suffix. Without it, PDF downloads don't work. 