### PR TITLE
fix: increase rate limit for /get-session endpoint

### DIFF
--- a/src/integrations/rate-limit/config.ts
+++ b/src/integrations/rate-limit/config.ts
@@ -5,6 +5,7 @@ export const rateLimitConfig = {
       window: 60,
       max: 60,
       customRules: {
+        "/get-session": { window: 60, max: 300 },
         "/sign-in/email": { window: 60, max: 5 },
         "/sign-up/email": { window: 60, max: 3 },
         "/request-password-reset": { window: 600, max: 3 },


### PR DESCRIPTION
## Summary

Increases the rate limit for the Better Auth `/get-session` endpoint.

## Why

The session endpoint can be called frequently during normal app usage, especially when the frontend checks or refreshes authentication state. A low rate limit may cause valid users to hit rate limiting during regular navigation or repeated session checks.

## Changes

- Increased the allowed request limit for `/get-session`.
