### PR TITLE
fixed App crashes when trying to change radius on avatar

### DIFF
--- a/apps/client/src/pages/builder/sidebars/left/sections/picture/options.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/sections/picture/options.tsx
@@ -57,7 +57,7 @@ export const PictureOptions = () => {
   };
 
   const borderRadius = useMemo(() => {
-    const radius = picture.borderRadius.toString() as keyof typeof borderRadiusToStringMap;
+    const radius = picture.borderRadius?.toString() as keyof typeof borderRadiusToStringMap;
     return borderRadiusToStringMap[radius];
   }, [picture.borderRadius]);
 


### PR DESCRIPTION
fixed #2109
The value is not present if you click on the same element so the function ".toString()" throws an error as the values are not present.
The simple solution is to check whether the value is present or not and the function should be called only when the value is present.