### PR TITLE
fix: reduce preview wheel zoom sensitivity

### DIFF
--- a/src/routes/builder/$resumeId/index.tsx
+++ b/src/routes/builder/$resumeId/index.tsx
@@ -27,7 +27,7 @@ function RouteComponent() {
 
   return (
     <div className="fixed inset-0">
-      <TransformWrapper centerOnInit limitToBounds={false} minScale={0.3} initialScale={0.6} maxScale={6}>
+      <TransformWrapper centerOnInit limitToBounds={false} minScale={0.3} initialScale={0.6} maxScale={6} wheel={{ step: 0.001 }}>
         <TransformComponent wrapperClass="h-full! w-full!">
           <ResumePreview
             showPageNumbers


### PR DESCRIPTION
I noticed that the builder preview currently relies on the default `react-zoom-pan-pinch` wheel behavior, which makes the preview inconvenient to use with a mouse wheel.

This addresses the preview zoom issue mentioned in #2899.

## Changes

Sets an explicit wheel zoom step on the builder `TransformWrapper`:

```tsx
wheel={{ step: 0.001 }}
```