### PR TITLE
feat: add Zen (OpenCode.ai) as AI provider

### DIFF
--- a/src/integrations/ai/store.ts
+++ b/src/integrations/ai/store.ts
@@ -4,7 +4,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { create } from "zustand/react";
 
-export type AIProvider = "vercel-ai-gateway" | "openai" | "gemini" | "anthropic" | "ollama";
+export type AIProvider = "vercel-ai-gateway" | "openai" | "gemini" | "anthropic" | "ollama" | "zen";
 
 type TestStatus = "unverified" | "success" | "failure";
 

--- a/src/integrations/orpc/services/ai.ts
+++ b/src/integrations/orpc/services/ai.ts
@@ -195,7 +195,7 @@ function normalizeResumeDataForSchema(data: Record<string, unknown>) {
   return { ...data, sections: normalizedSections };
 }
 
-export const aiProviderSchema = z.enum(["ollama", "openai", "gemini", "anthropic", "vercel-ai-gateway"]);
+export const aiProviderSchema = z.enum(["ollama", "openai", "gemini", "anthropic", "vercel-ai-gateway", "zen"]);
 
 type AIProvider = z.infer<typeof aiProviderSchema>;
 
@@ -209,6 +209,21 @@ type GetModelInput = {
 const MAX_AI_FILE_BYTES = 10 * 1024 * 1024; // 10MB
 const MAX_AI_FILE_BASE64_CHARS = Math.ceil((MAX_AI_FILE_BYTES * 4) / 3) + 4;
 
+function getZenModel({ model, apiKey, baseURL }: { model: string; apiKey: string; baseURL: string }) {
+  const lowerModel = model.toLowerCase();
+
+  if (lowerModel.startsWith("claude")) {
+    return createAnthropic({ apiKey, baseURL }).languageModel(model);
+  }
+
+  if (lowerModel.startsWith("gemini")) {
+    return createGoogleGenerativeAI({ apiKey, baseURL }).languageModel(model);
+  }
+
+  // GPT, o1, o3, o4 and all other models use the OpenAI-compatible endpoint
+  return createOpenAI({ apiKey, baseURL }).chat(model);
+}
+
 function getModel(input: GetModelInput) {
   const { provider, model, apiKey } = input;
   const baseURL = input.baseURL || undefined;
@@ -219,6 +234,7 @@ function getModel(input: GetModelInput) {
     .with("anthropic", () => createAnthropic({ apiKey, baseURL }).languageModel(model))
     .with("vercel-ai-gateway", () => createGateway({ apiKey, baseURL }).languageModel(model))
     .with("gemini", () => createGoogleGenerativeAI({ apiKey, baseURL }).languageModel(model))
+    .with("zen", () => getZenModel({ model, apiKey, baseURL: baseURL || "https://opencode.ai/zen/v1" }))
     .exhaustive();
 }
 

--- a/src/routes/dashboard/settings/ai.tsx
+++ b/src/routes/dashboard/settings/ai.tsx
@@ -56,6 +56,12 @@ const providerOptions: (ComboboxOption<AIProvider> & { defaultBaseURL: string })
     keywords: ["gemini", "google", "bard"],
     defaultBaseURL: "https://generativelanguage.googleapis.com/v1beta",
   },
+  {
+    value: "zen",
+    label: "Zen (OpenCode.ai)",
+    keywords: ["zen", "opencode", "gateway"],
+    defaultBaseURL: "https://opencode.ai/zen/v1",
+  },
 ];
 
 function AIForm() {


### PR DESCRIPTION
## Summary

- Adds [Zen](https://opencode.ai) (by OpenCode.ai) as a new AI provider, a curated AI gateway with ~41 optimized models including GPT, Claude, Gemini, Qwen, MiniMax, and more.
- Zen uses **different native API formats per model family**, so the implementation intelligently routes based on the model name prefix:
  - `claude*` models → Anthropic SDK
  - `gemini*` models → Google Generative AI SDK
  - All others (GPT, Qwen, MiniMax, GLM, Kimi, etc.) → OpenAI-compatible SDK
- All routes point to `https://opencode.ai/zen/v1` — **no new dependencies required**.

## Changes

- `src/integrations/ai/store.ts` — Added `"zen"` to the `AIProvider` type union.
- `src/integrations/orpc/services/ai.ts` — Added `"zen"` to the Zod provider schema, added `getZenModel()` function with model family routing, and wired it into `getModel()`.
- `src/routes/dashboard/settings/ai.tsx` — Added "Zen (OpenCode.ai)" to the provider combobox options.

## Test plan

- [ ] Select "Zen (OpenCode.ai)" as the AI provider in Dashboard > Settings > AI
- [ ] Enter a Zen API key and a Claude model name (e.g., `claude-sonnet-4`) — verify it routes through Anthropic SDK
- [ ] Enter a Gemini model name (e.g., `gemini-3-flash`) — verify it routes through Google SDK
- [ ] Enter a GPT model name (e.g., `gpt-5`) — verify it routes through OpenAI SDK
- [ ] Click "Test Connection" and verify it succeeds for each model family
- [ ] Enable AI features and test: chat, PDF/DOCX import, resume analysis, and resume tailoring
- [ ] Verify other providers still work as expected