### PR TITLE
feat(projects): allow reordering of project item tags

### DIFF
--- a/apps/client/src/pages/builder/sidebars/left/dialogs/projects.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/dialogs/projects.tsx
@@ -28,6 +28,10 @@ const formSchema = projectSchema;
 
 type FormValues = z.infer<typeof formSchema>;
 
+const handleDragOver = (e: React.DragEvent) => {
+  e.preventDefault();
+};
+
 export const ProjectsDialog = () => {
   const form = useForm<FormValues>({
     defaultValues: defaultProject,
@@ -35,6 +39,23 @@ export const ProjectsDialog = () => {
   });
 
   const [pendingKeyword, setPendingKeyword] = useState("");
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+
+  const handleDrop = (
+    e: React.DragEvent,
+    dropIndex: number,
+    field: { value: string[]; onChange: (value: string[]) => void },
+  ) => {
+    e.preventDefault();
+    if (draggedIndex === null) return;
+
+    const newKeywords = [...field.value];
+    const [draggedItem] = newKeywords.splice(draggedIndex, 1);
+    newKeywords.splice(dropIndex, 0, draggedItem);
+
+    field.onChange(newKeywords);
+    setDraggedIndex(null);
+  };
 
   return (
     <SectionDialog<FormValues>
@@ -151,18 +172,28 @@ export const ProjectsDialog = () => {
                     <motion.div
                       key={item}
                       layout
+                      draggable
                       initial={{ opacity: 0, y: -50 }}
                       animate={{ opacity: 1, y: 0, transition: { delay: index * 0.1 } }}
                       exit={{ opacity: 0, x: -50 }}
+                      onDragStart={() => {
+                        setDraggedIndex(index);
+                      }}
+                      onDragOver={handleDragOver}
+                      onDrop={(e) => {
+                        handleDrop(e, index, field);
+                      }}
                     >
-                      <Badge
-                        className="cursor-pointer"
-                        onClick={() => {
-                          field.onChange(field.value.filter((v) => item !== v));
-                        }}
-                      >
+                      <Badge className="cursor-move">
                         <span className="mr-1">{item}</span>
-                        <X size={12} weight="bold" />
+                        <X
+                          className="cursor-pointer"
+                          size={12}
+                          weight="bold"
+                          onClick={() => {
+                            field.onChange(field.value.filter((v) => item !== v));
+                          }}
+                        />
                       </Badge>
                     </motion.div>
                   ))}


### PR DESCRIPTION
# Allow Reordering Project Tags via Drag and Drop

## Changes
- Added drag and drop functionality for project tags
- Implemented drag state management using `useState`
- Added `handleDrop` function to handle reordering logic
- Tags can now be reordered by dragging and dropping

## Why
This enhances user experience by allowing manual reordering of project tags instead of being stuck with the order of entry.

## Testing
- [x] Verified drag and drop works in different browsers (Chrome, Firefox, Safari)
- [x] Confirmed state updates correctly after reordering

Closes #2169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced drag-and-drop functionality for managing keywords, enabling users to reorder items in the project interface.
  - Enhanced the interactive experience by providing intuitive visual cues when dragging keywords, along with streamlined actions for moving and removing items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->