### PR TITLE
Fix(client): Fix Unintentional Form Submission on Rich-input Toolbar Actions

### DIFF
--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -85,7 +85,12 @@ const InsertImageForm = ({ onInsert }: InsertImageProps) => {
 
   return (
     <Form {...form}>
-      <form className="space-y-3" onSubmit={form.handleSubmit(onSubmit)}>
+      <form className="space-y-3" 
+      onSubmit={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        form.handleSubmit(onSubmit)();
+      }}>
         <p className="prose prose-sm prose-zinc dark:prose-invert">
           Insert an image from an external URL and use it on your resume.
         </p>
@@ -384,6 +389,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           size="sm"
           variant="ghost"
           className="px-2"
+          type="button"
           disabled={!editor.can().chain().focus().setHardBreak().run()}
           onClick={() => editor.chain().focus().setHardBreak().run()}
         >
@@ -396,6 +402,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           size="sm"
           variant="ghost"
           className="px-2"
+          type="button"
           disabled={!editor.can().chain().focus().setHorizontalRule().run()}
           onClick={() => editor.chain().focus().setHorizontalRule().run()}
         >


### PR DESCRIPTION
**Description**
This pull request addresses a bug where the "Insert Image" button and certain toolbar actions (Insert Horizontal Rule and Insert Break Line) would unintentionally trigger the submission of section_dialog

**Fixed Problem**
- Issue: The "Insert Image" button would unintentionally cause the section_dialog to submit, closing the form. (issue #1996)
- Issue: The "Insert Horizontal Rule" and "Insert Break Line" buttons in the editor toolbar would trigger the submission of section_dialog, make these buttons unusable.

**Changes Made**
1. Prevent Default Form Submission for Insert Image
Updated the InsertImageForm component to use e.stopPropagation() and e.preventDefault() in the onSubmit handler. This prevents the image insertion from causing the parent form to submit.

2. Set type="button" for Toolbar Buttons:
Ensured the "Insert Horizontal Rule" and "Insert Break Line" buttons in the toolbar have type="button" to prevent them from submitting the parent form.

**Testing**
- Clicking the "Insert Image" button inserts the image without submitting the section_dialog form. 
- Using the "Insert Horizontal Rule" and "Insert Break Line" buttons performs the respective actions without submitting the section_dialog form

**Related Issues**
Fixes #1996

This is my first contribution to an open-source project. Please let me know if there are any issues or areas for improvement. Thank you!