### PR TITLE
fix(bug): clear resumes on logout to prevent seeing resumes from previously logged in accounts

### DIFF
--- a/apps/client/src/services/auth/logout.ts
+++ b/apps/client/src/services/auth/logout.ts
@@ -18,10 +18,12 @@ export const useLogout = () => {
     onSuccess: () => {
       setUser(null);
       queryClient.setQueryData(["user"], null);
+      queryClient.setQueryData(["resumes"], null);
     },
     onError: () => {
       setUser(null);
       queryClient.setQueryData(["user"], null);
+      queryClient.setQueryData(["resumes"], null);
     },
   });
 


### PR DESCRIPTION
### Clear Resumes on logout

## Changes

When logging out, the queryData from the key "resumes" is set to null

## Why

When a user logs out, the resumes aren't cleared. If you then create a new account, the resumes from the previously logged in account are visible. 
Trying to interact with resumes from a previously logged in account returns errors, preventing it from being a serious bug, but clearing them is, in my opinion, still the best approach.