### PR TITLE
fix(printer): make PDF margins match resume background color

### DIFF
--- a/src/integrations/orpc/services/printer.ts
+++ b/src/integrations/orpc/services/printer.ts
@@ -135,10 +135,15 @@ export const printerService = {
 			const isFreeForm = format === "free-form";
 
 			const contentHeight = await page.evaluate(
-				(marginY: number, isFreeForm: boolean, minPageHeight: number) => {
+				(marginY: number, isFreeForm: boolean, minPageHeight: number, backgroundColor: string) => {
 					const root = document.documentElement;
+					const body = document.body;
 					const pageElements = document.querySelectorAll("[data-page-index]");
 					const container = document.querySelector(".resume-preview-container") as HTMLElement | null;
+
+					// Ensure PDF margins inherit the resume background color instead of defaulting to white.
+					root.style.backgroundColor = backgroundColor;
+					body.style.backgroundColor = backgroundColor;
 
 					if (isFreeForm) {
 						// For free-form: add visual gaps between pages, then measure total height
@@ -193,6 +198,7 @@ export const printerService = {
 				marginY,
 				isFreeForm,
 				pageDimensionsAsPixels[format].height,
+				data.metadata.design.colors.background,
 			);
 
 			// Step 6: Generate the PDF with the specified dimensions and margins


### PR DESCRIPTION
## Summary
- set the HTML and body print background color to the resume background before PDF generation
- ensure Puppeteer margin areas inherit the same background color as the page design

## Why
Issue #2741 reports PDF margins rendering as white for templates that apply margins via Puppeteer instead of CSS padding (for example Kakuna).

## Validation
- `pnpm typecheck`
- `pnpm exec biome check src/integrations/orpc/services/printer.ts`

Fixes #2741
