### PR TITLE
fix(i18n): translate Skills section title to Chinese (zh-CN)

### DIFF
--- a/locales/zh-CN.po
+++ b/locales/zh-CN.po
@@ -3078,7 +3078,7 @@ msgstr "大小"
 #: src/dialogs/resume/sections/custom.tsx
 #: src/utils/resume/section.tsx
 msgid "Skills"
-msgstr "Skills"
+msgstr "技能"
 
 #: src/routes/dashboard/job-search/-components/tailor-dialog.tsx
 msgid "Skip"


### PR DESCRIPTION
Closes #2930 

`locales/zh-CN.po` was missing the Chinese translation for the `Skills` msgid, so the **Skills** section heading rendered as the English word "Skills" under the Simplified Chinese UI — while every other section title was correctly localized.

```diff
 msgid "Skills"
-msgstr "Skills"
+msgstr "技能"
```

Translation chosen to match the existing `zh-TW` entry (`技能`).
