### PR TITLE
fix(printer): fix incorrect artboard port in dev mode

### DIFF
--- a/apps/server/src/printer/printer.service.ts
+++ b/apps/server/src/printer/printer.service.ts
@@ -105,6 +105,7 @@ export class PrinterService {
         // Switch client URL from `localhost` to `host.docker.internal` in development
         // This is required because the browser is running in a container and the client is running on the host machine.
         url = url.replace("localhost", "host.docker.internal");
+        url = url.replace("3000", "6173");
 
         await page.setRequestInterception(true);
 


### PR DESCRIPTION
When the printer service generates the resume, it reads and replaces `PUBLIC_URL` to retrieve the URL of the artboard.

However, when `PUBLIC_URL` is set to its default value, which is `http://localhost:3000`, the URL of the artboard becomes `http://host.docker.internal:3000`. The port does not match the default port of the artboard, which is `6173`, leading to an error in generating the resume.

```ts
      const publicUrl = this.configService.getOrThrow<string>("PUBLIC_URL");

      if ([publicUrl, storageUrl].some((url) => url.includes("localhost"))) {
        // Switch client URL from `localhost` to `host.docker.internal` in development
        // This is required because the browser is running in a container and the client is running on the host machine.
        url = url.replace("localhost", "host.docker.internal");
```