### PR TITLE
fix(edit profile picture): fix the page crash happening when clicking on circular border radius

### DIFF
--- a/apps/client/src/pages/builder/sidebars/left/sections/picture/options.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/sections/picture/options.tsx
@@ -61,8 +61,9 @@ export const PictureOptions = () => {
     return borderRadiusToStringMap[radius];
   }, [picture.borderRadius]);
 
-  const onBorderRadiusChange = (value: BorderRadius) => {
-    setValue("basics.picture.borderRadius", stringToBorderRadiusMap[value]);
+  const onBorderRadiusChange = (value: string) => {
+    if (!value) return;
+    setValue("basics.picture.borderRadius", stringToBorderRadiusMap[value as BorderRadius]);
   };
 
   return (


### PR DESCRIPTION
Fixes  #1953 

### Issue
In profile picture edit section, when a user selects a circle border radius, clicks on the numeric input for the border radius, and then clicks outside, the `onBorderRadiusChange` function is triggered and receives an empty string (`""`) as the `value`.

### Fix
So updated the code to check for empty string as being done in `onAspectRatioChange` function.