### PR TITLE
fix: Fix unnecessary scrollbar appearing on the right sidebar

### DIFF
--- a/src/routes/builder/$resumeId/-sidebar/right/index.tsx
+++ b/src/routes/builder/$resumeId/-sidebar/right/index.tsx
@@ -47,7 +47,7 @@ export function BuilderSidebarRight() {
 		<>
 			<SidebarEdge scrollAreaRef={scrollAreaRef} />
 
-			<ScrollArea ref={scrollAreaRef} className="@container h-[calc(100svh-3.5rem)] bg-background sm:me-12">
+			<ScrollArea ref={scrollAreaRef} className="@container h-[calc(100svh-3.5rem)] bg-background overflow-hidden sm:me-12">
 				<div className="space-y-4 p-4">
 					{rightSidebarSections.map((section) => (
 						<Fragment key={section}>


### PR DESCRIPTION
Problem
Currently, expanding the Page and Custom CSS sections can cause the `ScrollArea Root` to overflow. This results in the entire right sidebar overflowing and displaying an unwanted scrollbar.

Crucially, this affects interaction: when a user tries to drag items of the Layout section in this state, it causes the whole sidebar to move instead of scrolling internally within the `ScrollArea`.

Reproduction:

- When other sections are expanded but Page and Custom CSS are collapsed, no scrollbar appears.
- However, if either Page or Custom CSS is expanded alongside other long sections, the sidebar scrollbar appears.

Solution
Applied `overflow: hidden` to constrain the right sidebar's `ScrollArea`, ensuring scrolling only happens internally.

before:
![chrome-capture-2026-03-07 (2)](https://github.com/user-attachments/assets/a666892a-65ab-4ab4-ad7a-dc21af0b8bea)

after:
![chrome-capture-2026-03-07 (3)](https://github.com/user-attachments/assets/0e4965de-5a5b-425e-9960-68c6deb590bc)
