### PR TITLE
feat(builder): arrange sidebar builder depending on section type in template #2564

### DIFF
--- a/src/dialogs/resume/template/data.ts
+++ b/src/dialogs/resume/template/data.ts
@@ -2,18 +2,12 @@ import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import type { Template } from "@/schema/templates";
 
-export enum SidebarType {
-	NO_SIDEBAR,
-	LEFT,
-	RIGHT,
-}
-
 export type TemplateMetadata = {
 	name: string;
 	description: MessageDescriptor;
 	imageUrl: string;
 	tags: string[];
-	sideBarType: SidebarType;
+	sidebarPosition: "left" | "right" | "none";
 };
 
 export const templates = {
@@ -22,90 +16,90 @@ export const templates = {
 		description: msg`Two-column with a bold colored sidebar and skill bars; great for creative or tech roles where visual flair is welcome.`,
 		imageUrl: "/templates/jpg/azurill.jpg",
 		tags: ["Two-column", "Creative", "Tech", "Visual flair"],
-		sideBarType: SidebarType.LEFT,
+		sidebarPosition: "left",
 	},
 	bronzor: {
 		name: "Bronzor",
 		description: msg`Two-column, clean and professional with subtle section dividers; suits corporate, finance, or consulting positions.`,
 		imageUrl: "/templates/jpg/bronzor.jpg",
 		tags: ["Two-column", "Clean", "Professional", "Corporate", "Finance", "Consulting"],
-		sideBarType: SidebarType.LEFT,
+		sidebarPosition: "none",
 	},
 	chikorita: {
 		name: "Chikorita",
 		description: msg`Two-column with a soft header accent and circular profile photo; ideal for marketing, HR, or client-facing roles.`,
 		imageUrl: "/templates/jpg/chikorita.jpg",
 		tags: ["Two-column", "Soft accent", "Marketing", "HR", "Client-facing"],
-		sideBarType: SidebarType.RIGHT,
+		sidebarPosition: "right",
 	},
 	ditgar: {
 		name: "Ditgar",
 		description: msg`Two-column with a dark teal sidebar and skills grid; modern feel for developers, data scientists, or technical PMs.`,
 		imageUrl: "/templates/jpg/ditgar.jpg",
 		tags: ["Two-column", "Modern", "Developer", "Data science", "Technical PM", "Dark sidebar"],
-		sideBarType: SidebarType.LEFT,
+		sidebarPosition: "left",
 	},
 	ditto: {
 		name: "Ditto",
 		description: msg`Two-column, minimal and text-dense with no decorative elements; perfect for traditional industries or ATS-heavy applications.`,
 		imageUrl: "/templates/jpg/ditto.jpg",
 		tags: ["Two-column", "ATS friendly", "Minimal", "Text-dense", "Traditional", "No decoration"],
-		sideBarType: SidebarType.LEFT,
+		sidebarPosition: "left",
 	},
 	gengar: {
 		name: "Gengar",
 		description: msg`Two-column with accent colors and clean typography; balanced choice for business analysts or operations roles.`,
 		imageUrl: "/templates/jpg/gengar.jpg",
 		tags: ["Two-column", "Accent colors", "Clean typography", "Business analyst", "Operations"],
-		sideBarType: SidebarType.LEFT,
+		sidebarPosition: "left",
 	},
 	glalie: {
 		name: "Glalie",
 		description: msg`Two-column, minimal with light gray sidebar and subtle icons; professional and understated for legal, finance, or executive roles.`,
 		imageUrl: "/templates/jpg/glalie.jpg",
 		tags: ["Two-column", "Minimal", "Professional", "Legal", "Finance", "Executive", "Understated"],
-		sideBarType: SidebarType.LEFT,
+		sidebarPosition: "left",
 	},
 	kakuna: {
 		name: "Kakuna",
 		description: msg`Single-column with a magenta left border accent; compact and efficient for entry-level or internship applications.`,
 		imageUrl: "/templates/jpg/kakuna.jpg",
 		tags: ["Single-column", "ATS friendly", "Compact", "Efficient", "Entry level", "Internship", "Magenta accent"],
-		sideBarType: SidebarType.NO_SIDEBAR,
+		sidebarPosition: "none",
 	},
 	lapras: {
 		name: "Lapras",
 		description: msg`Single-column; polished and serious for senior or enterprise-level positions.`,
 		imageUrl: "/templates/jpg/lapras.jpg",
 		tags: ["Single-column", "ATS friendly", "Polished", "Senior", "Enterprise"],
-		sideBarType: SidebarType.NO_SIDEBAR,
+		sidebarPosition: "none",
 	},
 	leafish: {
 		name: "Leafish",
 		description: msg`Two-column with a muted color sidebar; earthy and calm, suits sustainability, healthcare, or nonprofit sectors.`,
 		imageUrl: "/templates/jpg/leafish.jpg",
 		tags: ["Two-column", "Muted sidebar", "Earthy", "Calm", "Sustainability", "Healthcare", "Nonprofit"],
-		sideBarType: SidebarType.RIGHT,
+		sidebarPosition: "right",
 	},
 	onyx: {
 		name: "Onyx",
 		description: msg`Single-column with a sidebar and clean grid layout; versatile for any professional or technical role.`,
 		imageUrl: "/templates/jpg/onyx.jpg",
 		tags: ["Single-column", "ATS friendly", "Sidebar", "Grid layout", "Versatile", "Professional", "Technical"],
-		sideBarType: SidebarType.NO_SIDEBAR,
+		sidebarPosition: "none",
 	},
 	pikachu: {
 		name: "Pikachu",
 		description: msg`Two-column with a left margin color; simple and approachable for creative, editorial, or junior roles.`,
 		imageUrl: "/templates/jpg/pikachu.jpg",
 		tags: ["Two-column", "Simple", "Creative", "Editorial", "Junior", "Accent colors"],
-		sideBarType: SidebarType.LEFT,
+		sidebarPosition: "left",
 	},
 	rhyhorn: {
 		name: "Rhyhorn",
 		description: msg`Single-column with a minimal top header and lots of whitespace; clean and modern for designers or content creators.`,
 		imageUrl: "/templates/jpg/rhyhorn.jpg",
 		tags: ["Single-column", "ATS friendly", "Minimal", "Clean", "Modern", "Designer", "Content creator", "Whitespace"],
-		sideBarType: SidebarType.NO_SIDEBAR,
+		sidebarPosition: "none",
 	},
 } as const satisfies Record<Template, TemplateMetadata>;


### PR DESCRIPTION
The current layout of the section management in the left-hand menu often mirrors the template structure incorrectly. In most templates, the Skills section is on the left and Work Experience is on the right, but the menu currently shows them in reverse order. This inconsistency can be confusing for users.

This PR aligns the column arrangement in the menu with the actual visual representation in the CV templates.

Changes:
- UI Alignment: Swapped/Adjusted the column order in the section management menu to match the template layouts.
- Consistency: Ensured that the mental model of "left side in menu = left side on CV" holds true across the application.

Related Issues
Closes [#2564](https://github.com/amruthpillai/reactive-resume/issues/2564)