### PR TITLE
fix(auth): E-Mail capitalization issue

### DIFF
--- a/apps/client/src/pages/auth/forgot-password/page.tsx
+++ b/apps/client/src/pages/auth/forgot-password/page.tsx
@@ -35,6 +35,8 @@ export const ForgotPasswordPage = () => {
   });
 
   const onSubmit = async (data: FormValues) => {
+     //email convert to lowecase
+     data.email = data.email.toLowerCase();
     await forgotPassword(data);
 
     setSubmitted(true);

--- a/apps/client/src/pages/auth/login/page.tsx
+++ b/apps/client/src/pages/auth/login/page.tsx
@@ -41,6 +41,8 @@ export const LoginPage = () => {
   });
 
   const onSubmit = async (data: FormValues) => {
+    //email/username convert to lowecase
+    data.identifier = data.identifier.toLowerCase();
     try {
       await login(data);
     } catch (error) {

--- a/apps/client/src/pages/auth/register/page.tsx
+++ b/apps/client/src/pages/auth/register/page.tsx
@@ -51,6 +51,8 @@ export const RegisterPage = () => {
   });
 
   const onSubmit = async (data: FormValues) => {
+    //email convert to lowecase
+    data.email = data.email.toLowerCase();
     try {
       await register(data);
 

--- a/apps/server/src/auth/auth.service.ts
+++ b/apps/server/src/auth/auth.service.ts
@@ -46,6 +46,10 @@ export class AuthService {
     }
   }
 
+  private getLowercase(input : string) : string {
+    return input.toLowerCase();
+  }
+
   generateToken(grantType: "access" | "refresh" | "reset" | "verification", payload?: Payload) {
     switch (grantType) {
       case "access":
@@ -95,6 +99,7 @@ export class AuthService {
 
   async register(registerDto: RegisterDto) {
     const hashedPassword = await this.hash(registerDto.password);
+    registerDto.email = this.getLowercase(registerDto.email);
 
     try {
       const user = await this.userService.create({
@@ -122,6 +127,7 @@ export class AuthService {
   }
 
   async authenticate({ identifier, password }: LoginDto) {
+    identifier = this.getLowercase(identifier);
     try {
       const user = await this.userService.findOneByIdentifier(identifier);
 
@@ -143,6 +149,7 @@ export class AuthService {
 
   // Password Reset Flows
   async forgotPassword(email: string) {
+    email = this.getLowercase(email)
     const token = this.generateToken("reset");
 
     await this.userService.updateByEmail(email, {
@@ -158,6 +165,7 @@ export class AuthService {
 
   async updatePassword(email: string, password: string) {
     const hashedPassword = await this.hash(password);
+    email = this.getLowercase(email);
 
     await this.userService.updateByEmail(email, {
       secrets: { update: { password: hashedPassword } },


### PR DESCRIPTION
Fixes   #1740

This issue affects email in three places where user needs to enter the email - during registration ,login and forgot-password page.
To fix that we convert the email to lowercase before processing or sending to db.

-> During the user registration , the email entered by user is converted to lowercase and then stored in db.

->Similarly , in forgot-password , so again as we do a check in db if given email exists or not, so again make given user email to lowercase.

-> And in login user can enter email or username(already in lowercase) so if we convert user-input to lowercase it won't affect login using username.
