### PR TITLE
fix(pdf): register CJK fallback font so Chinese/Japanese/Korean text …

### DIFF
--- a/packages/fonts/src/index.ts
+++ b/packages/fonts/src/index.ts
@@ -184,6 +184,25 @@ export function getFallbackWebFontFamilies(family: string) {
 	return fallback === family ? [] : [fallback];
 }
 
+/**
+ * Returns a CJK web font (Noto Sans/Serif SC) to register as a glyph-level
+ * fallback for PDF rendering, or `null` when no fallback is needed
+ * (standard PDF font, or primary already is the fallback).
+ *
+ * Source Han Sans/Serif SC covers all CJK-Unified ideographs, so a single
+ * font handles Simplified/Traditional Chinese, Japanese kanji and Korean
+ * hanja — the locales reporting #2986 / #3006.
+ */
+export function getPdfCjkFallbackFontFamily(family: string): string | null {
+	if (isStandardPdfFontFamily(family)) return null;
+
+	const fallback = getPrimaryCjkWebFont(family);
+	if (fallback === family) return null;
+	if (!getWebFont(fallback)) return null;
+
+	return fallback;
+}
+
 export function getLoadableWebFontWeights(family: string, preferredWeights: string[]) {
 	const font = webFontMap.get(family);
 	if (!font) return [];

--- a/packages/pdf/src/document.tsx
+++ b/packages/pdf/src/document.tsx
@@ -1,4 +1,4 @@
-import type { LayoutPage, ResumeData } from "@reactive-resume/schema/resume/data";
+import type { LayoutPage, ResumeData, Typography } from "@reactive-resume/schema/resume/data";
 import type { Template } from "@reactive-resume/schema/templates";
 import type { ComponentType } from "react";
 import type { SectionTitleResolver } from "./section-title";
@@ -23,8 +23,13 @@ export type ResumeDocumentProps = {
 export const ResumeDocument = ({ data, template, resolveSectionTitle }: ResumeDocumentProps) => {
 	const TemplatePageComponent = getTemplatePage(template);
 	const typography = registerFonts(data.metadata.typography);
+	// `registerFonts` widens `fontFamily` to `string | string[]` for CJK
+	// fallback (#2986); the cast carries that wider runtime value through
+	// `ResumeData` without changing the public schema.
 	const resumeData =
-		typography === data.metadata.typography ? data : { ...data, metadata: { ...data.metadata, typography } };
+		typography === data.metadata.typography
+			? data
+			: { ...data, metadata: { ...data.metadata, typography: typography as unknown as Typography } };
 
 	return (
 		<RenderProvider data={resumeData} resolveSectionTitle={resolveSectionTitle}>

--- a/packages/pdf/src/hooks/use-register-fonts.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.ts
@@ -1,7 +1,12 @@
 import type { FontWeight } from "@reactive-resume/fonts";
 import type { Typography } from "@reactive-resume/schema/resume/data";
 import { Font } from "@react-pdf/renderer";
-import { getFont, getWebFontSource, isStandardPdfFontFamily } from "@reactive-resume/fonts";
+import {
+	getFont,
+	getPdfCjkFallbackFontFamily,
+	getWebFontSource,
+	isStandardPdfFontFamily,
+} from "@reactive-resume/fonts";
 
 type FontWeightRange = {
 	lowest: number;
@@ -10,6 +15,13 @@ type FontWeightRange = {
 
 const registeredFontVariants = new Set<string>();
 const fallbackFontFamily = "IBM Plex Serif";
+
+// `fontFamily` is widened to `string | string[]` so react-pdf can do
+// glyph-level font fallback for CJK characters (#2986).
+export type PdfTypography = Omit<Typography, "body" | "heading"> & {
+	body: Omit<Typography["body"], "fontFamily"> & { fontFamily: string | string[] };
+	heading: Omit<Typography["heading"], "fontFamily"> & { fontFamily: string | string[] };
+};
 
 const getFontWeightRange = (fontWeights: string[]): FontWeightRange => {
 	const numericWeights = fontWeights.map(Number).filter((weight) => Number.isFinite(weight));
@@ -53,7 +65,7 @@ const resolvePdfTypography = (typography: Typography): Typography => {
 	};
 };
 
-export const registerFonts = (typography: Typography): Typography => {
+export const registerFonts = (typography: Typography): PdfTypography => {
 	Font.registerHyphenationCallback((word) => [word]);
 
 	const pdfTypography = resolvePdfTypography(typography);
@@ -84,5 +96,32 @@ export const registerFonts = (typography: Typography): Typography => {
 		registerFont(headingFontFamily, headingRange.highest, italic);
 	}
 
-	return pdfTypography;
+	// Register a CJK fallback so textkit can substitute per-codepoint for
+	// characters the primary font lacks (#2986). One weight is enough —
+	// substitution is per-codepoint, not per-weight.
+	const bodyCjkFallback = getPdfCjkFallbackFontFamily(bodyFontFamily);
+	const headingCjkFallback = getPdfCjkFallbackFontFamily(headingFontFamily);
+
+	if (bodyCjkFallback) {
+		registerFont(bodyCjkFallback, 400, false);
+	}
+	if (headingCjkFallback && headingCjkFallback !== bodyCjkFallback) {
+		registerFont(headingCjkFallback, 400, false);
+	}
+
+	// Latin-only path: no fallback registered, return as-is.
+	if (!bodyCjkFallback && !headingCjkFallback) {
+		return pdfTypography as PdfTypography;
+	}
+
+	const bodyStack: string | string[] = bodyCjkFallback ? [bodyFontFamily, bodyCjkFallback] : bodyFontFamily;
+	const headingStack: string | string[] = headingCjkFallback
+		? [headingFontFamily, headingCjkFallback]
+		: headingFontFamily;
+
+	return {
+		...pdfTypography,
+		body: { ...pdfTypography.body, fontFamily: bodyStack },
+		heading: { ...pdfTypography.heading, fontFamily: headingStack },
+	};
 };


### PR DESCRIPTION
@amruthpillai 

## Summary

Fixes #2986. Restores correct rendering of Chinese / Japanese / Korean text in the PDF preview and export by registering a CJK-capable font as a glyph-level fallback alongside the user-selected typography.

| Before | After |
|---|---|
|<img width="621" height="101" alt="image" src="https://github.com/user-attachments/assets/1ca67667-3742-425c-bf6d-aff2f422633e" />|<img width="621" height="101" alt="image" src="https://github.com/user-attachments/assets/0de4365c-d1b6-4995-99ef-ad53fa49515f" />|

## Root cause

Since v5.1.0 the renderer was migrated from Puppeteer to `@react-pdf/renderer`. The new pipeline (`packages/pdf/src/hooks/use-register-fonts.ts`) only registers the user-selected typography family — Roboto, IBM Plex Serif, Open Sans, etc. — none of which contain CJK glyphs.

When the resume contains a CJK character:

1. The `<Text>` is styled with `fontFamily: 'Roboto'` (a single string).
2. `@react-pdf/renderer`'s textkit layer looks up each codepoint in Roboto.
3. Roboto has no glyph for the CJK codepoint → it falls back to `.notdef`.
4. The PDF is rendered with `.notdef` glyphs for every CJK character, which look like garbled boxes.

There was no CJK fallback registered, and `fontFamily` was always passed as a single string, so textkit's per-codepoint substitution path was never engaged.

## Fix

`@react-pdf/renderer`'s textkit layer **already supports per-codepoint font substitution** when a `<Text>` is styled with `fontFamily` as a **string array** — provided every family in the stack has actually been `Font.register()`-ed. This PR wires that up:

### 1. `packages/fonts` — pick the right CJK fallback

New helper `getPdfCjkFallbackFontFamily(family)`:

- Returns **`Noto Sans SC`** for sans-serif primary fonts, **`Noto Serif SC`** for serif primary fonts (matches the visual style).
- Returns **`null`** when no fallback is needed:
  - primary is a standard PDF font (Helvetica / Courier / Times) — Latin-only by design;
  - primary is already the resolved CJK fallback;
  - the resolved fallback isn't actually shipped as a webfont.
- Source Han Sans/Serif SC covers all CJK-Unified ideographs, so a single font handles **Simplified Chinese, Traditional Chinese, Japanese kanji, and Korean hanja** — i.e. all the locales reporting #2986 / #3006.

### 2. `packages/pdf/hooks/use-register-fonts` — register the fallback and widen the stack

After registering the primary body/heading fonts as before, additionally `Font.register(...)` the resolved CJK fallback. Only **regular weight** is registered for the fallback — substitution is per-codepoint, not per-weight, so a single face covers headings and body at any weight (one extra ~8 MB file, vs. registering all six weight/italic combinations).

The function's return type is widened to a new `PdfTypography` whose `body.fontFamily` and `heading.fontFamily` become a `[primary, cjkFallback]` two-element stack.

### 3. `packages/pdf/document` — propagate the widened type

A cast carries the widened runtime value back through `ResumeData` without changing the public `Typography` schema. All 15 templates already read `metadata.typography.body.fontFamily` directly, and `StyleSheet.fontFamily` accepts both `string` and `string[]`, so **no template edits are required**.

## Why this is safe for existing (Latin-only) users

- For standard PDF fonts (Helvetica/Courier/Times) and resumes whose primary already is a CJK font, `getPdfCjkFallbackFontFamily` returns `null`, so no extra `Font.register` call is made.
- When no fallback applies, `registerFonts` returns the **original typography reference unchanged** (zero allocation, identical to current behaviour).
- Even when the fallback is registered, textkit's `fontSubstitution` only consults it for codepoints the primary font cannot render. Latin glyphs continue to come from the primary font with identical metrics — a Roboto resume looks pixel-identical to before.

## Testing

- ✅ Reproduced the original bug on `main` with a Simplified Chinese resume (Azurill / Onyx / Chikorita templates) — characters rendered as garbled boxes.
- ✅ With this branch, the same resume renders correctly in both the live preview and the exported PDF.
- ✅ Existing Latin-only resumes render identically (verified visually against `main`).
- ✅ `pnpm lint` clean, `pnpm typecheck` clean for `packages/pdf` and `packages/fonts`.

## Known follow-up (out of scope for this PR)

While verifying the fix I noticed a separate, narrower issue: when a resume has typography **`lineHeight` set below ~1.35** _and_ contains CJK content, the descenders of CJK glyphs (e.g. 育, 实, 程) are visually clipped by the next line. Resumes at the default `lineHeight` of 1.5 are unaffected.

Root cause is independent of this PR: textkit computes the line box from the primary (Latin) font's ascent/descent, but Source Han Sans/Serif SC glyphs nearly fill the em-box, so a tightened line-height causes the glyph to extend past its line box. Browsers handle this transparently via mixed-script line-box rules, react-pdf does not.

This only manifests *because* CJK glyphs now render at all (i.e. it was masked by the original `.notdef` rendering). I will open a separate issue + PR for it once this one lands so the two changes can be reviewed independently.

## Notes

- The CJK font is downloaded lazily by `@react-pdf/renderer` on first render that needs it, so users who never have CJK content pay no bandwidth or memory cost.
