### PR TITLE
fix(rich-input.tsx): replace default scrollbar with themed scrollbar in Summary Editor, fixed issue #2420

### DIFF
--- a/libs/ui/src/components/rich-input.tsx
+++ b/libs/ui/src/components/rich-input.tsx
@@ -44,10 +44,10 @@ import { Button } from "./button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "./form";
 import { Input } from "./input";
 import { Popover, PopoverContent } from "./popover";
+import { ScrollArea } from "./scroll-area";
 import { Skeleton } from "./skeleton";
 import { Toggle } from "./toggle";
 import { Tooltip } from "./tooltip";
-import { ScrollArea } from "./scroll-area";
 
 const InsertImageFormSchema = z.object({
   src: z.string(),
@@ -527,18 +527,18 @@ export const RichInput = forwardRef<Editor, RichInputProps>(
       <div>
         {!hideToolbar && <Toolbar editor={editor} />}
 
-        <ScrollArea orientation="vertical" className="rounded-sm border px-3 py-2">
+        <ScrollArea orientation="vertical" className="rounded-sm border p-3 pt-0">
           <EditorContent
             editor={editor}
             className={cn(
-              "grid min-h-[160px] w-full bg-transparent text-sm placeholder:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50",
+              "grid min-h-[140px] w-full bg-transparent text-sm placeholder:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50",
               hideToolbar && "pt-2",
               className,
             )}
             {...props}
           />
         </ScrollArea>
-        
+
         {footer?.(editor)}
       </div>
     );


### PR DESCRIPTION

<img width="597" height="415" alt="Screenshot From 2025-10-17 01-09-04" src="https://github.com/user-attachments/assets/1758fb05-9374-455f-8bcf-14f70c195c2d" />

Old Summary editor with default scrollbar

---

<img width="597" height="415" alt="Screenshot From 2025-10-17 01-12-05" src="https://github.com/user-attachments/assets/b668891d-bf59-48be-becb-5a01a03041e2" />

New themed scrollbar added ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized editor layout to introduce a scrollable container for smoother content scrolling without changing toolbar behavior or public APIs.

* **Style**
  * Adjusted editor spacing and visual hierarchy; minimum editor height slightly reduced for a tighter appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->