### PR TITLE
Fix regex for parsing linkedin array links

### DIFF
--- a/libs/utils/src/namespaces/csv.ts
+++ b/libs/utils/src/namespaces/csv.ts
@@ -23,4 +23,4 @@ export const parseCSV = async (string: string) => {
  * @returns
  */
 export const parseArrayLikeCSVEntry = (csvEntry: string) =>
-  csvEntry.replace(/^\[/, "").replace(/$]/, "").split(",");
+  csvEntry.replace(/^\[/, "").replace(/\]$/, "").split(",");


### PR DESCRIPTION
The second replace was incorrect, resulting in a link like `https://google.com]` which failed zod validation