### PR TITLE
fix: remove redundant resume- prefix from download filename, page spacing

### DIFF
--- a/src/routes/$username/$slug.tsx
+++ b/src/routes/$username/$slug.tsx
@@ -79,7 +79,7 @@ function RouteComponent() {
 			<div
 				className={cn("mx-auto max-w-[210mm]", "print:m-0 print:block print:max-w-full print:px-0", "md:my-4 md:px-4")}
 			>
-				<ResumePreview pageClassName="print:w-full! w-full max-w-full" />
+				<ResumePreview className="space-y-4" pageClassName="print:w-full! w-full max-w-full" />
 			</div>
 
 			<Button


### PR DESCRIPTION
Hi there! Love your work. Been self-hosting your app for a while now.                                                                                                                     
   
Two commits for you to consider:

### ${resume.name}.pdf
One thing I noticed is that `resume-` is hardcoded into the download filename starting in v5. Since users already name their resumes, this can lead to redundant filenames or UI/UX frustrations best avoided: forcing trasnformation of filenames without warning the user.

My resumes downloaded as `resume-Jacob-Resume.pdf` after migrating.

Small change, just drops the prefix so downloads use the resume name as-is. Would you be open to this?

### className="space-y-4"
I've workshopped my resume around to other folks, mentors and recruiters, and the first comment they typically have to say is "Oh, where's the page spacing?!?!" :)

The shared link view currently renders multi-page resumes with pages stacked flush against each other, which makes it difficult to tell where one ends and the next begins. This seems to trip up the folks I share my resume with. Would you consider this commit?


<img width="713" height="839" alt="before" src="https://github.com/user-attachments/assets/56b70d6e-62b8-4858-9c0a-34aa49c4c68d" />
<img width="589" height="829" alt="after padding" src="https://github.com/user-attachments/assets/84501f4a-00ac-4504-ad7b-b42496d70672" />