### PR TITLE
fix(experience): remove bold from role titles and tighten role spacing

### DIFF
--- a/src/components/resume/shared/items/experience-item.tsx
+++ b/src/components/resume/shared/items/experience-item.tsx
@@ -45,11 +45,11 @@ export function ExperienceItem({ className, ...item }: ExperienceItemProps) {
 
 			{/* Role Progression */}
 			{hasRoles && (
-				<div className="experience-item-roles mt-(--page-gap-y) flex flex-col gap-y-(--page-gap-y)">
+				<div className="experience-item-roles mt-0 flex flex-col gap-y-1">
 					{item.roles.map((role) => (
 						<div key={role.id} className="experience-item-role">
 							<div className="flex items-start justify-between gap-x-2">
-								<strong className="section-item-metadata experience-item-role-position">{role.position}</strong>
+								<span className="section-item-metadata experience-item-role-position">{role.position}</span>
 								<span className="section-item-metadata experience-item-role-period shrink-0 text-end">
 									{role.period}
 								</span>


### PR DESCRIPTION
Following the merge of the role progression feature (#2761), two visual issues were present:

- Role position titles were rendering in bold (`<strong>` tag) making them visually heavier than intended
- Spacing between the company header and first role was too large due to the `mt-(--page-gap-y)` class

- Replaced `<strong>` with `<span>` for role position titles to match the weight of other metadata
- Changed role list top margin from `mt-(--page-gap-y)` to `mt-0` for tighter, more natural grouping under the company header

Tested locally on dev server