### PR TITLE
feat(skills): allow reordering skill keywords

### DIFF
--- a/apps/client/src/pages/builder/sidebars/left/dialogs/skills.tsx
+++ b/apps/client/src/pages/builder/sidebars/left/dialogs/skills.tsx
@@ -25,6 +25,10 @@ const formSchema = skillSchema;
 
 type FormValues = z.infer<typeof formSchema>;
 
+const handleDragOver = (e: React.DragEvent) => {
+  e.preventDefault();
+};
+
 export const SkillsDialog = () => {
   const form = useForm<FormValues>({
     defaultValues: defaultSkill,
@@ -32,6 +36,23 @@ export const SkillsDialog = () => {
   });
 
   const [pendingKeyword, setPendingKeyword] = useState("");
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+
+  const handleDrop = (
+    e: React.DragEvent,
+    dropIndex: number,
+    field: { value: string[]; onChange: (value: string[]) => void },
+  ) => {
+    e.preventDefault();
+    if (draggedIndex === null) return;
+
+    const newKeywords = [...field.value];
+    const [draggedItem] = newKeywords.splice(draggedIndex, 1);
+    newKeywords.splice(dropIndex, 0, draggedItem);
+
+    field.onChange(newKeywords);
+    setDraggedIndex(null);
+  };
 
   return (
     <SectionDialog<FormValues>
@@ -122,18 +143,28 @@ export const SkillsDialog = () => {
                     <motion.div
                       key={item}
                       layout
+                      draggable
                       initial={{ opacity: 0, y: -50 }}
                       animate={{ opacity: 1, y: 0, transition: { delay: index * 0.1 } }}
                       exit={{ opacity: 0, x: -50 }}
+                      onDragStart={() => {
+                        setDraggedIndex(index);
+                      }}
+                      onDragOver={handleDragOver}
+                      onDrop={(e) => {
+                        handleDrop(e, index, field);
+                      }}
                     >
-                      <Badge
-                        className="cursor-pointer"
-                        onClick={() => {
-                          field.onChange(field.value.filter((v) => item !== v));
-                        }}
-                      >
+                      <Badge className="cursor-move">
                         <span className="mr-1">{item}</span>
-                        <X size={12} weight="bold" />
+                        <X
+                          className="cursor-pointer"
+                          size={12}
+                          weight="bold"
+                          onClick={() => {
+                            field.onChange(field.value.filter((v) => item !== v));
+                          }}
+                        />
                       </Badge>
                     </motion.div>
                   ))}


### PR DESCRIPTION
Fixes #2269

### Description

Allow reordering skill keywords via drag and drop. This implementation is basically identical to #2202.

### Changes

- Added drag and drop functionality for skill keywords
- Implemented drag state management using useState
- Added handleDrop function to handle reordering logic
- Keywords can now be reordered by dragging and dropping
