### PR TITLE
fix(templates): fix Summary text in the Awards section to be the same…

### DIFF
--- a/apps/artboard/src/templates/chikorita.tsx
+++ b/apps/artboard/src/templates/chikorita.tsx
@@ -207,7 +207,7 @@ const Section = <T,>({
                 </div>
 
                 {summary !== undefined && !isEmptyString(summary) && (
-                  <div dangerouslySetInnerHTML={{ __html: summary }} className="wysiwyg" />
+                  <div dangerouslySetInnerHTML={{ __html: summary }}/>
                 )}
 
                 {level !== undefined && level > 0 && <Rating level={level} />}


### PR DESCRIPTION
fix issue #2047
[Bug] Awards Summary Text Color is different than Title/Other fields 
after fixing image
![Screenshot 2024-09-14 025309](https://github.com/user-attachments/assets/db63967a-f47f-42b1-b690-a725fe17895e)
