### PR TITLE
feat(toggle-pan): Add toggle to switch between "Scroll to Pan" and "Scroll to Zoom"

### DIFF
--- a/apps/artboard/src/pages/builder.tsx
+++ b/apps/artboard/src/pages/builder.tsx
@@ -1,7 +1,7 @@
 import { SectionKey } from "@reactive-resume/schema";
 import { pageSizeMap, Template } from "@reactive-resume/utils";
 import { AnimatePresence, motion } from "framer-motion";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ReactZoomPanPinchRef, TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
 
 import { MM_TO_PX, Page } from "../components/page";
@@ -13,6 +13,8 @@ export const BuilderLayout = () => {
   const format = useArtboardStore((state) => state.resume.metadata.page.format);
   const layout = useArtboardStore((state) => state.resume.metadata.layout);
   const template = useArtboardStore((state) => state.resume.metadata.template as Template);
+
+  const [wheelPanning, setWheelPanning] = useState(true);
 
   const Template = useMemo(() => getTemplate(template), [template]);
 
@@ -26,6 +28,9 @@ export const BuilderLayout = () => {
       if (event.data.type === "RESET_VIEW") {
         transformRef.current?.resetTransform(0);
         setTimeout(() => transformRef.current?.centerView(0.8, 0), 10);
+      }
+      if (event.data.type === "TOGGLE_PAN_MODE") {
+        setWheelPanning(event.data.panMode);
       }
     };
 
@@ -44,6 +49,12 @@ export const BuilderLayout = () => {
       minScale={0.4}
       initialScale={0.8}
       limitToBounds={false}
+      panning={{
+        wheelPanning: wheelPanning,
+      }}
+      wheel={{
+        wheelDisabled: wheelPanning,
+      }}
     >
       <TransformComponent
         wrapperClass="!w-screen !h-screen"

--- a/apps/client/src/pages/builder/_components/toolbar.tsx
+++ b/apps/client/src/pages/builder/_components/toolbar.tsx
@@ -2,6 +2,7 @@ import { t } from "@lingui/macro";
 import {
   ArrowClockwise,
   ArrowCounterClockwise,
+  ArrowsOutCardinal,
   CircleNotch,
   ClockClockwise,
   CubeFocus,
@@ -9,6 +10,7 @@ import {
   Hash,
   LineSegment,
   LinkSimple,
+  MagnifyingGlass,
   MagnifyingGlassMinus,
   MagnifyingGlassPlus,
 } from "@phosphor-icons/react";
@@ -19,6 +21,7 @@ import { useToast } from "@/client/hooks/use-toast";
 import { usePrintResume } from "@/client/services/resume";
 import { useBuilderStore } from "@/client/stores/builder";
 import { useResumeStore, useTemporalResumeStore } from "@/client/stores/resume";
+import { useState } from "react";
 
 const openInNewTab = (url: string) => {
   const win = window.open(url, "_blank");
@@ -31,6 +34,7 @@ export const BuilderToolbar = () => {
   const undo = useTemporalResumeStore((state) => state.undo);
   const redo = useTemporalResumeStore((state) => state.redo);
   const frameRef = useBuilderStore((state) => state.frame.ref);
+  const [panMode, setPanMode] = useState<boolean>(true);
 
   const id = useResumeStore((state) => state.resume.id);
   const isPublic = useResumeStore((state) => state.resume.visibility === "public");
@@ -59,6 +63,10 @@ export const BuilderToolbar = () => {
   const onZoomOut = () => frameRef?.contentWindow?.postMessage({ type: "ZOOM_OUT" }, "*");
   const onResetView = () => frameRef?.contentWindow?.postMessage({ type: "RESET_VIEW" }, "*");
   const onCenterView = () => frameRef?.contentWindow?.postMessage({ type: "CENTER_VIEW" }, "*");
+  const onTogglePanMode = () => {
+    setPanMode(!panMode); // local button state
+    frameRef?.contentWindow?.postMessage({ type: "TOGGLE_PAN_MODE", panMode: !panMode }, "*"); // toggle artboard state
+  };
 
   return (
     <motion.div className="fixed inset-x-0 bottom-0 mx-auto hidden py-6 text-center md:block">
@@ -87,6 +95,20 @@ export const BuilderToolbar = () => {
           >
             <ArrowClockwise />
           </Button>
+        </Tooltip>
+
+        <Separator orientation="vertical" className="h-9" />
+
+        <Tooltip
+          content={
+            panMode
+              ? t`Scroll to Pan (Click to switch to Zoom)`
+              : t`Scroll to Zoom (Click to switch to Pan)`
+          }
+        >
+          <Toggle className="rounded-none" pressed={panMode} onPressedChange={onTogglePanMode}>
+            {panMode ? <ArrowsOutCardinal /> : <MagnifyingGlass />}
+          </Toggle>
         </Tooltip>
 
         <Separator orientation="vertical" className="h-9" />

--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
     "react-parallax-tilt": "^1.7.227",
     "react-resizable-panels": "^2.0.19",
     "react-router-dom": "6.23.1",
-    "react-zoom-pan-pinch": "^3.4.4",
+    "react-zoom-pan-pinch": "^3.6.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sharp": "^0.33.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,8 +363,8 @@ importers:
         specifier: 6.23.1
         version: 6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-zoom-pan-pinch:
-        specifier: ^3.4.4
-        version: 3.4.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^3.6.1
+        version: 3.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -9068,8 +9068,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-zoom-pan-pinch@3.4.4:
-    resolution: {integrity: sha512-lGTu7D9lQpYEQ6sH+NSlLA7gicgKRW8j+D/4HO1AbSV2POvKRFzdWQ8eI0r3xmOsl4dYQcY+teV6MhULeg1xBw==}
+  react-zoom-pan-pinch@3.6.1:
+    resolution: {integrity: sha512-SdPqdk7QDSV7u/WulkFOi+cnza8rEZ0XX4ZpeH7vx3UZEg7DoyuAy3MCmm+BWv/idPQL2Oe73VoC0EhfCN+sZQ==}
     engines: {node: '>=8', npm: '>=5'}
     peerDependencies:
       react: '*'
@@ -14616,7 +14616,7 @@ snapshots:
 
   '@testing-library/dom@10.1.0':
     dependencies:
-      '@babel/code-frame': 7.24.6
+      '@babel/code-frame': 7.24.7
       '@babel/runtime': 7.24.5
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -21160,7 +21160,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
-  react-zoom-pan-pinch@3.4.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-zoom-pan-pinch@3.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
### Motivation:
To improve UX with trackpads.

### Explanation:
The current trackpad behaviour does not feel natural. Usually when scrolling on a trackpad using 2 fingers, the page or content would Pan; whereas Zooming is achieved by pinching 2 fingers.

### Considerations:
On a mouse, it is arguably more user-friendly to Scroll to Zoom. Therefore, I have added a toggle button to switch between behaviours.

I opted for the default behaviour to be Scroll to Pan because there are already various methods to control the zoom levels, and I believe that panning actions are more common than zooming. For context, the default Double-click behaviour is set to Zoom In; and there are the Zoom In & Out buttons on the toolbar to control the zoom levels. Open to discussion / change.

### Changes:
- Add a new button to the Toolbar to handle switching between "Scroll to Pan" and "Scroll to Zoom"
- Modify wheel behaviour to pan by default for a more natural behaviour with trackpads (https://github.com/BetterTyped/react-zoom-pan-pinch/pull/447)
- Bump react-zoom-pan-pinch version to `3.6.1` from `3.4.4`

### Screenshot:
New button
<img width="446" alt="image" src="https://github.com/user-attachments/assets/5ba9953f-ef29-4b13-bcb6-ab4b30fc7c6b">
