### PR TITLE
Fix storageurl in dev

### DIFF
--- a/apps/server/src/printer/printer.service.ts
+++ b/apps/server/src/printer/printer.service.ts
@@ -192,6 +192,13 @@ export class PrinterService {
       await page.close();
       browser.disconnect();
 
+      const isDevelopment = this.configService.getOrThrow<string>("NODE_ENV") === "development";
+      const storagePort = this.configService.get<string>("STORAGE_PORT");
+
+      if (isDevelopment && storagePort) {
+        return resumeUrl.replace(":9000", `:${storagePort}`); // replace the port from the resumeurl with STORAGE_PORT
+      }
+
       return resumeUrl;
     } catch (error) {
       console.trace(error);


### PR DESCRIPTION
Probably fixes https://github.com/AmruthPillai/Reactive-Resume/issues/1683

Problem for me was, that the "download pdf" button redirected me to the right url, but the wrong port after changing the storage port in the ``.env`` file