### PR TITLE
fix(api): allow empty name in public resume output schema

### DIFF
--- a/packages/api/src/dto/resume.ts
+++ b/packages/api/src/dto/resume.ts
@@ -39,7 +39,13 @@ export const resumeDto = {
 
 	getBySlug: {
 		input: z.object({ username: z.string(), slug: z.string() }),
-		output: resumeSchema.omit({ password: true, userId: true, createdAt: true, updatedAt: true }),
+		// `name` is the owner-chosen dashboard title and is intentionally redacted
+		// to an empty string for non-owner viewers (see redactResumeForViewer in
+		// helpers/resume-access-policy.ts). Relax the `min(1)` constraint here so
+		// the redacted public response passes output validation.
+		output: resumeSchema
+			.omit({ name: true, password: true, userId: true, createdAt: true, updatedAt: true })
+			.extend({ name: z.string() }),
 	},
 
 	create: {


### PR DESCRIPTION
Fixes #3011.

## What

Relax the `name` field on the `getBySlug` output schema from `z.string().min(1)` to `z.string()`, so the redacted public response passes oRPC output validation. Ownership-gated procedures (`getById`, `update`, `patch`, `list`, etc.) keep the `min(1)` constraint - this is a one-procedure change.

## Why

`redactResumeForViewer` deliberately blanks the dashboard-title `name` for non-owner viewers (the comment in `helpers/resume-access-policy.ts` notes the title can contain owner-only context like "Senior Eng @ Foo - final draft"). But every output schema derived from `resumeSchema` inherits `name.min(1)`, so the redacted payload fails validation, oRPC throws `Output validation failed`, and every public resume URL returns HTTP 500 (rendered as 404 by the SPA shell). The entire public-share feature is broken on recent self-hosted builds.

I considered dropping the `name` redaction instead, but the existing comment makes the privacy intent explicit, so the schema is the right side to bend.

Verified locally: with this change applied, public resume URLs serve correctly to non-owner viewers; owner self-views are unaffected.