### PR TITLE
feat(server): Support for SMTP-over-TLS

### DIFF
--- a/apps/server/src/config/schema.ts
+++ b/apps/server/src/config/schema.ts
@@ -26,7 +26,7 @@ export const configSchema = z.object({
 
   // Mail Server
   MAIL_FROM: z.string().includes("@").optional().default("noreply@localhost"),
-  SMTP_URL: z.string().url().startsWith("smtp://").optional(),
+  SMTP_URL: z.string().url().refine(url => url.startsWith("smtp://") || url.startsWith("smtps://")).optional(),
 
   // Storage
   STORAGE_ENDPOINT: z.string(),


### PR DESCRIPTION
As per the code restriction specified in the configuration schema,  the `SMTP_URL` was required to start with `smtp://`.

https://github.com/AmruthPillai/Reactive-Resume/blob/fe77b14807873efb12af535fd119b2cbe17d87e9/apps/server/src/config/schema.ts#L29

However, my email service provider utilizes SSL on port 465. Despite attempting various configurations based on the nodemailer documentation available [here](https://nodemailer.com/smtp/), I encountered difficulties in sending emails through the SMTP service using the following settings:

```
smtp://username:password@smtp.example.com:465
smtp://username:password@smtp.example.com:465/?secure=true
smtp://username:password@smtp.example.com:587/?requireTLS=true
```

Upon further investigation, I found that nodemailer supports the `smtps://` protocol. Consequently, I have updated the validation in zod to permit the `SMTP_URL` configuration to start with `smtps://`. This adjustment now enables me to utilize the following configuration for sending emails via SMTP of my email service provider:

```
smtps://username:password@smtp.example.com:465
```

So I made this pull request, hoping to help people who have the same problem as me.