### PR TITLE
fix(docs): Add missing themes to bug-report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -76,7 +76,10 @@ body:
         - Bronzor
         - Chikorita
         - Ditto
+        - Gengar
+        - Glalie
         - Kakuna
+        - Leafish
         - Nosepass
         - Onyx
         - Pikachu


### PR DESCRIPTION
A few themes were missing when I filled out a bug report.