### PR TITLE
feat(openai): add Azure OpenAI support with configuration options

### DIFF
--- a/apps/client/src/constants/llm.ts
+++ b/apps/client/src/constants/llm.ts
@@ -1,2 +1,3 @@
 export const DEFAULT_MODEL = "gpt-3.5-turbo";
 export const DEFAULT_MAX_TOKENS = 1024;
+export const DEFAULT_AZURE_API_VERSION = "2025-01-01-preview";

--- a/apps/client/src/constants/llm.ts
+++ b/apps/client/src/constants/llm.ts
@@ -1,3 +1,3 @@
 export const DEFAULT_MODEL = "gpt-3.5-turbo";
 export const DEFAULT_MAX_TOKENS = 1024;
-export const DEFAULT_AZURE_API_VERSION = "2025-01-01-preview";
+export const DEFAULT_AZURE_API_VERSION = "2024-10-21";

--- a/apps/client/src/pages/dashboard/settings/_sections/openai.tsx
+++ b/apps/client/src/pages/dashboard/settings/_sections/openai.tsx
@@ -127,7 +127,7 @@ export const OpenAISettings = () => {
           <Trans>
             You can also integrate with Azure OpenAI by enabling the "Use Azure OpenAI" checkbox
             and setting the Resource URL to your Azure OpenAI resource (e.g.,
-            `https://your-resource.openai.azure.com`). Set the deployment name in the Model field
+            <code>https://your-resource.openai.azure.com</code>). Set the deployment name in the Model field
             and specify the appropriate API version for your Azure deployment.
           </Trans>
         </p>
@@ -135,8 +135,8 @@ export const OpenAISettings = () => {
         <p>
           <Trans>
             You can also integrate with Ollama simply by setting the API key to
-            `sk-1234567890abcdef` and the Base URL to your Ollama URL, i.e.
-            `http://localhost:11434/v1`. You can also pick and choose models and set the max tokens
+            <code>sk-1234567890abcdef</code> and the Base URL to your Ollama URL, i.e.
+            <code>http://localhost:11434/v1</code>. You can also pick and choose models and set the max tokens
             as per your preference.
           </Trans>
         </p>
@@ -228,8 +228,10 @@ export const OpenAISettings = () => {
               <FormItem className="flex flex-row items-center space-x-3 space-y-0">
                 <FormControl>
                   <Checkbox
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
+                    checked={!!field.value}
+                    onCheckedChange={(value) => {
+                      field.onChange(Boolean(value));
+                    }}
                   />
                 </FormControl>
                 <div className="space-y-1 leading-none">

--- a/apps/client/src/services/openai/client.ts
+++ b/apps/client/src/services/openai/client.ts
@@ -4,12 +4,43 @@ import { OpenAI } from "openai";
 import { useOpenAiStore } from "@/client/stores/openai";
 
 export const openai = () => {
-  const { apiKey, baseURL } = useOpenAiStore.getState();
+  const { apiKey, baseURL, isAzure, azureApiVersion, model } = useOpenAiStore.getState();
 
   if (!apiKey) {
     throw new Error(
       t`Your OpenAI API Key has not been set yet. Please go to your account settings to enable OpenAI Integration.`,
     );
+  }
+
+  if (isAzure) {
+    if (!baseURL) {
+      throw new Error(
+        t`Azure OpenAI Base URL is required when using Azure OpenAI.`,
+      );
+    }
+
+    if (!model) {
+      throw new Error(
+        t`Azure OpenAI deployment name (model) is required when using Azure OpenAI.`,
+      );
+
+      if (!azureApiVersion) {
+        throw new Error(
+          t`Azure OpenAI API version is required when using Azure OpenAI.`,
+        );
+      }
+    }
+
+    // Construct Azure OpenAI URL: https://your-resource.openai.azure.com/openai/deployments/your-deployment
+    const azureBaseURL = baseURL.endsWith('/') ? baseURL.slice(0, -1) : baseURL;
+    const constructedURL = `${azureBaseURL}/openai/deployments/${model}`;
+
+    return new OpenAI({
+      apiKey,
+      baseURL: constructedURL,
+      defaultQuery: { "api-version": azureApiVersion ?? undefined },
+      dangerouslyAllowBrowser: true,
+    });
   }
 
   if (baseURL) {

--- a/apps/client/src/services/openai/client.ts
+++ b/apps/client/src/services/openai/client.ts
@@ -14,21 +14,15 @@ export const openai = () => {
 
   if (isAzure) {
     if (!baseURL) {
-      throw new Error(
-        t`Azure OpenAI Base URL is required when using Azure OpenAI.`,
-      );
+      throw new Error(t`Azure OpenAI Base URL is required when using Azure OpenAI.`);
     }
 
     if (!model) {
-      throw new Error(
-        t`Azure OpenAI deployment name (model) is required when using Azure OpenAI.`,
-      );
+      throw new Error(t`Azure OpenAI deployment name (model) is required when using Azure OpenAI.`);
+    }
 
-      if (!azureApiVersion) {
-        throw new Error(
-          t`Azure OpenAI API version is required when using Azure OpenAI.`,
-        );
-      }
+    if (!azureApiVersion) {
+      throw new Error(t`Azure OpenAI API version is required when using Azure OpenAI.`);
     }
 
     // Construct Azure OpenAI URL: https://your-resource.openai.azure.com/openai/deployments/your-deployment

--- a/apps/client/src/stores/openai.ts
+++ b/apps/client/src/stores/openai.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-import { DEFAULT_MAX_TOKENS, DEFAULT_MODEL } from "../constants/llm";
+import { DEFAULT_MAX_TOKENS, DEFAULT_MODEL, DEFAULT_AZURE_API_VERSION } from "../constants/llm";
 
 type OpenAIStore = {
   baseURL: string | null;
@@ -12,6 +12,10 @@ type OpenAIStore = {
   setModel: (model: string | null) => void;
   maxTokens: number | null;
   setMaxTokens: (maxTokens: number | null) => void;
+  isAzure: boolean;
+  setIsAzure: (isAzure: boolean) => void;
+  azureApiVersion: string | null;
+  setAzureApiVersion: (apiVersion: string | null) => void;
 };
 
 export const useOpenAiStore = create<OpenAIStore>()(
@@ -32,6 +36,14 @@ export const useOpenAiStore = create<OpenAIStore>()(
       maxTokens: DEFAULT_MAX_TOKENS,
       setMaxTokens: (maxTokens: number | null) => {
         set({ maxTokens });
+      },
+      isAzure: false,
+      setIsAzure: (isAzure: boolean) => {
+        set({ isAzure });
+      },
+      azureApiVersion: DEFAULT_AZURE_API_VERSION,
+      setAzureApiVersion: (azureApiVersion: string | null) => {
+        set({ azureApiVersion });
       },
     }),
     { name: "openai" },


### PR DESCRIPTION
Fixes #2381 [Feature] Add support for Azure OpenAi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Azure OpenAI integration in settings with a “Use Azure OpenAI” toggle, Resource URL, Deployment Name, and Azure API Version; labels/placeholders adjust dynamically and values persist/reset appropriately.
  - Client now supports constructing/using Azure endpoints when Azure mode is enabled.

- Documentation
  - Updated on-screen guidance to clarify Azure/OpenAI/Ollama usage.

- Chores
  - Introduced a default Azure API version (2024-10-21).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->