### PR TITLE
Fixed Printer issues in linux self-hosted deployments

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -24,6 +24,8 @@ services:
     restart: unless-stopped
     networks:
       - printer_network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - QUEUED=10
       - HEALTH=true


### PR DESCRIPTION
Experienced issue:
When self-hosting on Linux, rx-resume is unable to contact the printer. 

Related issues:
#2924

Explanation of changes:
Setting the printer to PRINTER_APP_URL=http://host.docker.internal:3000 auto resolves in Windows and MacOS but in Linux, this only works when `extra_hosts` is configured explicitly within compose.yml for both the reactive resume and browser volumes. Currently, `extra_hosts` is set within the reactive resume volume but not within the browser volume. This PR fixes that. 