### PR TITLE
Fix: bold text not visible in resume preview

### DIFF
--- a/src/components/resume/hooks/use-css-variables.tsx
+++ b/src/components/resume/hooks/use-css-variables.tsx
@@ -13,10 +13,19 @@ export const useCSSVariables = ({ picture, metadata }: UseCssVariablesProps) => 
     const lowestBodyFontWeight = Math.min(...metadata.typography.body.fontWeights.map(Number));
     const lowestHeadingFontWeight = Math.min(...metadata.typography.heading.fontWeights.map(Number));
 
-    const highestBodyFontWeight = Math.max(...metadata.typography.body.fontWeights.map(Number));
-    const highestHeadingFontWeight = Math.max(...metadata.typography.heading.fontWeights.map(Number));
+    const rawHighestBodyFontWeight = Math.max(...metadata.typography.body.fontWeights.map(Number));
+    const rawHighestHeadingFontWeight = Math.max(...metadata.typography.heading.fontWeights.map(Number));
 
-    return { lowestBodyFontWeight, lowestHeadingFontWeight, highestBodyFontWeight, highestHeadingFontWeight };
+    const highestBodyFontWeight = rawHighestBodyFontWeight <= lowestBodyFontWeight ? 700 : rawHighestBodyFontWeight;
+    const highestHeadingFontWeight =
+      rawHighestHeadingFontWeight <= lowestHeadingFontWeight ? 700 : rawHighestHeadingFontWeight;
+
+    return {
+      lowestBodyFontWeight,
+      lowestHeadingFontWeight,
+      highestBodyFontWeight,
+      highestHeadingFontWeight,
+    };
   }, [metadata.typography.body.fontWeights, metadata.typography.heading.fontWeights]);
 
   return {


### PR DESCRIPTION

This pull request updates the logic for determining the highest font weights in the `useCSSVariables` hook to handle cases where the highest and lowest font weights are equal or invalid. Now, if the highest font weight is less than or equal to the lowest, it defaults to 700, ensuring more robust and predictable typography styling.

**Typography font weight calculation improvements:**

* Updated the calculation of `highestBodyFontWeight` and `highestHeadingFontWeight` in `useCSSVariables` to default to 700 if the highest value is less than or equal to the lowest, improving handling of edge cases in font weight arrays.

Fixes #2843 
