### PR TITLE
revert: readded the .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,81 @@
+# Environment
+NODE_ENV=development
+
+# Ports
+PORT=3000
+
+# URLs
+# These URLs must reference a publicly accessible domain or IP address, not a docker container ID (depending on your compose setup)
+PUBLIC_URL=http://localhost:3000
+STORAGE_URL=http://localhost:9000/default # default is the bucket name specified in the STORAGE_BUCKET variable
+
+# Database (Prisma/PostgreSQL)
+# This can be swapped out to use any other database, like MySQL
+# Note: This is used only in the compose.yml file
+POSTGRES_PORT=5432
+POSTGRES_DB=postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+
+# Database (Prisma/PostgreSQL)
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres?schema=public
+
+# Authentication Secrets
+# generated with `openssl rand -base64 64`
+ACCESS_TOKEN_SECRET=access_token_secret
+REFRESH_TOKEN_SECRET=refresh_token_secret
+
+# Chrome Browser (for printing)
+# generated with `openssl rand -hex 32`
+CHROME_PORT=8080
+CHROME_TOKEN=chrome_token
+CHROME_URL=ws://localhost:8080
+# Launch puppeteer with flag to ignore https errors
+# CHROME_IGNORE_HTTPS_ERRORS=true
+
+# Mail Server (for e-mails)
+# For testing, you can use https://ethereal.email/create
+MAIL_FROM=noreply@localhost
+# SMTP_URL=smtp://username:password@smtp.ethereal.email:587
+
+# Storage
+STORAGE_ENDPOINT=localhost
+STORAGE_PORT=9000
+STORAGE_REGION=us-east-1
+STORAGE_BUCKET=default
+STORAGE_ACCESS_KEY=minioadmin
+STORAGE_SECRET_KEY=minioadmin
+STORAGE_USE_SSL=false
+STORAGE_SKIP_BUCKET_CHECK=false
+
+# Nx Cloud (Optional)
+# NX_CLOUD_ACCESS_TOKEN=
+
+# Crowdin (Optional)
+# CROWDIN_PROJECT_ID=
+# CROWDIN_PERSONAL_TOKEN=
+
+# Feature Flags (Optional)
+# DISABLE_SIGNUPS=false
+# DISABLE_EMAIL_AUTH=false
+
+# GitHub (OAuth, Optional)
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# GITHUB_CALLBACK_URL=http://localhost:5173/api/auth/github/callback
+
+# Google (OAuth, Optional)
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+# GOOGLE_CALLBACK_URL=http://localhost:5173/api/auth/google/callback
+
+# OpenID (Optional)
+# VITE_OPENID_NAME=
+# OPENID_AUTHORIZATION_URL=
+# OPENID_CALLBACK_URL=http://localhost:5173/api/auth/openid/callback
+# OPENID_CLIENT_ID=
+# OPENID_CLIENT_SECRET=
+# OPENID_ISSUER=
+# OPENID_SCOPE=openid profile email
+# OPENID_TOKEN_URL=
+# OPENID_USER_INFO_URL=


### PR DESCRIPTION
This fixes the issue #2400 .
In Contibution.md  step 3 states that to Copy .env.example to .env, however this .env.example file seems to be deleted by the commit 78eefe9da1778686a9a42b46ad5a05a26e4da1ec, so i have re-added this file back to this. Hope this helps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive .env.example with annotated defaults for environment modes, ports, URLs, database, authentication secrets, headless browser, mail, storage, feature flags, OAuth/OpenID, and CI tooling to streamline setup and ensure configuration consistency.
  * No functional changes; guidance only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->