### PR TITLE
fix(layout): handle text overflow in sidebar/footer elements

### DIFF
--- a/src/routes/dashboard/-components/sidebar.tsx
+++ b/src/routes/dashboard/-components/sidebar.tsx
@@ -179,7 +179,7 @@ export function DashboardSidebar() {
 							animate={{ y: 0, height: "auto", opacity: 1 }}
 							exit={{ y: 50, height: 0, opacity: 0 }}
 						>
-							<Copyright className="shrink-0 text-nowrap p-2" />
+							<Copyright className="shrink-0 break-words whitespace-normal p-2" />
 						</motion.div>
 					)}
 				</AnimatePresence>


### PR DESCRIPTION
What does this PR do? This PR replaces truncate / text-nowrap with break-words whitespace-normal to improve text wrapping in the sidebar and footer sections.

Why is this needed? The current layout often hides information or breaks the design when using languages with specific characteristics:

Finnish: Contains very long compound words without spaces, which previously got cut off.

Indonesian: Often has long addresses or descriptions that need to wrap to the next line naturally.

Japanese: Uses characters without standard spacing, causing layout breaks in narrow containers.

How was it tested? I verified the changes using dummy data in the languages mentioned above. The text now wraps correctly to the next line and breaks long words only when necessary to fit the container.

Screenshoots:

Finnish

before
<img width="670" height="136" alt="before-finnish" src="https://github.com/user-attachments/assets/453904b8-4179-44f4-9f4d-b8030920f214" />

after
![after-finnish](https://github.com/user-attachments/assets/914c9668-ff34-40b4-916c-773c26bf646a)


Japanese

before
![before-japanese](https://github.com/user-attachments/assets/86bef113-8220-42a4-a362-ae93ebc61677)

after
![after-japanese](https://github.com/user-attachments/assets/acad521d-5596-42c3-94a5-31b9ab366f51)

Indonesian

before
![before-indonesian](https://github.com/user-attachments/assets/3755e4f3-1e6a-425a-a82a-470e39329a3a)

after
![after-indonesian](https://github.com/user-attachments/assets/d603520e-e8bd-42d7-b92c-d3a9f8119be4)

