### PR TITLE
Make /v1 endpoint optional in order to support Ollama models

### DIFF
--- a/apps/client/src/pages/dashboard/settings/_sections/openai.tsx
+++ b/apps/client/src/pages/dashboard/settings/_sections/openai.tsx
@@ -27,7 +27,7 @@ const formSchema = z.object({
   baseURL: z
     .string()
     // eslint-disable-next-line lingui/no-unlocalized-strings
-    .regex(/^https?:\/\/[^/]+\/?$/, "That doesn't look like a valid URL")
+    .regex(/^https?:\/\/[^/]+\/?(v1)?$/, "That doesn't look like a valid URL")
     .or(z.literal(""))
     .default(""),
   model: z.string().default(DEFAULT_MODEL),


### PR DESCRIPTION
[Earlier commit](https://github.com/AmruthPillai/Reactive-Resume/commit/18cf814779474063f7edba1958a91f9d5f8c233e) removes the ability to specify /v1 which breaks Ollama integration. 

This PR fixes regression by making /v1 ending optional 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated OpenAI settings URL validation to support optional `/v1` endpoint segment
	- Improved base URL validation for more flexible configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->