### PR TITLE
fix(artboard): fix padding regression in Gengar template (#2463)

### DIFF
--- a/apps/artboard/src/templates/gengar.tsx
+++ b/apps/artboard/src/templates/gengar.tsx
@@ -187,7 +187,7 @@ const Section = <T,>({
   if (!section.visible || section.items.filter((item) => item.visible).length === 0) return null;
 
   return (
-    <section id={section.id} className="grid">
+    <section id={section.id} className="my-custom grid px-custom">
       <h4 className="mb-2 border-b border-primary text-base font-bold">{section.name}</h4>
 
       <div
@@ -586,10 +586,7 @@ export const Gengar = ({ columns, isFirstPage = false }: TemplateProps) => {
       >
         {isFirstPage && <Header />}
 
-        <div
-          className="flex-1 space-y-4 p-custom"
-          style={{ backgroundColor: hexToRgb(primaryColor, 0.2) }}
-        >
+        <div className="flex-1" style={{ backgroundColor: hexToRgb(primaryColor, 0.2) }}>
           {sidebar.map((section) => (
             <Fragment key={section}>{mapSectionToComponent(section)}</Fragment>
           ))}
@@ -597,11 +594,9 @@ export const Gengar = ({ columns, isFirstPage = false }: TemplateProps) => {
       </div>
 
       <div className={cn("main group", sidebar.length > 0 ? "col-span-2" : "col-span-3")}>
-        <div className="space-y-4 p-custom">
-          {main.map((section) => (
-            <Fragment key={section}>{mapSectionToComponent(section)}</Fragment>
-          ))}
-        </div>
+        {main.map((section) => (
+          <Fragment key={section}>{mapSectionToComponent(section)}</Fragment>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

This PR addresses a CSS layout regression in the **Gengar** template where the background summary section had gaps and did not extend to the edges as expected. With the fix, the PDF output matches the template's sample image.

## Related Issues

Fixes #2463

## Screenshots

### Before
<img width="794" height="670" alt="image" src="https://github.com/user-attachments/assets/6f0ee82f-ada2-493b-9fe3-719e9f7cb4f5" />

### After
<img width="792" height="701" alt="image" src="https://github.com/user-attachments/assets/4d2dfc38-10c1-4e90-9d1c-e60c3a9226b1" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized spacing and padding in template layouts, removing redundant styling containers while maintaining consistent design presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->