### PR TITLE
Add description field to interests section

### DIFF
--- a/src/components/resume/shared/items/interests-item.tsx
+++ b/src/components/resume/shared/items/interests-item.tsx
@@ -23,6 +23,15 @@ export function InterestsItem({ className, ...item }: InterestsItemProps) {
           {item.keywords.join(", ")}
         </span>
       )}
+
+      {/* Description */}
+      {item.description && (
+        <div
+          className="section-item-description interests-item-description opacity-80"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: item.description }}
+        />
+      )}
     </div>
   );
 }

--- a/src/dialogs/resume/sections/interest.tsx
+++ b/src/dialogs/resume/sections/interest.tsx
@@ -10,6 +10,7 @@ import type { DialogProps } from "@/dialogs/store";
 
 import { ChipInput } from "@/components/input/chip-input";
 import { IconPicker } from "@/components/input/icon-picker";
+import { RichInput } from "@/components/input/rich-input";
 import { useResumeStore } from "@/components/resume/store/resume";
 import { Button } from "@/components/ui/button";
 import { DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -38,6 +39,7 @@ export function CreateInterestDialog({ data }: DialogProps<"resume.sections.inte
       icon: data?.item?.icon ?? "acorn",
       name: data?.item?.name ?? "",
       keywords: data?.item?.keywords ?? [],
+      description: data?.item?.description ?? "",
     },
   });
 
@@ -91,6 +93,7 @@ export function UpdateInterestDialog({ data }: DialogProps<"resume.sections.inte
       icon: data.item.icon,
       name: data.item.name,
       keywords: data.item.keywords,
+      description: data.item.description ?? "",
     },
   });
 
@@ -181,6 +184,20 @@ function InterestForm() {
               <Trans>Keywords</Trans>
             </FormLabel>
             <FormControl render={<ChipInput {...field} />} />
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="description"
+        render={({ field }) => (
+          <FormItem className="col-span-full">
+            <FormLabel>
+              <Trans>Description</Trans>
+            </FormLabel>
+            <FormControl render={<RichInput {...field} value={field.value} onChange={field.onChange} />} />
             <FormMessage />
           </FormItem>
         )}

--- a/src/schema/resume/data.ts
+++ b/src/schema/resume/data.ts
@@ -169,6 +169,10 @@ export const interestItemSchema = baseItemSchema.extend({
     .array(z.string())
     .catch([])
     .describe("The keywords associated with the interest/hobby, if any. These are displayed as tags below the name."),
+  description: z
+    .string()
+    .catch("")
+    .describe("A free-text description of the interest/hobby. Supports HTML formatting."),
 });
 
 export const languageItemSchema = baseItemSchema.extend({


### PR DESCRIPTION
**Problem:** The interests section stores content as a keywords array which renders as a comma-joined string, making it impossible to write free-form sentences without commas being misinterpreted as keyword separators.

**Solution:** Added an optional description rich text field to the interests item schema, mirroring the pattern used in experience and other sections. The form now includes a Tiptap rich text editor for the description field, and the render component displays it when present.

<img width="653" height="322" alt="interests_keywords_current" src="https://github.com/user-attachments/assets/ba0e867e-7610-4ad6-92f8-9e9a1ad2b49f" />
<img width="662" height="466" alt="interests_description_new" src="https://github.com/user-attachments/assets/61984139-7a4e-4aea-ae42-6152a8a0fbce" />
