### PR TITLE
fix: prevent desktop horizontal overflow in home hero

### DIFF
--- a/src/routes/_home/-sections/hero.tsx
+++ b/src/routes/_home/-sections/hero.tsx
@@ -13,7 +13,7 @@ export function Hero() {
   return (
     <section
       id="hero"
-      className="relative flex min-h-svh w-svw flex-col items-center justify-center overflow-hidden border-b py-24"
+      className="relative flex min-h-svh w-full flex-col items-center justify-center overflow-hidden border-b py-24"
     >
       <Spotlight />
 


### PR DESCRIPTION
Quick fix to solve the horizontal overflow issue on the Startpage.