### PR TITLE
fix(docker): add environment variable for puppeteer to launch with `ignoreHTTPSerrors` flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,8 @@ REFRESH_TOKEN_SECRET=refresh_token_secret
 CHROME_PORT=8080
 CHROME_TOKEN=chrome_token
 CHROME_URL=ws://localhost:8080
+# Launch puppeteer with flag to ignore https errors
+# CHROME_IGNORE_HTTPS_ERRORS=true
 
 # Mail Server (for e-mails)
 # For testing, you can use https://ethereal.email/create

--- a/apps/server/src/config/schema.ts
+++ b/apps/server/src/config/schema.ts
@@ -20,6 +20,10 @@ export const configSchema = z.object({
   // Browser
   CHROME_TOKEN: z.string(),
   CHROME_URL: z.string().url(),
+  CHROME_IGNORE_HTTPS_ERRORS: z
+    .string()
+    .default("false")
+    .transform((s) => s !== "false" && s !== "0"),
 
   // Mail Server
   MAIL_FROM: z.string().includes("@").optional().default("noreply@localhost"),

--- a/apps/server/src/printer/printer.service.ts
+++ b/apps/server/src/printer/printer.service.ts
@@ -17,6 +17,8 @@ export class PrinterService {
 
   private readonly browserURL: string;
 
+  private readonly ignoreHTTPSErrors: boolean;
+
   constructor(
     private readonly configService: ConfigService<Config>,
     private readonly storageService: StorageService,
@@ -26,11 +28,15 @@ export class PrinterService {
     const chromeToken = this.configService.getOrThrow<string>("CHROME_TOKEN");
 
     this.browserURL = `${chromeUrl}?token=${chromeToken}`;
+    this.ignoreHTTPSErrors = this.configService.getOrThrow<boolean>("CHROME_IGNORE_HTTPS_ERRORS");
   }
 
   private async getBrowser() {
     try {
-      return await connect({ browserWSEndpoint: this.browserURL });
+      return await connect({
+        browserWSEndpoint: this.browserURL,
+        ignoreHTTPSErrors: this.ignoreHTTPSErrors,
+      });
     } catch (error) {
       throw new InternalServerErrorException(
         ErrorMessage.InvalidBrowserConnection,


### PR DESCRIPTION
Fixes #1897 

---

Add environment variable `CHROME_IGNORE_HTTPS_ERRORS` for puppeteer to launch with flag `ignoreHTTPSerrors` (defaults to `false` for keep existing behavior).