### PR TITLE
Bug Fix #1847 - Fix Sidebar Height in Chikorita template

### DIFF
--- a/apps/artboard/src/templates/chikorita.tsx
+++ b/apps/artboard/src/templates/chikorita.tsx
@@ -512,7 +512,7 @@ export const Chikorita = ({ columns, isFirstPage = false }: TemplateProps) => {
   const [main, sidebar] = columns;
 
   return (
-    <div className="grid h-full grid-cols-3">
+    <div className="grid min-h-[inherit] grid-cols-3">
       <div className="main p-custom group col-span-2 space-y-4">
         {isFirstPage && <Header />}
 


### PR DESCRIPTION
Fix the Sidebar is not stretching to the full height in the Chikorita template

I added a small bug fix to get the hang of the project.

I am inspired by your work on this and am looking forward to collaborating more.