### PR TITLE
Fix broken hyperlinks, images and custom CSS (#2182)

### DIFF
--- a/apps/artboard/src/pages/artboard.tsx
+++ b/apps/artboard/src/pages/artboard.tsx
@@ -64,7 +64,7 @@ export const ArtboardPage = () => {
         <title>{name} | Reactive Resume</title>
         {metadata.css.visible && (
           <style id="custom-css" lang="css">
-            {sanitize(metadata.css.value)}
+            {metadata.css.value}
           </style>
         )}
       </Helmet>

--- a/apps/artboard/src/pages/artboard.tsx
+++ b/apps/artboard/src/pages/artboard.tsx
@@ -1,4 +1,3 @@
-import { sanitize } from "@reactive-resume/utils";
 import { useEffect, useMemo } from "react";
 import { Helmet } from "react-helmet-async";
 import { Outlet } from "react-router";

--- a/libs/utils/src/namespaces/string.ts
+++ b/libs/utils/src/namespaces/string.ts
@@ -63,6 +63,8 @@ export const sanitize = (html: string, options?: sanitizeHtml.IOptions) => {
     allowedAttributes: {
       ...options?.allowedAttributes,
       "*": ["class", "style"],
+      "a": ["href", "target"],
+      "img": ["src", "alt"],
     },
     allowedStyles: {
       ...options?.allowedStyles,


### PR DESCRIPTION
I don't know how to test this but I think it should fix #2182.

- Added attributes for `a` and `img` ([sanitize-html documentation](https://github.com/apostrophecms/sanitize-html#:~:text=allowedAttributes%3A%20%7B%0A%20%20a%3A%20%5B%20%27href%27%2C%20%27name%27%2C%20%27target%27%20%5D%2C%0A%20%20//%20We%20don%27t%20currently%20allow%20img%20itself%20by%20default%2C%20but%0A%20%20//%20these%20attributes%20would%20make%20sense%20if%20we%20did.%0A%20%20img%3A%20%5B%20%27src%27%2C%20%27srcset%27%2C%20%27alt%27%2C%20%27title%27%2C%20%27width%27%2C%20%27height%27%2C%20%27loading%27%20%5D%0A%7D))
- Removed sanitization of custom CSS (which is useless and prevents the characters `&` and `>` from being used)
     <sub>([CSS doesn't need to be sanitized.](https://github.com/AmruthPillai/Reactive-Resume/pull/2186/files/809551d0f81cc1860ab8b682212bc820680aa5da#r1931449796))</sub>
     <img src="https://github.com/user-attachments/assets/ce6f3b17-85ed-4158-b45b-e11632501a3c" width="500px" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Security**
    - Updated CSS handling in the Artboard page to allow unsanitized styles.
    - Expanded allowed attributes for HTML sanitization, including support for links and images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->