### PR TITLE
fix: Change PRINTER_APP_URL to enable PDF export 

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -98,7 +98,7 @@ services:
       - TZ=Etc/UTC
       - NODE_ENV=production
       - APP_URL=http://localhost:3000
-      - PRINTER_APP_URL=http://host.docker.internal:3000
+      - PRINTER_APP_URL=http://reactive_resume:3000
       # Printer
       - PRINTER_ENDPOINT=ws://browserless:3000?token=${BROWSERLESS_TOKEN:-change-me}
       # - PRINTER_ENDPOINT=http://chrome:9222 # Or, if you're using chromedp/headless-shell


### PR DESCRIPTION
# Summary

PDF export was broken. Puppeteer (running inside the Browserless Docker container) would time out waiting for the resume page to render.

## Why

Root cause: The Browserless container navigated to the app via host.docker.internal:3000.

## Changes

Use Docker service name (http://reactive_resume:3000) for PRINTER_APP_URL instead of host.docker.internal:3000
