### PR TITLE
Fix broken images

### DIFF
--- a/libs/utils/src/namespaces/string.ts
+++ b/libs/utils/src/namespaces/string.ts
@@ -61,7 +61,7 @@ export const sanitize = (html: string, options?: sanitizeHtml.IOptions) => {
   return sanitizeHtml(html, {
     ...options,
     allowedTags: [
-      ...options?.allowedTags,
+      ...(options?.allowedTags ?? []),
       // default tags (https://www.npmjs.com/package/sanitize-html#default-options)
       "address", "article", "aside", "footer", "header", "h1", "h2", "h3", "h4",
       "h5", "h6", "hgroup", "main", "nav", "section", "blockquote", "dd", "div",

--- a/libs/utils/src/namespaces/string.ts
+++ b/libs/utils/src/namespaces/string.ts
@@ -60,6 +60,19 @@ export const parseLayoutLocator = (payload: SortablePayload | null): LayoutLocat
 export const sanitize = (html: string, options?: sanitizeHtml.IOptions) => {
   return sanitizeHtml(html, {
     ...options,
+    allowedTags: [
+      ...options?.allowedTags,
+      // default tags (https://www.npmjs.com/package/sanitize-html#default-options)
+      "address", "article", "aside", "footer", "header", "h1", "h2", "h3", "h4",
+      "h5", "h6", "hgroup", "main", "nav", "section", "blockquote", "dd", "div",
+      "dl", "dt", "figcaption", "figure", "hr", "li", "main", "ol", "p", "pre",
+      "ul", "a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn",
+      "em", "i", "kbd", "mark", "q", "rb", "rp", "rt", "rtc", "ruby", "s", "samp",
+      "small", "span", "strong", "sub", "sup", "time", "u", "var", "wbr", "caption",
+      "col", "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr",
+      // images
+      "img",
+    ],
     allowedAttributes: {
       ...options?.allowedAttributes,
       "*": ["class", "style"],


### PR DESCRIPTION
- Allowed img tags to be used in summaries

My initial pull request (#2186) did not fix images (from issue #2182).
I hope this one will.
<sup>Please test this locally before merging just in case, so that I don't have to make a third pull request. 😅</sup>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced HTML sanitization by expanding the list of allowed HTML tags, including semantic and structural elements like `address`, `article`, `aside`, `footer`, and `header`.
	- Added support for image tags in the sanitization process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->