### PR TITLE
set endOfLine to auto to support the codebase also on windows machines

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,14 @@
               }
             ]
           }
+        ],
+
+        // prettier
+        "prettier/prettier": [
+          "warn",
+          {
+            "endOfLine": "auto"
+          }
         ]
       }
     },

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "printWidth": 100
+  "printWidth": 100,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
I'm using a windows machine and I needed to apply these changes in order to be able to work on the repo locally.
Setting them in the repo will support local development on windows machines, as well.