### PR TITLE
Fix split row right content promotion

### DIFF
--- a/packages/pdf/src/templates/shared/meta-line.tsx
+++ b/packages/pdf/src/templates/shared/meta-line.tsx
@@ -1,9 +1,0 @@
-import { Small } from "./primitives";
-
-export const MetaLine = ({ children }: { children: Array<string | undefined> }) => {
-	const content = children.filter(Boolean).join(" • ");
-
-	if (!content) return null;
-
-	return <Small>{content}</Small>;
-};

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -40,6 +40,7 @@ import { getTemplateMetrics } from "./metrics";
 import { Bold, Div, Heading, Icon, Link, Small, Text } from "./primitives";
 import { RichText } from "./rich-text";
 import { getInlineItemWebsiteUrl, shouldRenderSeparateItemWebsite } from "./section-links";
+import { hasSplitRowText, promoteBottomRightWhenTopRightMissing } from "./split-row";
 import { composeStyles } from "./styles";
 
 type SectionItemsContextValue = {
@@ -331,6 +332,10 @@ const ExperienceSection = ({
 				{items.map((item) => {
 					const hasPosition = Boolean(item.position.trim());
 					const hasLocation = Boolean(item.location.trim());
+					const { topRight: headerLocation, bottomRight: headerPeriod } = promoteBottomRightWhenTopRightMissing({
+						topRight: item.location,
+						bottomRight: item.period,
+					});
 
 					const renderInlineHeader = () => (
 						<InlineItemHeader
@@ -352,13 +357,15 @@ const ExperienceSection = ({
 						<>
 							<View style={composeStyles(splitRowStyle)}>
 								<ItemTitle website={item.website}>{item.company}</ItemTitle>
-								<Text style={composeStyles(alignRightStyle)}>{item.location}</Text>
+								{hasSplitRowText(headerLocation) && (
+									<Text style={composeStyles(alignRightStyle)}>{headerLocation}</Text>
+								)}
 							</View>
 
-							{item.roles.length === 0 && (
+							{item.roles.length === 0 && (hasPosition || hasSplitRowText(headerPeriod)) && (
 								<View style={composeStyles(splitRowStyle)}>
-									<Text>{item.position}</Text>
-									<Text style={composeStyles(alignRightStyle)}>{item.period}</Text>
+									{hasPosition && <Text>{item.position}</Text>}
+									{hasSplitRowText(headerPeriod) && <Text style={composeStyles(alignRightStyle)}>{headerPeriod}</Text>}
 								</View>
 							)}
 						</>
@@ -368,7 +375,7 @@ const ExperienceSection = ({
 						<SectionItem key={item.id}>
 							<SectionItemHeader>{inlineItemHeader ? renderInlineHeader() : renderSplitHeader()}</SectionItemHeader>
 
-							{item.roles.length > 0 && <MetaLine>{[item.period]}</MetaLine>}
+							{item.roles.length > 0 && <MetaLine>{[headerPeriod]}</MetaLine>}
 
 							{item.roles.map((role) => (
 								<View key={role.id}>
@@ -416,6 +423,11 @@ const EducationSection = ({
 					const gradeAndLocation = [item.grade, item.location].filter(Boolean).join(" • ");
 					const hasArea = Boolean(item.area.trim());
 					const hasDegree = Boolean(item.degree.trim());
+					const { topRight: headerDegreeAndGrade, bottomRight: headerLocationAndPeriod } =
+						promoteBottomRightWhenTopRightMissing({
+							topRight: degreeAndGrade,
+							bottomRight: locationAndPeriod,
+						});
 
 					const renderInlineHeader = () => (
 						<>
@@ -440,13 +452,19 @@ const EducationSection = ({
 						<>
 							<View style={composeStyles(splitRowStyle)}>
 								<ItemTitle website={item.website}>{item.school}</ItemTitle>
-								<Text style={composeStyles(alignRightStyle)}>{degreeAndGrade}</Text>
+								{hasSplitRowText(headerDegreeAndGrade) && (
+									<Text style={composeStyles(alignRightStyle)}>{headerDegreeAndGrade}</Text>
+								)}
 							</View>
 
-							<View style={composeStyles(splitRowStyle)}>
-								<Text>{item.area}</Text>
-								<Text style={composeStyles(alignRightStyle)}>{locationAndPeriod}</Text>
-							</View>
+							{(hasArea || hasSplitRowText(headerLocationAndPeriod)) && (
+								<View style={composeStyles(splitRowStyle)}>
+									{hasArea && <Text>{item.area}</Text>}
+									{hasSplitRowText(headerLocationAndPeriod) && (
+										<Text style={composeStyles(alignRightStyle)}>{headerLocationAndPeriod}</Text>
+									)}
+								</View>
+							)}
 						</>
 					);
 
@@ -728,31 +746,40 @@ const VolunteerSection = ({
 	return (
 		<SectionShell sectionId={sectionId} title={volunteer.title}>
 			<SectionItems columns={volunteer.columns}>
-				{items.map((item) => (
-					<SectionItem key={item.id}>
-						<SectionItemHeader>
-							{inlineItemHeader ? (
-								<InlineItemHeader
-									leading={<Text>{item.location}</Text>}
-									middle={<ItemTitle website={item.website}>{item.organization}</ItemTitle>}
-									trailing={<Text style={composeStyles(alignRightStyle)}>{item.period}</Text>}
-								/>
-							) : (
-								<>
-									<View style={composeStyles(splitRowStyle)}>
-										<ItemTitle website={item.website}>{item.organization}</ItemTitle>
-										<Text style={composeStyles(alignRightStyle)}>{item.location}</Text>
-									</View>
+				{items.map((item) => {
+					const { topRight: headerLocation, bottomRight: headerPeriod } = promoteBottomRightWhenTopRightMissing({
+						topRight: item.location,
+						bottomRight: item.period,
+					});
 
-									<MetaLine>{[item.period]}</MetaLine>
-								</>
-							)}
-						</SectionItemHeader>
-						<RichText>{item.description}</RichText>
+					return (
+						<SectionItem key={item.id}>
+							<SectionItemHeader>
+								{inlineItemHeader ? (
+									<InlineItemHeader
+										leading={hasSplitRowText(item.location) ? <Text>{item.location}</Text> : null}
+										middle={<ItemTitle website={item.website}>{item.organization}</ItemTitle>}
+										trailing={<Text style={composeStyles(alignRightStyle)}>{item.period}</Text>}
+									/>
+								) : (
+									<>
+										<View style={composeStyles(splitRowStyle)}>
+											<ItemTitle website={item.website}>{item.organization}</ItemTitle>
+											{hasSplitRowText(headerLocation) && (
+												<Text style={composeStyles(alignRightStyle)}>{headerLocation}</Text>
+											)}
+										</View>
 
-						<ItemWebsiteLink website={item.website} />
-					</SectionItem>
-				))}
+										<MetaLine>{[headerPeriod]}</MetaLine>
+									</>
+								)}
+							</SectionItemHeader>
+							<RichText>{item.description}</RichText>
+
+							<ItemWebsiteLink website={item.website} />
+						</SectionItem>
+					);
+				})}
 			</SectionItems>
 		</SectionShell>
 	);

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -35,12 +35,11 @@ import {
 } from "./context";
 import { filterItems, hasVisibleItems, isSectionVisible, isVisibleSummary } from "./filtering";
 import { LevelDisplay } from "./level-display";
-import { MetaLine } from "./meta-line";
 import { getTemplateMetrics } from "./metrics";
 import { Bold, Div, Heading, Icon, Link, Small, Text } from "./primitives";
 import { RichText } from "./rich-text";
 import { getInlineItemWebsiteUrl, shouldRenderSeparateItemWebsite } from "./section-links";
-import { hasSplitRowText, promoteBottomRightWhenTopRightMissing } from "./split-row";
+import { hasSplitRowText, promoteSplitRowRight } from "./split-row";
 import { composeStyles } from "./styles";
 
 type SectionItemsContextValue = {
@@ -196,8 +195,8 @@ const awardTitleDateRowStyle = {
 } satisfies Style;
 
 const useSectionSplitRowStyle = () => {
-	const splitRowStyle = useTemplateStyle("splitRow");
 	const placement = useTemplatePlacement();
+	const splitRowStyle = useTemplateStyle("splitRow");
 	const stackSidebarItemHeader = useTemplateFeature("stackSidebarItemHeader");
 
 	return composeStyles(
@@ -332,9 +331,9 @@ const ExperienceSection = ({
 				{items.map((item) => {
 					const hasPosition = Boolean(item.position.trim());
 					const hasLocation = Boolean(item.location.trim());
-					const { topRight: headerLocation, bottomRight: headerPeriod } = promoteBottomRightWhenTopRightMissing({
-						topRight: item.location,
-						bottomRight: item.period,
+					const { top: headerLocation, bottom: headerPeriod } = promoteSplitRowRight({
+						top: item.location,
+						bottom: item.period,
 					});
 
 					const renderInlineHeader = () => (
@@ -375,7 +374,7 @@ const ExperienceSection = ({
 						<SectionItem key={item.id}>
 							<SectionItemHeader>{inlineItemHeader ? renderInlineHeader() : renderSplitHeader()}</SectionItemHeader>
 
-							{item.roles.length > 0 && <MetaLine>{[headerPeriod]}</MetaLine>}
+							{item.roles.length > 0 && <Text>{item.period}</Text>}
 
 							{item.roles.map((role) => (
 								<View key={role.id}>
@@ -423,11 +422,10 @@ const EducationSection = ({
 					const gradeAndLocation = [item.grade, item.location].filter(Boolean).join(" • ");
 					const hasArea = Boolean(item.area.trim());
 					const hasDegree = Boolean(item.degree.trim());
-					const { topRight: headerDegreeAndGrade, bottomRight: headerLocationAndPeriod } =
-						promoteBottomRightWhenTopRightMissing({
-							topRight: degreeAndGrade,
-							bottomRight: locationAndPeriod,
-						});
+					const { top: headerDegreeAndGrade, bottom: headerLocationAndPeriod } = promoteSplitRowRight({
+						top: degreeAndGrade,
+						bottom: locationAndPeriod,
+					});
 
 					const renderInlineHeader = () => (
 						<>
@@ -647,7 +645,7 @@ const AwardsSection = ({
 						<SectionItemHeader>
 							<View style={composeStyles(splitRowStyle, awardTitleDateRowStyle)}>
 								<ItemTitle website={item.website}>{item.title}</ItemTitle>
-								<Small style={composeStyles(alignRightStyle)}>{item.date}</Small>
+								<Text style={composeStyles(alignRightStyle)}>{item.date}</Text>
 							</View>
 							<Text>{item.awarder}</Text>
 						</SectionItemHeader>
@@ -671,6 +669,8 @@ const CertificationsSection = ({
 	const data = useRender();
 	const certifications = sectionData ?? data.sections.certifications;
 	const items = getVisibleItems(certifications, "certifications");
+	const splitRowStyle = useSectionSplitRowStyle();
+	const alignRightStyle = useTemplateStyle("alignRight");
 
 	if (items.length === 0) return null;
 
@@ -680,10 +680,13 @@ const CertificationsSection = ({
 				{items.map((item) => (
 					<SectionItem key={item.id}>
 						<SectionItemHeader>
-							<ItemTitle website={item.website}>{item.title}</ItemTitle>
+							<View style={composeStyles(splitRowStyle)}>
+								<ItemTitle website={item.website}>{item.title}</ItemTitle>
+								<Text style={composeStyles(alignRightStyle)}>{item.date}</Text>
+							</View>
 							<Text>{item.issuer}</Text>
-							<Small>{item.date}</Small>
 						</SectionItemHeader>
+
 						<RichText>{item.description}</RichText>
 
 						<ItemWebsiteLink website={item.website} />
@@ -704,6 +707,8 @@ const PublicationsSection = ({
 	const data = useRender();
 	const publications = sectionData ?? data.sections.publications;
 	const items = getVisibleItems(publications, "publications");
+	const splitRowStyle = useSectionSplitRowStyle();
+	const alignRightStyle = useTemplateStyle("alignRight");
 
 	if (items.length === 0) return null;
 
@@ -713,10 +718,14 @@ const PublicationsSection = ({
 				{items.map((item) => (
 					<SectionItem key={item.id}>
 						<SectionItemHeader>
-							<ItemTitle website={item.website}>{item.title}</ItemTitle>
+							<View style={composeStyles(splitRowStyle)}>
+								<ItemTitle website={item.website}>{item.title}</ItemTitle>
+								<Text style={composeStyles(alignRightStyle)}>{item.date}</Text>
+							</View>
+
 							<Text>{item.publisher}</Text>
-							<Small>{item.date}</Small>
 						</SectionItemHeader>
+
 						<RichText>{item.description}</RichText>
 
 						<ItemWebsiteLink website={item.website} />
@@ -747,11 +756,6 @@ const VolunteerSection = ({
 		<SectionShell sectionId={sectionId} title={volunteer.title}>
 			<SectionItems columns={volunteer.columns}>
 				{items.map((item) => {
-					const { topRight: headerLocation, bottomRight: headerPeriod } = promoteBottomRightWhenTopRightMissing({
-						topRight: item.location,
-						bottomRight: item.period,
-					});
-
 					return (
 						<SectionItem key={item.id}>
 							<SectionItemHeader>
@@ -765,12 +769,12 @@ const VolunteerSection = ({
 									<>
 										<View style={composeStyles(splitRowStyle)}>
 											<ItemTitle website={item.website}>{item.organization}</ItemTitle>
-											{hasSplitRowText(headerLocation) && (
-												<Text style={composeStyles(alignRightStyle)}>{headerLocation}</Text>
+											{hasSplitRowText(item.period) && (
+												<Text style={composeStyles(alignRightStyle)}>{item.period}</Text>
 											)}
 										</View>
 
-										<MetaLine>{[headerPeriod]}</MetaLine>
+										<Text>{item.location}</Text>
 									</>
 								)}
 							</SectionItemHeader>
@@ -806,7 +810,7 @@ const ReferencesSection = ({
 						<SectionItemHeader>
 							<ItemTitle website={item.website}>{item.name}</ItemTitle>
 							<Text>{item.position}</Text>
-							<MetaLine>{[item.phone]}</MetaLine>
+							<Text>{item.phone}</Text>
 						</SectionItemHeader>
 						<RichText>{item.description}</RichText>
 

--- a/packages/pdf/src/templates/shared/split-row.test.ts
+++ b/packages/pdf/src/templates/shared/split-row.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hasSplitRowText, promoteBottomRightWhenTopRightMissing } from "./split-row";
+import { hasSplitRowText, promoteSplitRowRight } from "./split-row";
 
 describe("hasSplitRowText", () => {
 	it("returns true only for non-empty text", () => {
@@ -9,40 +9,19 @@ describe("hasSplitRowText", () => {
 	});
 });
 
-describe("promoteBottomRightWhenTopRightMissing", () => {
+describe("promoteSplitRowRight", () => {
 	it("keeps both right cells when the top-right cell has content", () => {
-		expect(
-			promoteBottomRightWhenTopRightMissing({
-				topRight: "Remote",
-				bottomRight: "2019 - 2024",
-			}),
-		).toEqual({
-			topRight: "Remote",
-			bottomRight: "2019 - 2024",
+		expect(promoteSplitRowRight({ top: "Remote", bottom: "2019 - 2024" })).toEqual({
+			top: "Remote",
+			bottom: "2019 - 2024",
 		});
 	});
 
 	it("moves bottom-right content to the top right when top-right content is missing", () => {
-		expect(
-			promoteBottomRightWhenTopRightMissing({
-				topRight: "",
-				bottomRight: "2019 - 2024",
-			}),
-		).toEqual({
-			topRight: "2019 - 2024",
-			bottomRight: "",
-		});
+		expect(promoteSplitRowRight({ top: "", bottom: "2019 - 2024" })).toEqual({ top: "2019 - 2024", bottom: "" });
 	});
 
 	it("treats whitespace-only cells as missing", () => {
-		expect(
-			promoteBottomRightWhenTopRightMissing({
-				topRight: "   ",
-				bottomRight: "\t",
-			}),
-		).toEqual({
-			topRight: "",
-			bottomRight: "",
-		});
+		expect(promoteSplitRowRight({ top: "   ", bottom: "\t" })).toEqual({ top: "", bottom: "" });
 	});
 });

--- a/packages/pdf/src/templates/shared/split-row.test.ts
+++ b/packages/pdf/src/templates/shared/split-row.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { hasSplitRowText, promoteBottomRightWhenTopRightMissing } from "./split-row";
+
+describe("hasSplitRowText", () => {
+	it("returns true only for non-empty text", () => {
+		expect(hasSplitRowText("2019 - 2024")).toBe(true);
+		expect(hasSplitRowText("   ")).toBe(false);
+		expect(hasSplitRowText(undefined)).toBe(false);
+	});
+});
+
+describe("promoteBottomRightWhenTopRightMissing", () => {
+	it("keeps both right cells when the top-right cell has content", () => {
+		expect(
+			promoteBottomRightWhenTopRightMissing({
+				topRight: "Remote",
+				bottomRight: "2019 - 2024",
+			}),
+		).toEqual({
+			topRight: "Remote",
+			bottomRight: "2019 - 2024",
+		});
+	});
+
+	it("moves bottom-right content to the top right when top-right content is missing", () => {
+		expect(
+			promoteBottomRightWhenTopRightMissing({
+				topRight: "",
+				bottomRight: "2019 - 2024",
+			}),
+		).toEqual({
+			topRight: "2019 - 2024",
+			bottomRight: "",
+		});
+	});
+
+	it("treats whitespace-only cells as missing", () => {
+		expect(
+			promoteBottomRightWhenTopRightMissing({
+				topRight: "   ",
+				bottomRight: "\t",
+			}),
+		).toEqual({
+			topRight: "",
+			bottomRight: "",
+		});
+	});
+});

--- a/packages/pdf/src/templates/shared/split-row.ts
+++ b/packages/pdf/src/templates/shared/split-row.ts
@@ -1,0 +1,20 @@
+type SplitRowRightContent = {
+	topRight: string;
+	bottomRight: string;
+};
+
+export const hasSplitRowText = (value: string | undefined): value is string => {
+	return typeof value === "string" && value.trim().length > 0;
+};
+
+export const promoteBottomRightWhenTopRightMissing = ({
+	topRight,
+	bottomRight,
+}: SplitRowRightContent): SplitRowRightContent => {
+	if (hasSplitRowText(topRight)) return { topRight, bottomRight: hasSplitRowText(bottomRight) ? bottomRight : "" };
+
+	return {
+		topRight: hasSplitRowText(bottomRight) ? bottomRight : "",
+		bottomRight: "",
+	};
+};

--- a/packages/pdf/src/templates/shared/split-row.ts
+++ b/packages/pdf/src/templates/shared/split-row.ts
@@ -1,20 +1,11 @@
-type SplitRowRightContent = {
-	topRight: string;
-	bottomRight: string;
-};
-
 export const hasSplitRowText = (value: string | undefined): value is string => {
 	return typeof value === "string" && value.trim().length > 0;
 };
 
-export const promoteBottomRightWhenTopRightMissing = ({
-	topRight,
-	bottomRight,
-}: SplitRowRightContent): SplitRowRightContent => {
-	if (hasSplitRowText(topRight)) return { topRight, bottomRight: hasSplitRowText(bottomRight) ? bottomRight : "" };
+type SplitRowContent = { top: string; bottom: string };
 
-	return {
-		topRight: hasSplitRowText(bottomRight) ? bottomRight : "",
-		bottomRight: "",
-	};
+export const promoteSplitRowRight = ({ top, bottom }: SplitRowContent): SplitRowContent => {
+	if (hasSplitRowText(top)) return { top, bottom: hasSplitRowText(bottom) ? bottom : "" };
+
+	return { top: hasSplitRowText(bottom) ? bottom : "", bottom: "" };
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Promote bottom-right split-row content into the top-right cell when the top-right cell is empty.
- Apply the rule to shared experience, education, and volunteer section rendering across templates that use split rows.
- Add focused tests for the split-row promotion helper.

## Testing
- `corepack pnpm --filter @reactive-resume/pdf test -- src/templates/shared/split-row.test.ts`
- `corepack pnpm --filter @reactive-resume/pdf typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb812a18-2c49-46c7-a146-9e141a0452cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb812a18-2c49-46c7-a146-9e141a0452cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

