### PR TITLE
fix(printer): make PDF margins match resume background color

### DIFF
--- a/src/integrations/orpc/services/printer.ts
+++ b/src/integrations/orpc/services/printer.ts
@@ -180,7 +180,10 @@ export const printerService = {
 								pageContent.style.paddingLeft = `${pagePaddingX}pt`;
 								pageContent.style.paddingRight = `${pagePaddingX}pt`;
 							}
-							if (pagePaddingY > 0) pageContent.style.paddingTop = `${pagePaddingY}pt`;
+							if (pagePaddingY > 0) {
+								pageContent.style.paddingTop = `${pagePaddingY}pt`;
+								pageContent.style.paddingBottom = `${pagePaddingY}pt`;
+							}
 						}
 					}
 


### PR DESCRIPTION
## Summary
- set the HTML and body print background color to the resume background before PDF generation
- ensure Puppeteer margin areas inherit the same background color as the page design
- fix a bug where when content wrapped across pages it would not add the margin correctly at the bottom of the previous page

## Why
Issue #2741 reports PDF margins rendering as white for templates that apply margins via Puppeteer instead of CSS padding (for example Kakuna).

## Validation
- `pnpm typecheck`
- `pnpm exec biome check src/integrations/orpc/services/printer.ts`
- Created a lorem ipsum CV with dark background, for reference, here are the files created with the changes in this PR applied:
[lorem-ipsum_20260303_2305.json](https://github.com/user-attachments/files/25727836/lorem-ipsum_20260303_2305.json)
[lorem-ipsum_20260303_2305.pdf](https://github.com/user-attachments/files/25727837/lorem-ipsum_20260303_2305.pdf)


Fixes #2741
