### PR TITLE
Fix OAuth Issues

### DIFF
--- a/src/components/user/dropdown-menu.tsx
+++ b/src/components/user/dropdown-menu.tsx
@@ -60,7 +60,7 @@ export function UserDropdownMenu({ children }: Props) {
 		});
 	}
 
-	if (!session) return null;
+	if (!session?.user) return null;
 
 	return (
 		<DropdownMenu>


### PR DESCRIPTION
Fixes GitHub OAuth sign-in for legacy accounts and prevents a user dropdown rendering error.

The GitHub OAuth profile mapping now checks for existing user accounts by their username or display username, reusing their stored account ID and email to ensure sign-in works correctly after a migration. Additionally, the user dropdown is guarded against rendering when `session.user` is undefined, preventing a runtime error.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f9be6f8-4834-4565-b373-ea82db75c55d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f9be6f8-4834-4565-b373-ea82db75c55d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

