### PR TITLE
Fix: generate PDF name from title instead of id

### DIFF
--- a/apps/server/src/printer/printer.service.ts
+++ b/apps/server/src/printer/printer.service.ts
@@ -187,7 +187,7 @@ export class PrinterService {
         resume.userId,
         "resumes",
         buffer,
-        resume.id,
+        resume.title,
       );
 
       // Close all the pages and disconnect from the browser


### PR DESCRIPTION
Fixes #836 

This changes the generated PDF name from the ID to the title (e.g. Resume V34.pdf).