### PR TITLE
Fix award title and date layout

### DIFF
--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -610,6 +610,8 @@ const AwardsSection = ({
 	const data = useRender();
 	const awards = sectionData ?? data.sections.awards;
 	const items = getVisibleItems(awards);
+	const splitRowStyle = useTemplateStyle("splitRow");
+	const alignRightStyle = useTemplateStyle("alignRight");
 
 	if (items.length === 0) return null;
 
@@ -619,9 +621,11 @@ const AwardsSection = ({
 				{items.map((item) => (
 					<SectionItem key={item.id}>
 						<SectionItemHeader>
-							<ItemTitle website={item.website}>{item.title}</ItemTitle>
+							<View style={composeStyles(splitRowStyle)}>
+								<ItemTitle website={item.website}>{item.title}</ItemTitle>
+								<Small style={composeStyles(alignRightStyle)}>{item.date}</Small>
+							</View>
 							<Text>{item.awarder}</Text>
-							<Small>{item.date}</Small>
 						</SectionItemHeader>
 						<RichText>{item.description}</RichText>
 

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -188,6 +188,12 @@ const stackedSidebarSplitRowStyle = {
 	alignItems: "flex-start",
 } satisfies Style;
 
+const awardTitleDateRowStyle = {
+	flexDirection: "row",
+	alignItems: "flex-start",
+	justifyContent: "space-between",
+} satisfies Style;
+
 const useSectionSplitRowStyle = () => {
 	const splitRowStyle = useTemplateStyle("splitRow");
 	const placement = useTemplatePlacement();
@@ -621,7 +627,7 @@ const AwardsSection = ({
 				{items.map((item) => (
 					<SectionItem key={item.id}>
 						<SectionItemHeader>
-							<View style={composeStyles(splitRowStyle)}>
+							<View style={composeStyles(splitRowStyle, awardTitleDateRowStyle)}>
 								<ItemTitle website={item.website}>{item.title}</ItemTitle>
 								<Small style={composeStyles(alignRightStyle)}>{item.date}</Small>
 							</View>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Keep award title and date on the same row in the shared PDF awards renderer.
- Leave the awarder directly below the title/date row and preserve description and website rendering.
- Force the award title/date row to remain inline even in templates whose sidebar split rows normally stack.

### Testing
- `pnpm --filter @reactive-resume/pdf typecheck`
- `pnpm exec biome check packages/pdf/src/templates/shared/sections.tsx`
- `pnpm --filter @reactive-resume/pdf test`
- One-off rendered PDF verification for all 14 templates in both main and sidebar placements. Log: [award_layout_check.log](https://cursor.com/artifacts/c/art-865d1858-0eae-4584-8b5c-99754f8f62bd)
<!-- CURSOR_AGENT_PR_BODY_END -->

### Resolves Issues
- fixes #3028

