### PR TITLE
feat: Allow sidebar button list to scroll internally on overflow

### DIFF
--- a/src/routes/builder/$resumeId/-components/edge.tsx
+++ b/src/routes/builder/$resumeId/-components/edge.tsx
@@ -9,7 +9,7 @@ export function BuilderSidebarEdge({ side, children }: Props) {
 	return (
 		<div
 			className={cn(
-				"absolute inset-y-0 hidden w-12 flex-col items-center justify-between bg-popover py-2.5 sm:flex",
+				"absolute inset-y-0 hidden min-h-0 w-12 flex-col items-center overflow-hidden bg-popover py-2.5 sm:flex",
 				side === "left" ? "inset-s-0 border-r" : "inset-e-0 border-l",
 			)}
 		>

--- a/src/routes/builder/$resumeId/-sidebar/left/index.tsx
+++ b/src/routes/builder/$resumeId/-sidebar/left/index.tsx
@@ -88,32 +88,34 @@ function SidebarEdge({ scrollAreaRef }: SidebarEdgeProps) {
 
 	return (
 		<BuilderSidebarEdge side="left">
-			<div />
+			<div className="flex min-h-0 w-full flex-1 flex-col items-center gap-y-2 overflow-hidden">
+				<div className="no-scrollbar min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden">
+					<div className="flex min-h-full flex-col items-center justify-center gap-y-2">
+						{leftSidebarSections.map((section) => (
+							<Button
+								key={section}
+								size="icon"
+								variant="ghost"
+								title={getSectionTitle(section)}
+								onClick={() => scrollToSection(section)}
+							>
+								{getSectionIcon(section)}
+							</Button>
+						))}
+					</div>
+				</div>
 
-			<div className="flex flex-col justify-center gap-y-2">
-				{leftSidebarSections.map((section) => (
-					<Button
-						key={section}
-						size="icon"
-						variant="ghost"
-						title={getSectionTitle(section)}
-						onClick={() => scrollToSection(section)}
-					>
-						{getSectionIcon(section)}
-					</Button>
-				))}
+				<UserDropdownMenu>
+					{({ session }) => (
+						<Button size="icon" variant="ghost">
+							<Avatar className="size-6">
+								<AvatarImage src={session.user.image ?? undefined} />
+								<AvatarFallback className="text-[0.5rem]">{getInitials(session.user.name)}</AvatarFallback>
+							</Avatar>
+						</Button>
+					)}
+				</UserDropdownMenu>
 			</div>
-
-			<UserDropdownMenu>
-				{({ session }) => (
-					<Button size="icon" variant="ghost">
-						<Avatar className="size-6">
-							<AvatarImage src={session.user.image ?? undefined} />
-							<AvatarFallback className="text-[0.5rem]">{getInitials(session.user.name)}</AvatarFallback>
-						</Avatar>
-					</Button>
-				)}
-			</UserDropdownMenu>
 		</BuilderSidebarEdge>
 	);
 }

--- a/src/routes/builder/$resumeId/-sidebar/right/index.tsx
+++ b/src/routes/builder/$resumeId/-sidebar/right/index.tsx
@@ -83,9 +83,8 @@ function SidebarEdge({ scrollAreaRef }: SidebarEdgeProps) {
 
 	return (
 		<BuilderSidebarEdge side="right">
-			<div />
-
-			<div className="flex flex-col justify-center gap-y-2">
+			<div className="no-scrollbar min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden">
+				<div className="flex min-h-full flex-col items-center justify-center gap-y-2">
 				{rightSidebarSections.map((section) => (
 					<Button
 						key={section}
@@ -98,8 +97,7 @@ function SidebarEdge({ scrollAreaRef }: SidebarEdgeProps) {
 					</Button>
 				))}
 			</div>
-
-			<div />
+			</div>
 		</BuilderSidebarEdge>
 	);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -131,6 +131,14 @@
 	aspect-ratio: 1 / 1.4142;
 }
 
+@utility no-scrollbar {
+	scrollbar-width: none;
+
+	&::-webkit-scrollbar {
+		display: none;
+	}
+}
+
 @layer base {
 	* {
 		@apply border-border outline-ring/50 min-w-0;


### PR DESCRIPTION
fixed #2790 

Problem
Currently, the sidebar lacks proper overflow handling for the button list, which negatively impacts the UI aesthetics when the window height is insufficient.

Solution
I have updated the sidebar layout logic to handle vertical constraints better:
- Fixed Bottom: The user menu button is now fixed to the bottom of the sidebar.
- Adaptive Alignment: The remaining buttons are vertically centered when there is sufficient screen height.
- Scroll Support: When vertical height is insufficient, the button list becomes scrollable via the mouse wheel (internal scrolling).

before:
![chrome-capture-2026-03-07](https://github.com/user-attachments/assets/d44f2386-1d52-4794-a470-98038de77d60)

after:
![chrome-capture-2026-03-07 (1)](https://github.com/user-attachments/assets/ab1d78a5-5bb5-4b11-81c7-a968e333c6c0)
