### PR TITLE
feat: add preview in dashboard using iframe

### DIFF
--- a/apps/client/src/pages/dashboard/resumes/_layouts/grid/_components/resume-card.tsx
+++ b/apps/client/src/pages/dashboard/resumes/_layouts/grid/_components/resume-card.tsx
@@ -20,6 +20,7 @@ import dayjs from "dayjs";
 import { AnimatePresence, motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 
+import { useResumePreview } from "@/client/services/resume/preview";
 import { useDialog } from "@/client/stores/dialog";
 
 import { BaseCard } from "./base-card";
@@ -29,6 +30,8 @@ type Props = {
 };
 
 export const ResumeCard = ({ resume }: Props) => {
+  const frameRef = useResumePreview(resume.data);
+
   const navigate = useNavigate();
   const { open } = useDialog<ResumeDto>("resume");
   const { open: lockOpen } = useDialog<ResumeDto>("lock");
@@ -59,6 +62,19 @@ export const ResumeCard = ({ resume }: Props) => {
     <ContextMenu>
       <ContextMenuTrigger>
         <BaseCard className="space-y-0" onClick={onOpen}>
+          <AnimatePresence presenceAffectsLayout>
+            <iframe
+              ref={frameRef}
+              title={resume.title}
+              src="/artboard/preview"
+              style={{
+                height: "100%",
+                width: "100%",
+                zoom: 0.35,
+              }}
+            />
+          </AnimatePresence>
+
           <AnimatePresence>
             {resume.locked && (
               <motion.div
@@ -77,6 +93,7 @@ export const ResumeCard = ({ resume }: Props) => {
               "absolute inset-x-0 bottom-0 z-10 flex flex-col justify-end space-y-0.5 p-4 pt-12",
               "bg-gradient-to-t from-background/80 to-transparent",
             )}
+            style={{ height: "100%" }}
           >
             <h4 className="line-clamp-2 font-medium">{resume.title}</h4>
             <p className="line-clamp-1 text-xs opacity-75">{t`Last updated ${lastUpdated}`}</p>

--- a/apps/client/src/pages/dashboard/resumes/_layouts/grid/_components/resume-card.tsx
+++ b/apps/client/src/pages/dashboard/resumes/_layouts/grid/_components/resume-card.tsx
@@ -30,7 +30,14 @@ type Props = {
 };
 
 export const ResumeCard = ({ resume }: Props) => {
-  const frameRef = useResumePreview(resume.data);
+  // Set the resume information with only the first page
+  const frameRef = useResumePreview({
+    ...resume.data,
+    metadata: {
+      ...resume.data.metadata,
+      layout: [resume.data.metadata.layout[0]],
+    },
+  });
 
   const navigate = useNavigate();
   const { open } = useDialog<ResumeDto>("resume");
@@ -67,6 +74,7 @@ export const ResumeCard = ({ resume }: Props) => {
               ref={frameRef}
               title={resume.title}
               src="/artboard/preview"
+              scrolling="no"
               style={{
                 height: "100%",
                 width: "100%",


### PR DESCRIPTION
Changes:
- ♻️ the `useResumePreview` hook is currently unused, because huge loading times
- 🚀 I refactored it to use the same functionality as [here](https://github.com/AmruthPillai/Reactive-Resume/blob/1bed63a4af591182295eca311e41dac34a283b8c/apps/client/src/pages/public/page.tsx#L81-L86)

Resume/blob/main/apps/client/src/pages/public/page.tsx#L81-L86)
  - using `iframe` to render it and set resume in the `useEffect((), [frameRef])`

💪 It is fast and from the exploratory tests I've done locally, we can rely on it, as well.

![image](https://github.com/user-attachments/assets/6f8a73d3-650f-4e1d-b455-ca0406efc127)

> Discussion in issue: https://github.com/AmruthPillai/Reactive-Resume/issues/2005#issuecomment-2319381861