### PR TITLE
fix: remove empty keywords spacing in interests items

### DIFF
--- a/src/components/resume/shared/items/interests-item.tsx
+++ b/src/components/resume/shared/items/interests-item.tsx
@@ -16,9 +16,11 @@ export function InterestsItem({ className, ...item }: InterestsItemProps) {
 			</div>
 
 			{/* Keywords */}
-			<span className="section-item-keywords interests-item-keywords inline-block opacity-80">
-				{item.keywords.join(", ")}
-			</span>
+			{item.keywords.length > 0 && (
+				<span className="section-item-keywords interests-item-keywords inline-block opacity-80">
+					{item.keywords.join(", ")}
+				</span>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
Only render keywords fields when they contain values in interests items.

Same solution as #2626 in the interests section.