### PR TITLE
fix(share resume): arial this is system font, and cannot be loaded via google

### DIFF
--- a/apps/artboard/src/pages/artboard.tsx
+++ b/apps/artboard/src/pages/artboard.tsx
@@ -5,6 +5,13 @@ import webfontloader from "webfontloader";
 
 import { useArtboardStore } from "../store/artboard";
 
+const pageLoadedEvent = () => {
+  const width = window.document.body.offsetWidth;
+  const height = window.document.body.offsetHeight;
+  const message = { type: "PAGE_LOADED", payload: { width, height } };
+  window.postMessage(message, "*");
+};
+
 export const ArtboardPage = () => {
   const name = useArtboardStore((state) => state.resume.basics.name);
   const metadata = useArtboardStore((state) => state.resume.metadata);
@@ -21,12 +28,13 @@ export const ArtboardPage = () => {
     webfontloader.load({
       google: { families: [fontString] },
       active: () => {
-        const width = window.document.body.offsetWidth;
-        const height = window.document.body.offsetHeight;
-        const message = { type: "PAGE_LOADED", payload: { width, height } };
-        window.postMessage(message, "*");
+        pageLoadedEvent();
       },
     });
+    if (fontString.includes("Arial")) {
+      pageLoadedEvent();
+      return;
+    }
   }, [fontString]);
 
   // Font Size & Line Height


### PR DESCRIPTION
### PR Description

[Issue](https://github.com/AmruthPillai/Reactive-Resume/issues/2214)

Arial cannot be loaded via Google Fonts (google: { families: ["Arial"] }) because it's a system font, not a web font hosted by Google. Google Fonts only provides web fonts that can be dynamically loaded from their servers, and Arial is a pre-installed system font available on most operating systems (Windows, macOS, Linux).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This update refines how the application handles page load detection, ensuring a more consistent and reliable user experience without altering visible features.

- **Refactor**
  - Streamlined the page load notification process for improved consistency when pages are fully loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->