### PR TITLE
fix(pdf): prevent empty Profiles background bleed in Ditgar and Gengar templates

### DIFF
--- a/packages/pdf/src/templates/ditgar/DitgarPage.tsx
+++ b/packages/pdf/src/templates/ditgar/DitgarPage.tsx
@@ -7,7 +7,7 @@ import { parseColorString, rgbaStringToHex } from "@reactive-resume/utils/color"
 import { useRender } from "../../context";
 import { CustomFieldContactItem, WebsiteContactItem } from "../shared/contact-item";
 import { TemplateProvider } from "../shared/context";
-import { filterSections } from "../shared/filtering";
+import { filterSections, splitFirstVisibleSection } from "../shared/filtering";
 import { getTemplateMetrics } from "../shared/metrics";
 import { getTemplatePageMinHeightStyle, getTemplatePageSize } from "../shared/page-size";
 import { hasTemplatePicture } from "../shared/picture";
@@ -52,9 +52,11 @@ export const DitgarPage = ({ page, pageIndex }: TemplatePageProps) => {
 	const showHeader = pageIndex === 0;
 	const showSidebar = !page.fullWidth || showHeader;
 	const sidebarSections = filterSections(page.sidebar, data);
-	const mainSections = filterSections(page.main, data);
-	const specialMainSection = showHeader ? mainSections[0] : undefined;
-	const regularMainSections = showHeader ? mainSections.slice(1) : mainSections;
+	const mainSectionGroups = showHeader
+		? splitFirstVisibleSection(page.main, data)
+		: { firstSection: undefined, remainingSections: filterSections(page.main, data) };
+	const specialMainSection = mainSectionGroups.firstSection;
+	const regularMainSections = mainSectionGroups.remainingSections;
 
 	return (
 		<Page size={pageSize} style={composeStyles(styles.page, pageMinHeightStyle)}>

--- a/packages/pdf/src/templates/gengar/GengarPage.tsx
+++ b/packages/pdf/src/templates/gengar/GengarPage.tsx
@@ -7,7 +7,7 @@ import { parseColorString, rgbaStringToHex } from "@reactive-resume/utils/color"
 import { useRender } from "../../context";
 import { CustomFieldContactItem, WebsiteContactItem } from "../shared/contact-item";
 import { TemplateProvider } from "../shared/context";
-import { filterSections } from "../shared/filtering";
+import { filterSections, splitFirstVisibleSection } from "../shared/filtering";
 import { getTemplateMetrics } from "../shared/metrics";
 import { getTemplatePageMinHeightStyle, getTemplatePageSize } from "../shared/page-size";
 import { hasTemplatePicture } from "../shared/picture";
@@ -47,9 +47,11 @@ export const GengarPage = ({ page, pageIndex }: TemplatePageProps) => {
 	const showHeader = pageIndex === 0;
 	const showSidebar = !page.fullWidth || showHeader;
 	const sidebarSections = filterSections(page.sidebar, data);
-	const mainSections = filterSections(page.main, data);
-	const specialMainSection = showHeader ? mainSections[0] : undefined;
-	const regularMainSections = showHeader ? mainSections.slice(1) : mainSections;
+	const mainSectionGroups = showHeader
+		? splitFirstVisibleSection(page.main, data)
+		: { firstSection: undefined, remainingSections: filterSections(page.main, data) };
+	const specialMainSection = mainSectionGroups.firstSection;
+	const regularMainSections = mainSectionGroups.remainingSections;
 
 	return (
 		<Page size={pageSize} style={composeStyles(styles.page, pageMinHeightStyle)}>

--- a/packages/pdf/src/templates/shared/filtering.test.ts
+++ b/packages/pdf/src/templates/shared/filtering.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { filterItems, filterSections, hasVisibleItems, isSectionVisible, isVisibleSummary } from "./filtering";
+import {
+	filterItems,
+	filterSections,
+	hasVisibleItems,
+	isSectionVisible,
+	isVisibleSummary,
+	splitFirstVisibleSection,
+} from "./filtering";
 
 describe("filterItems", () => {
 	it("returns only items where hidden is false", () => {
@@ -186,5 +193,31 @@ describe("filterSections", () => {
 
 	it("preserves order of input section ids", () => {
 		expect(filterSections(["experience", "summary"], data)).toEqual(["experience", "summary"]);
+	});
+});
+
+describe("splitFirstVisibleSection", () => {
+	const data = {
+		summary: { hidden: false, content: "<p>Hi</p>" },
+		sections: {
+			profiles: { hidden: false, items: [] },
+			experience: { hidden: false, items: [{ hidden: false, company: "Acme" }] },
+			skills: { hidden: false, items: [{ hidden: false, name: "TypeScript" }] },
+		},
+		customSections: [],
+	};
+
+	it("does not promote the next visible section when the configured first section is empty", () => {
+		expect(splitFirstVisibleSection(["profiles", "experience", "skills"], data)).toEqual({
+			firstSection: undefined,
+			remainingSections: ["experience", "skills"],
+		});
+	});
+
+	it("keeps the configured first section separate when it is visible", () => {
+		expect(splitFirstVisibleSection(["summary", "experience", "skills"], data)).toEqual({
+			firstSection: "summary",
+			remainingSections: ["experience", "skills"],
+		});
 	});
 });

--- a/packages/pdf/src/templates/shared/filtering.ts
+++ b/packages/pdf/src/templates/shared/filtering.ts
@@ -126,3 +126,16 @@ export const isSectionVisible = (sectionId: string, data: FilterableData): boole
 export const filterSections = (sectionIds: string[], data: FilterableData): string[] => {
 	return sectionIds.filter((sectionId) => isSectionVisible(sectionId, data));
 };
+
+export const splitFirstVisibleSection = (
+	sectionIds: string[],
+	data: FilterableData,
+): { firstSection: string | undefined; remainingSections: string[] } => {
+	const [firstSectionId, ...remainingSectionIds] = sectionIds;
+	const firstSection = firstSectionId && isSectionVisible(firstSectionId, data) ? firstSectionId : undefined;
+
+	return {
+		firstSection,
+		remainingSections: filterSections(remainingSectionIds, data),
+	};
+};


### PR DESCRIPTION
Closes #3043

## What was broken

When using the Ditgar or Gengar templates without any visible Profiles items, the first visible main section was promoted into the special top section.

For resumes where `profiles` was configured first but had no visible items, `experience` could move into the tinted header/profile area, causing the profile background color to bleed into the Experience section.

## Root cause

Both templates filtered the main section list first and then used the first remaining visible section as the special top section.

That meant an empty configured first section, such as `profiles`, was removed before the template decided which section should receive the special top treatment. The next visible section, such as `experience`, was then incorrectly rendered in that tinted container.

## Changes

`packages/pdf/src/templates/shared/filtering.ts`

- Added `splitFirstVisibleSection`, which keeps the configured first section separate only when that original first section is visible.
- Remaining sections are still filtered normally.

`packages/pdf/src/templates/ditgar/DitgarPage.tsx`

- Uses `splitFirstVisibleSection` for first-page main sections.
- Prevents `experience` or other later sections from being promoted when `profiles` is empty.

`packages/pdf/src/templates/gengar/GengarPage.tsx`

- Applies the same first-section behavior as Ditgar.

`packages/pdf/src/templates/shared/filtering.test.ts`

- Added regression coverage for the empty `profiles` case.
- Added coverage for the visible first-section case.

## Testing

- [ ] Ditgar template with no Profiles — Experience section background should NOT bleed into profile area
- [ ] Gengar template with no Profiles — same background bleed check
- [ ] Ditgar template WITH Profiles defined — layout renders correctly as before
- [ ] Gengar template WITH Profiles defined — layout renders correctly as before
- [ ] First visible section is promoted correctly when Profiles is empty
- [ ] PDF output matches expected visual for both templates
