### PR TITLE
[Feature] Highlight the selected options under Rich inputs.

### DIFF
--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -151,7 +151,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("bold")}
           disabled={!editor.can().chain().toggleBold().run()}
-          className={editor.isActive("bold") ? "bg-secondary" : undefined}
+          data-state={editor.isActive("bold") ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleBold().run()}
         >
           <TextBIcon />
@@ -164,7 +164,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("italic")}
           disabled={!editor.can().chain().focus().toggleItalic().run()}
-          className={editor.isActive("italic") ? "bg-secondary" : undefined}
+          data-state={editor.isActive("italic") ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleItalic().run()}
         >
           <TextItalicIcon />
@@ -177,7 +177,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("strike")}
           disabled={!editor.can().chain().focus().toggleStrike().run()}
-          className={editor.isActive("strike") ? "bg-secondary" : undefined}
+          data-state={editor.isActive("strike") ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleStrike().run()}
         >
           <TextStrikethroughIcon />
@@ -190,7 +190,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("underline")}
           disabled={!editor.can().chain().focus().toggleUnderline().run()}
-          className={editor.isActive("underline") ? "bg-secondary" : undefined}
+          data-state={editor.isActive("underline") ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleUnderline().run()}
         >
           <TextAUnderlineIcon />
@@ -203,7 +203,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("highlight")}
           disabled={!editor.can().chain().focus().toggleHighlight().run()}
-          className={editor.isActive("highlight") ? "bg-secondary" : undefined}
+          data-state={editor.isActive("highlight") ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleHighlight().run()}
         >
           <HighlighterCircleIcon />
@@ -222,7 +222,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("code")}
           disabled={!editor.can().chain().focus().toggleCode().run()}
-          className={editor.isActive("code") ? "bg-secondary" : undefined}
+          data-state={editor.isActive("code") ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleCode().run()}
         >
           <CodeIconImport />
@@ -235,7 +235,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("codeBlock")}
           disabled={!editor.can().chain().focus().toggleCodeBlock().run()}
-          className={editor.isActive("codeBlock") ? "bg-secondary" : undefined}
+          data-state={editor.isActive("codeBlock") ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleCodeBlock().run()}
         >
           <CodeBlockIconImport />
@@ -248,7 +248,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("heading", { level: 1 })}
           disabled={!editor.can().chain().focus().toggleHeading({ level: 1 }).run()}
-          className={editor.isActive("heading", { level: 1 }) ? "bg-secondary" : undefined}
+          data-state={editor.isActive("heading", { level: 1 }) ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
         >
           <TextHOneIcon />
@@ -261,7 +261,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("heading", { level: 2 })}
           disabled={!editor.can().chain().focus().toggleHeading({ level: 2 }).run()}
-          className={editor.isActive("heading", { level: 2 }) ? "bg-secondary" : undefined}
+          data-state={editor.isActive("heading", { level: 2 }) ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
         >
           <TextHTwoIcon />
@@ -274,7 +274,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("heading", { level: 3 })}
           disabled={!editor.can().chain().focus().toggleHeading({ level: 3 }).run()}
-          className={editor.isActive("heading", { level: 3 }) ? "bg-secondary" : undefined}
+          data-state={editor.isActive("heading", { level: 3 }) ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
         >
           <TextHThreeIcon />
@@ -286,7 +286,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           size="sm"
           type="button"
           pressed={editor.isActive("paragraph")}
-          className={editor.isActive("paragraph") ? "bg-secondary" : undefined}
+          data-state={editor.isActive("paragraph") ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().setParagraph().run()}
         >
           <ParagraphIconImport />
@@ -299,7 +299,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive({ textAlign: "left" })}
           disabled={!editor.can().chain().focus().setTextAlign("left").run()}
-          className={editor.isActive({ textAlign: "left" }) ? "bg-secondary" : undefined}
+          data-state={editor.isActive({ textAlign: "left" }) ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().setTextAlign("left").run()}
         >
           <TextAlignLeftIcon />
@@ -312,7 +312,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive({ textAlign: "center" })}
           disabled={!editor.can().chain().focus().setTextAlign("center").run()}
-          className={editor.isActive({ textAlign: "center" }) ? "bg-secondary" : undefined}
+          data-state={editor.isActive({ textAlign: "center" }) ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().setTextAlign("center").run()}
         >
           <TextAlignCenterIcon />
@@ -325,7 +325,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive({ textAlign: "right" })}
           disabled={!editor.can().chain().focus().setTextAlign("right").run()}
-          className={editor.isActive({ textAlign: "right" }) ? "bg-secondary" : undefined}
+          data-state={editor.isActive({ textAlign: "right" }) ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().setTextAlign("right").run()}
         >
           <TextAlignRightIcon />
@@ -338,7 +338,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive({ textAlign: "justify" })}
           disabled={!editor.can().chain().focus().setTextAlign("justify").run()}
-          className={editor.isActive({ textAlign: "justify" }) ? "bg-secondary" : undefined}
+          data-state={editor.isActive({ textAlign: "justify" }) ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().setTextAlign("justify").run()}
         >
           <TextAlignJustifyIcon />
@@ -351,7 +351,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("bulletList")}
           disabled={!editor.can().chain().focus().toggleBulletList().run()}
-          className={editor.isActive("bulletList") ? "bg-secondary" : undefined}
+          data-state={editor.isActive("bulletList") ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleBulletList().run()}
         >
           <ListBulletsIcon />
@@ -364,7 +364,7 @@ const Toolbar = ({ editor }: { editor: Editor }) => {
           type="button"
           pressed={editor.isActive("orderedList")}
           disabled={!editor.can().chain().focus().toggleOrderedList().run()}
-          className={editor.isActive("orderedList") ? "bg-secondary" : undefined}
+          data-state={editor.isActive("orderedList") ? "on" : "off"}
           onPressedChange={() => editor.chain().focus().toggleOrderedList().run()}
         >
           <ListNumbersIcon />


### PR DESCRIPTION
This PR adds the requested feature #2388 .
When user selects any of the rich inputs (Bold, italic etc. ) visual feedback is shown for the selected item.

Screenshot of working feature for reference.
<img width="499" height="568" alt="image" src="https://github.com/user-attachments/assets/20f6f90f-ee86-4193-945a-dda969ef67c7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Rich text editor toolbar now shows active/inactive states for formatting controls for clearer visual feedback.
  * Active states cover bold, italic, underline, strikethrough, highlight, inline/code block, headings (H1–H3), paragraph, text alignment (left/center/right/justify), and bullet/numbered lists.
  * Improves editing clarity and consistency; no behavioral or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->