### PR TITLE
fix(ai): make testConnection prompt compatible with strict JSON-mode providers

### DIFF
--- a/src/integrations/orpc/services/ai.ts
+++ b/src/integrations/orpc/services/ai.ts
@@ -278,7 +278,7 @@ async function testConnection(input: TestConnectionInput): Promise<boolean> {
   const result = await generateText({
     model: getModel(input),
     output: Output.choice({ options: [RESPONSE_OK] }),
-    messages: [{ role: "user", content: `Respond with "${RESPONSE_OK}"` }],
+    messages: [{ role: "user", content: `Respond only with the json object {"result":"${RESPONSE_OK}"}` }],
   });
 
   return result.output === RESPONSE_OK;


### PR DESCRIPTION
## Problem

The AI Settings → "Test Connection" button fails with the toast `Could not reach the AI provider. Please try again.` for **every OpenAI-compatible provider that enforces strict JSON mode** — including OpenAI itself, DeepSeek, and providers reached through OpenRouter. The toast is misleading: the request is reaching the provider successfully and getting a `400`, but the catch in `src/integrations/orpc/router/ai.ts` maps any `AISDKError` to `BAD_GATEWAY`, hiding the real cause.

There are actually two upstream constraints that the current test prompt violates:

### 1. Missing the literal word "json"

`Output.choice` (from `ai`) emits `response_format: { type: "json_object" }`. OpenAI and DeepSeek both enforce that the prompt must contain the literal substring "json" when this response format is set. The current prompt (`Respond with "1"`) does not.

OpenRouter response when testing against `openai/gpt-4o-mini`:
```json
{"error":{"message":"'messages' must contain the word 'json' in some form, to use 'response_format' of type 'json_object'.","type":"invalid_request_error","param":"messages","code":null},"provider_name":"OpenAI"}
```

OpenRouter response when testing against `deepseek/deepseek-v4-flash`:
```json
{"error":{"message":"Prompt must contain the word 'json' in some form to use 'response_format' of type 'json_object'.","type":"invalid_request_error","code":"invalid_request_error"},"provider_name":"DeepSeek"}
```

### 2. Wrong target shape

Even after the prompt contains "json", the AI SDK's `Output.choice` validator requires the model to return an object of the form `{ result: "<one of options>" }` (the schema has `properties: { result: ... }, required: ["result"]`). A reasonable-sounding prompt like `Return a json object containing the value 1` makes the model emit `{"value": "1"}` and the SDK throws `AI_NoObjectGeneratedError: response did not match schema. Type validation failed: ... response must be an object that contains a choice value.` — confusingly worded, since the actual required key is `result`, not `choice`.

## Fix

Make the prompt explicitly request the exact JSON shape the validator expects:

```ts
messages: [{ role: "user", content: `Respond only with the json object {"result":"${RESPONSE_OK}"}` }],
```

This satisfies both constraints simultaneously:
- contains the word "json" (passes the provider-side check),
- instructs the model to emit `{"result":"1"}` directly (passes the SDK-side schema check).

## Verification

Tested against OpenRouter with `deepseek/deepseek-v4-flash`, `openai/gpt-4o-mini`, and `anthropic/claude-haiku-4-5`. All three return `{"result":"1"}` with `finish_reason: stop`, and Reactive Resume's "Test Connection" returns the success state.

Direct curl reproduction (showing only DeepSeek; the OpenAI and Anthropic routes behave identically):
```bash
curl https://openrouter.ai/api/v1/chat/completions \
  -H "Authorization: Bearer $OPENROUTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"Respond only with the json object {\"result\":\"1\"}"}],"response_format":{"type":"json_object"}}'
# -> content: {"result":"1"}
```

## Optional follow-up (out of scope for this PR)

The router (`src/integrations/orpc/router/ai.ts`) classifies any `AISDKError` as `BAD_GATEWAY`. This collapses provider-side `400`s into a "could not reach" toast, which makes future regressions of this kind very hard to diagnose. A follow-up could distinguish by `error.statusCode`: 4xx -> `BAD_REQUEST` with the provider's actual message surfaced; 5xx and network errors -> `BAD_GATEWAY`. Happy to send a separate PR for that if it's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)