### PR TITLE
Bugfix: hide password on shortcuts

### DIFF
--- a/libs/hooks/src/hooks/use-password-toggle.ts
+++ b/libs/hooks/src/hooks/use-password-toggle.ts
@@ -8,7 +8,7 @@ export const usePasswordToggle = (formRef: React.RefObject<HTMLElement | null>) 
         formRef.current
           ?.querySelector<HTMLInputElement>('input[name="password"]')
           ?.setAttribute("type", "text");
-      } else if (event.key === "v" && (event.ctrlKey || event.metaKey)) {
+      } else if ((event.key === "v" || event.key === "V") && (event.ctrlKey || event.metaKey)) {
         // unless Ctrl+V is pressed => don't show pasted password
         formRef.current
           ?.querySelector<HTMLInputElement>('input[name="password"]')


### PR DESCRIPTION
### Bugfix
- A: passwords on the login page are briefly revealed when pasting with `Ctrl+V`
- B: when using shortcut to autofill (e.g. `Ctrl+Shift+L` for Bitwarden), which opens a new window to unlock the password manager, the password is not hidden again, as the `Control` keyup event is not send to the login page

#### Expected Behavior
Password should only be visible when the user intentionally holds down a modifier key for quick inspection, and should never remain visible longer than intended.

#### Fixes
- A: when "V" is pressed while "Ctrl" is pressed, reset the input field to `type="password"`
- B: listen to "blur" event and hide password

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Password fields remain masked when pasting, preventing pasted content from being revealed accidentally.
  * Password inputs automatically re-mask when the application or window loses focus to protect sensitive input.
  * Improved modifier-key handling to reduce accidental password exposure and enhance input privacy, ensuring show/hide behavior is consistent across key and focus events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->