### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=id">Bahasa Indonesia</a>
+      </div>
+    </div>
+  </details>
+</div>
+
 ![Reactive Resume](https://i.imgur.com/FFc4nyZ.jpg)
 
 ![App Version](https://img.shields.io/github/package-json/version/AmruthPillai/Reactive-Resume?label=version)


### PR DESCRIPTION
@86jkuncle created [issue-51](https://github.com/OpenAiTx/OpenAiTx/issues/51), user would like to add language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages. System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links :
- [English](https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=en)
- [简体中文](https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=AmruthPillai&project=Reactive-Resume&lang=ko) ..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962" />

If this was not your expection, please close this PR. Thank you! 🙌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible language selection menu to the top right of the README, allowing users to easily navigate to documentation in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->