### PR TITLE
fix(linkedin): use case-insensitive slug check to prevent missing image

### DIFF
--- a/apps/artboard/src/components/brand-icon.tsx
+++ b/apps/artboard/src/components/brand-icon.tsx
@@ -5,7 +5,7 @@ type BrandIconProps = {
 };
 
 export const BrandIcon = forwardRef<HTMLImageElement, BrandIconProps>(({ slug }, ref) => {
-  if (slug === "linkedin") {
+  if (slug.toLowerCase() === "linkedin") {
     return (
       <img
         ref={ref}


### PR DESCRIPTION
**Summary:**
Fixes an issue where varying capitalizations of "linkedin" (e.g., "LinkedIn") resulted in an empty image by making the slug check case-insensitive.

**Changes Made:**

- Converted the slug to lowercase before comparison to handle all capitalization variations.