### PR TITLE
Allow Usage of OpenAI Compatible APIs

### DIFF
--- a/apps/client/src/pages/dashboard/settings/_sections/openai.tsx
+++ b/apps/client/src/pages/dashboard/settings/_sections/openai.tsx
@@ -22,12 +22,12 @@ const formSchema = z.object({
   apiKey: z
     .string()
     // eslint-disable-next-line lingui/no-unlocalized-strings
-    .regex(/^sk-.+$/, "That doesn't look like a valid OpenAI API key.")
+    .min(1, "API key cannot be empty.") //allow api keys like hf-.. and gsk_..
     .default(""),
   baseURL: z
     .string()
     // eslint-disable-next-line lingui/no-unlocalized-strings
-    .regex(/^https?:\/\/[^/]+\/?$/, "That doesn't look like a valid URL")
+    .regex(/^https?:\/\/[^\s]+$/, "That doesn't look like a valid URL") //allow different openai compatible endpoints like https://api.groq.com/openai/v1 and https://api-inference.huggingface.co/v1/
     .or(z.literal(""))
     .default(""),
   model: z.string().default(DEFAULT_MODEL),


### PR DESCRIPTION
OpenAI API isn't free, so this limits users to either buying an OpenAI subscription or using a locally hosted Ollama instance.  

Either of them requires resources that the average user might not have.  

I found many alternatives that the average user might be able to access more easily. An example is the Groq API, which hosts open-source models with a reasonable rate limit for a single user for free (currently).  

Their OpenAI-compatible endpoint (at the time of writing) looks like this:  
`https://api.groq.com/openai/v1`  

And their API keys look like this:  
`gsk_....`  

Reactive Resume's front end disables the save button when this data is entered.

Since it saves the OpenAI auth in browser storage, I manually edited mine to Groq API's, and it worked!  

![screenshot](https://github.com/user-attachments/assets/18284a20-ff3b-442c-b5e4-377b5e4d8b5c)  

So, I changed the front-end fields verification to allow the user to enter any OpenAI-compatible endpoint and API key.  

Please note that I do not have enough experience and that I haven't tested my changes (which are just two lines of code).  

**TO DO:**  
Make a "Verify Connection" button that sends a test request to the API (similar to Open WebUI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated OpenAI settings validation to support more flexible API key and base URL formats
  - Improved input validation to accommodate different API key prefixes and endpoint configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->