### PR TITLE
Update readme (add self-host the application in less than 30 seconds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Start creating your standout resume with Reactive Resume today!
 - GitHub/Google OAuth (for quickly authenticating users)
 - LinguiJS and Crowdin (for translation management and localization)
 
+## 🌐 Self Host
+
+self-host the application in less than 30 seconds
+
+[![](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://cloud.sealos.io/?openapp=system-template%3FtemplateName%3DReactive-Resume)
+
 ## Star History
 
 <a href="https://star-history.com/#AmruthPillai/Reactive-Resume&Date">


### PR DESCRIPTION
hi, I've added Reactive-Resume to the [Sealos](https://github.com/labring/sealos) app store. Now, you can deploy Reactive-Resume by clicking on "deploy application," which is very convenient. Just click on the shortcut icon to view the Reactive-Resume you just deployed.

<img width="1526" alt="image" src="https://github.com/AmruthPillai/Reactive-Resume/assets/43649186/86a57cf1-60f4-4f48-823c-d160da52fc25">

<img width="1198" alt="image" src="https://github.com/AmruthPillai/Reactive-Resume/assets/43649186/d489598e-3c88-44fc-bbaa-4acd9173f59f">
