### PR TITLE
fix(builder): skills and languages form error from level data type

### DIFF
--- a/apps/client/src/pages/builder/sidebars/left/dialogs/languages.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/dialogs/languages.tsx
@@ -59,7 +59,7 @@ export const LanguagesDialog = () => {
         <FormField
           name="level"
           control={form.control}
-          render={({ field }) => (
+          render={({ field: { onChange, ...field } }) => (
             <FormItem className="sm:col-span-2">
               <FormLabel>{t`Level`}</FormLabel>
               <FormControl className="py-2">
@@ -70,7 +70,7 @@ export const LanguagesDialog = () => {
                     max={5}
                     value={[field.value]}
                     onValueChange={(value) => {
-                      field.onChange(value[0]);
+                      onChange(value[0]);
                     }}
                   />
 

--- a/apps/client/src/pages/builder/sidebars/left/dialogs/skills.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/dialogs/skills.tsx
@@ -72,7 +72,7 @@ export const SkillsDialog = () => {
         <FormField
           name="level"
           control={form.control}
-          render={({ field }) => (
+          render={({ field: { onChange, ...field } }) => (
             <FormItem className="sm:col-span-2">
               <FormLabel>{t`Level`}</FormLabel>
               <FormControl className="py-2">
@@ -84,7 +84,7 @@ export const SkillsDialog = () => {
                     value={[field.value]}
                     orientation="horizontal"
                     onValueChange={(value) => {
-                      field.onChange(value[0]);
+                      onChange(value[0]);
                     }}
                   />
 


### PR DESCRIPTION
# Desc
When I adjust the "level" in the skills pop-up, clicking save will pop up a form to check for errors: 
<img width="574" alt="image" src="https://github.com/user-attachments/assets/d632913e-0bd2-4053-bb66-5f3630dd83b6" />

The actual reason is that the onChange and onValueChange of the Slider component take effect simultaneously
