### PR TITLE
feat(resumes): remember user's layout choice

### DIFF
--- a/apps/client/src/pages/dashboard/resumes/page.tsx
+++ b/apps/client/src/pages/dashboard/resumes/page.tsx
@@ -21,8 +21,6 @@ export const ResumesPage = () => {
   const [layout, setLayout] = useState<Layout>(Layout.Grid);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-
     try {
       const storedLayout = localStorage.getItem(LOCAL_STORAGE_LAYOUT_KEY);
       if (storedLayout && VALID_LAYOUT_VALUES.includes(storedLayout as Layout)) {


### PR DESCRIPTION
Saves the layout (grid or list view) selected by the user on the resume dashboard page to localStorage.

This ensures that the user's preference is retained across different sessions, providing a more consistent user experience. Additionally, the code was refactored to use an enum for managing layout states, enhancing readability and type safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resumes dashboard lets you switch between Grid and List layouts.
  * Your chosen layout is persisted locally and restored across sessions.
  * Layout toggle stays in sync with the displayed view for immediate feedback.

* **Refactor**
  * Safer default layout (Grid) with client-side restoration guard for consistent behavior.
  * Added validation and error handling around loading/saving the chosen layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->