### PR TITLE
bugfix: Fixed clipping issue with cards on dashboard page

### DIFF
--- a/apps/client/src/pages/dashboard/resumes/page.tsx
+++ b/apps/client/src/pages/dashboard/resumes/page.tsx
@@ -49,7 +49,10 @@ export const ResumesPage = () => {
           </TabsList>
         </div>
 
-        <ScrollArea className="h-[calc(100vh-140px)] lg:h-[calc(100vh-88px)]">
+        <ScrollArea
+          className="h-[calc(100vh-140px)] overflow-visible lg:h-[calc(100vh-88px)]"
+          allowOverflow={true}
+        >
           <TabsContent value="grid">
             <GridView />
           </TabsContent>

--- a/libs/ui/src/components/scroll-area.tsx
+++ b/libs/ui/src/components/scroll-area.tsx
@@ -7,6 +7,7 @@ export const ScrollArea = forwardRef<
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
     hideScrollbar?: boolean;
     orientation?: "vertical" | "horizontal";
+    allowOverflow?: boolean;
   }
 >(
   (
@@ -14,6 +15,7 @@ export const ScrollArea = forwardRef<
       type = "scroll",
       orientation = "vertical",
       hideScrollbar = false,
+      allowOverflow = false,
       className,
       children,
       ...props
@@ -26,7 +28,10 @@ export const ScrollArea = forwardRef<
       className={cn("relative overflow-hidden", className)}
       {...props}
     >
-      <ScrollAreaPrimitive.Viewport className="size-full rounded-[inherit]">
+      <ScrollAreaPrimitive.Viewport
+        className="size-full rounded-[inherit]"
+        style={allowOverflow ? { overflowX: "visible", overflowY: "visible" } : {}}
+      >
         {children}
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar orientation={orientation} className={cn(hideScrollbar && "opacity-0")} />


### PR DESCRIPTION
[Issue](https://github.com/AmruthPillai/Reactive-Resume/issues/2034)

Fixed Card clipping issue on Dashboard page in grid view. Where the sides of the card where being clipped once the hover animation is triggered. 

**BEFORE**

desktop
![image](https://github.com/user-attachments/assets/bf0c59e4-27d9-47e1-a73a-873041b34556)

Mobile
![image](https://github.com/user-attachments/assets/17227488-b3a9-4948-bee7-f7ae9793a126)


**AFTER**
Desktop
![image](https://github.com/user-attachments/assets/5e4cbe25-1855-4c7a-9a6f-3d4c49b142c5)

Mobile
![image](https://github.com/user-attachments/assets/89b38249-a4ca-415d-8e74-614cb3cf8695)

**Explanation:**
By default ScrollAreaPrimitive.Root sets the class name to 'overflow-hidden'. Then passing a classname with 'overflow-visible' to the scroll-area UI component is not enough. "ScrollAreaPrimitiv.Viewport" applies some extra default styles if the props type='scroll'. I have added a boolean prop type that allows us to disable this and allow bot overflowX and overflowY to be visible in the scenarios where we need it. 

Let me know if you need more information. 



