### PR TITLE
fix: align role period text to end in experience item (#2876)

### DIFF
--- a/src/components/resume/shared/items/experience-item.tsx
+++ b/src/components/resume/shared/items/experience-item.tsx
@@ -70,7 +70,7 @@ export function ExperienceItem({ className, ...item }: ExperienceItemProps) {
             <div key={role.id} className="experience-item-role">
               <div className="grid grid-cols-2 items-start justify-between gap-x-2">
                 <div className="section-item-metadata experience-item-role-position">{role.position}</div>
-                <div className="section-item-metadata experience-item-role-period">{role.period}</div>
+                <div className="section-item-metadata experience-item-role-period text-end">{role.period}</div>
               </div>
 
               {stripHtml(role.description) && (


### PR DESCRIPTION
# Fix: Align role period text in experience items with multiple roles
Closes #2876 

# Problem
When an experience entry uses Role Progression (multiple roles at the same company), the period/date for each role is left-aligned in the two-column grid layout. This causes the date to appear off-center instead of right-aligned under the location field.

This affects all templates (since ExperienceItem is a shared component), and appears in the editor preview, shared links, and exported PDFs.

Single-role experience entries are unaffected — their period is already correctly right-aligned via text-end on the header container.

Screenshot from issue (credit: @rick-cross): Multiple roles → period drifts left; single role → period correctly right-aligned.

# Root Cause
In the Role Progression section, position and period are laid out using grid grid-cols-2. The second column (experience-item-role-period) has no text alignment specified, so it defaults to text-align: start (left), while the single-role header uses text-end.

# Scope
1 file changed: `src/components/resume/shared/items/experience-item.tsx`
All 13 templates benefit from this fix (shared component)
No breaking changes — single-role entries are unaffected (different render branch)
