### PR TITLE
Resolve PDF download issue in offline mode

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -30,7 +30,7 @@ export function downloadWithAnchor(blob: Blob, filename: string) {
 	a.click();
 	document.body.removeChild(a);
 
-	setTimeout(() => URL.revokeObjectURL(url), 500);
+	setTimeout(() => URL.revokeObjectURL(url), 5000);
 }
 
 export async function downloadFromUrl(url: string, filename: string) {


### PR DESCRIPTION
## Description

This PR fixes an issue where PDF download fails in offline mode when running the app via Docker.

## Problem

When running the application offline (e.g., using Docker without internet access), 
the `setTimeout` delay of 500ms before triggering `downloadWithAnchor` was too short.

As a result: 
The download always returned error because of the timeout

## Solution: 
 Increased the timeout duration to allow sufficient time for the PDF to be prepared

## How to Reproduce

1. Run the app using Docker
3. Attempt to download a PDF
4. Observe that download may fail with the previous 500ms delay

## How to Test

1. Run the app in Docker (offline mode)
2. Download a PDF
3. Confirm that the file downloads successfully