### PR TITLE
fix: bold formatting not visible in rich text editor

### DIFF
--- a/src/components/input/rich-input.module.css
+++ b/src/components/input/rich-input.module.css
@@ -167,11 +167,11 @@
 	}
 
 	strong {
-		font-weight: var(--page-body-font-weight-bold);
+		font-weight: var(--page-body-font-weight-bold, bold);
 	}
 
 	a {
-		font-weight: var(--page-body-font-weight-bold);
+		font-weight: var(--page-body-font-weight-bold, bold);
 		text-decoration: underline;
 		text-underline-offset: 0.15rem;
 	}


### PR DESCRIPTION
## Problem

When applying bold formatting in the rich text editor (e.g. Experience summary), the text does **not** appear visually bold inside the editor. However, after saving, the rendered resume output correctly shows bold text.

## Root Cause

In `src/components/input/rich-input.module.css`, the `.editor_content` class styles `<strong>` elements using:

```css
strong {
  font-weight: var(--page-body-font-weight-bold);
}
```

The CSS variable `--page-body-font-weight-bold` is only injected by `use-css-variables.tsx`, which runs in the **resume preview** context. In the **editor UI**, this variable is never defined, so `var(--page-body-font-weight-bold)` silently resolves to nothing — leaving `<strong>` text without any visible weight change.

## Fix

Add a `bold` fallback to the CSS variable for both `strong` and `a` elements:

```css
strong {
  font-weight: var(--page-body-font-weight-bold, bold);
}

a {
  font-weight: var(--page-body-font-weight-bold, bold);
}
```

This ensures bold text renders correctly in the editor while still respecting the resume theme's custom font-weight when available.

Fixes #2730