### PR TITLE
Update minimum node to 18.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
   },
   "packageManager": "pnpm@8.11.0",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.17.0"
   },
   "prisma": {
     "schema": "tools/prisma/schema.prisma"


### PR DESCRIPTION
Running the app locally failed for me, as I was on 18.12.0 and per Sharp's documentation, https://sharp.pixelplumbing.com/install#prerequisites, it requires a minimum of 18.17.0+. Once I upgraded to the latest 18 (18.19.1) everything worked fine.