### PR TITLE
fix(templates): Add right border after website in Rhyhorn

### DIFF
--- a/apps/artboard/src/templates/rhyhorn.tsx
+++ b/apps/artboard/src/templates/rhyhorn.tsx
@@ -124,7 +124,7 @@ const Link = ({ url, icon, iconOnRight, label, className }: LinkProps) => {
   if (!isUrl(url.href)) return null;
 
   return (
-    <div className="flex items-center gap-x-1.5">
+    <div className="flex items-center gap-x-1.5 border-r pr-2 last:border-r-0 last:pr-0">
       {!iconOnRight && (icon ?? <i className="ph ph-bold ph-link text-primary" />)}
       <a
         href={url.href}


### PR DESCRIPTION
Closes #2090 
Added right border to website if custom fields are used

Before:
![Screenshot 2024-11-05 at 5 10 21 PM](https://github.com/user-attachments/assets/f179d101-fd06-4951-91d2-b4b069f3ccd3)
After:
![Screenshot 2024-11-05 at 5 11 14 PM](https://github.com/user-attachments/assets/f59beab5-5838-4be6-bca5-14d85dd7b987)
