### PR TITLE
fix(template): fix gengar template summary section not rendering in sidebar

### DIFF
--- a/apps/artboard/src/templates/gengar.tsx
+++ b/apps/artboard/src/templates/gengar.tsx
@@ -531,6 +531,7 @@ const mapSectionToComponent = (section: SectionKey) => {
     case "education": {
       return <Education />;
     }
+    
     case "summary": {
       return <Summary />;
     }


### PR DESCRIPTION
The Summary section remains in the main area and cannot be moved to the sidebar, unlike on other pages. (See issue: #2371)

✅ What changed / Fix
Modified the layout logic so the Summary section is eligible to be moved into the sidebar even on page one.

🔗 References
Fixes issue #2371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Summary section accessible via sidebar navigation and app routing.

* **Refactor**
  * Ensures Summary is rendered consistently through the app’s section mapping by removing the prior first-page special-case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->