### PR TITLE
Fix(artboard): truncate link to stop overflow

### DIFF
--- a/apps/artboard/src/templates/azurill.tsx
+++ b/apps/artboard/src/templates/azurill.tsx
@@ -131,7 +131,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/bronzor.tsx
+++ b/apps/artboard/src/templates/bronzor.tsx
@@ -122,7 +122,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/chikorita.tsx
+++ b/apps/artboard/src/templates/chikorita.tsx
@@ -125,7 +125,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/ditto.tsx
+++ b/apps/artboard/src/templates/ditto.tsx
@@ -142,7 +142,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/gengar.tsx
+++ b/apps/artboard/src/templates/gengar.tsx
@@ -120,7 +120,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/glalie.tsx
+++ b/apps/artboard/src/templates/glalie.tsx
@@ -128,7 +128,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/kakuna.tsx
+++ b/apps/artboard/src/templates/kakuna.tsx
@@ -148,7 +148,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/leafish.tsx
+++ b/apps/artboard/src/templates/leafish.tsx
@@ -145,7 +145,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/nosepass.tsx
+++ b/apps/artboard/src/templates/nosepass.tsx
@@ -124,7 +124,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/onyx.tsx
+++ b/apps/artboard/src/templates/onyx.tsx
@@ -151,7 +151,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/pikachu.tsx
+++ b/apps/artboard/src/templates/pikachu.tsx
@@ -151,7 +151,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>

--- a/apps/artboard/src/templates/rhyhorn.tsx
+++ b/apps/artboard/src/templates/rhyhorn.tsx
@@ -123,7 +123,7 @@ const Link = ({ url, icon, label, className }: LinkProps) => {
         href={url.href}
         target="_blank"
         rel="noreferrer noopener nofollow"
-        className={cn("inline-block", className)}
+        className={cn("inline-block max-w-64 truncate", className)}
       >
         {label || url.label || url.href}
       </a>


### PR DESCRIPTION
Fixes #1814 

The issue only mentions link overflow in the certificates section but this can happen to any link in the resume. Due to the current component structure, we can fix it only by truncating all links in a resume template.

> [!WARNING]
> This will break resumes depending on link URL/label word wrap for layout.

> This is just a simple fix. There are so many questions I have in my mind. Should we line-clamp instead? If so, how many lines? Should we use container query units instead of the arbitrary 256px max-width? But all of these can break some existing resumes, so do we just let the links overflow and suggest using labels and link shorteners instead?