### PR TITLE
fix(printer.service.ts): fix pdf rendering, issue #2374 solved

### DIFF
--- a/apps/server/src/printer/printer.service.ts
+++ b/apps/server/src/printer/printer.service.ts
@@ -127,13 +127,33 @@ export class PrinterService {
       // Set the data of the resume to be printed in the browser's session storage
       const numberPages = resume.data.metadata.layout.length;
 
-      await page.goto(`${url}/artboard/preview`, { waitUntil: "networkidle0" });
+      await page.goto(`${url}/artboard/preview`, { waitUntil: "domcontentloaded" });
 
       await page.evaluate((data) => {
         window.localStorage.setItem("resume", JSON.stringify(data));
       }, resume.data);
 
-      await page.reload({ waitUntil: "load" });
+      await Promise.all([
+        page.reload({ waitUntil: "load" }),
+        // Wait until first page is present before proceeding
+        page.waitForSelector('[data-page="1"]', { timeout: 15_000 }),
+      ]);
+
+      if (resume.data.basics.picture.url) {
+        await page.waitForSelector('img[alt="Profile"]');
+        await page.evaluate(() =>
+          Promise.all(
+            // eslint-disable-next-line unicorn/prefer-spread
+            Array.from(document.images).map((img) => {
+              if (img.complete) return;
+              return new Promise((resolve) => {
+                // eslint-disable-next-line unicorn/prefer-add-event-listener
+                img.onload = img.onerror = resolve;
+              });
+            }),
+          ),
+        );
+      }
 
       const pagesBuffer: Buffer[] = [];
 

--- a/apps/server/src/printer/printer.service.ts
+++ b/apps/server/src/printer/printer.service.ts
@@ -127,11 +127,13 @@ export class PrinterService {
       // Set the data of the resume to be printed in the browser's session storage
       const numberPages = resume.data.metadata.layout.length;
 
-      await page.evaluateOnNewDocument((data) => {
+      await page.goto(`${url}/artboard/preview`, { waitUntil: "networkidle0" });
+
+      await page.evaluate((data) => {
         window.localStorage.setItem("resume", JSON.stringify(data));
       }, resume.data);
 
-      await page.goto(`${url}/artboard/preview`, { waitUntil: "networkidle0" });
+      await page.reload({ waitUntil: "load" });
 
       const pagesBuffer: Buffer[] = [];
 


### PR DESCRIPTION
fix(printer-service): ensure PDF renders correctly by caching resume data before reload

Previously used evaluateOnNewDocument, which caused localStorage to be set too late.
Now the resume data is cached via evaluate() before reload, ensuring the page
loads with correct data and improving reliability and efficiency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent cases where the artboard preview or print output could load with missing, outdated, or blank content by changing the initialization sequence to ensure injected data is applied before rendering.

* **Performance & Stability**
  * Improved reliability by waiting for the first page and any profile image resources to finish loading before continuing, reducing race conditions and improving rendering consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->