### PR TITLE
replace unpkg w/ jsdelivr

### DIFF
--- a/apps/artboard/index.html
+++ b/apps/artboard/index.html
@@ -39,6 +39,6 @@
     <script type="module" src="/src/main.tsx"></script>
 
     <!-- Phosphor Icons -->
-    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
   </body>
 </html>

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -42,6 +42,6 @@
     <script type="module" src="/src/main.tsx"></script>
 
     <!-- Phosphor Icons -->
-    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #2232 and #2230

UNPKG has not been actively maintained and ~~has been down since `Mar 15, 2025`~~ was down from Mar 15, 2025, 2:00 AM and down for 18 hours (https://github.com/unpkg/unpkg/issues/412). Migrating to jsDelivr means a more stable and reliant service.

The PR replaces UNPKG usage with jsDelivr.

See also another upstream PR: https://github.com/phosphor-icons/web/pull/37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the external icons script URL to use a new CDN provider for improved asset delivery without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->