### PR TITLE
fix(pdf): increase headerNameLineHeight to 1.3 to prevent descender clipping

### DIFF
--- a/packages/pdf/src/templates/shared/styles.ts
+++ b/packages/pdf/src/templates/shared/styles.ts
@@ -21,7 +21,11 @@ export const mergeStyles = (...styles: StyleInput[]): Style => Object.assign({},
 
 export const mergeLinkStyles = (...styles: StyleInput[]): Style => mergeStyles(...styles, linkUnderlineStyle);
 
-export const headerNameLineHeight = 1.2;
+// Increased from 1.2 to 1.3 to prevent descenders (g, p, y, etc.) from being
+// clipped by the overflow:hidden applied in safeTextStyle on all Heading elements.
+// At 1.5× heading font size, a lineHeight of 1.2 leaves insufficient room for
+// the descender depth of many fonts, causing letters to appear visually cut off.
+export const headerNameLineHeight = 1.3;
 
 export type ResolvePlacementColorOptions = {
 	placement: TemplatePlacement;


### PR DESCRIPTION
## Summary

Fixes #3042 — descenders (letters like **g**, **p**, **y**, **j**) in the resume header name are clipped at the bottom across all templates.

**Root cause:** `primitives.tsx` applies `overflow: hidden` to every `Heading` element via `safeTextStyle`. The header name is rendered at `1.5×` heading font size with `lineHeight: 1.2` (`headerNameLineHeight` in `shared/styles.ts`). At this enlarged size, the 1.2 line-height leaves insufficient vertical room for font descenders, causing `overflow: hidden` to clip them.

**Fix:** Raise `headerNameLineHeight` from `1.2` → `1.3` in `packages/pdf/src/templates/shared/styles.ts`. This constant is shared across all 13 templates, so the fix applies everywhere.

**Change:**
```diff
- export const headerNameLineHeight = 1.2;
+ export const headerNameLineHeight = 1.3;
```

No other files changed. No layout shifts expected — the 0.1 increase only affects the header name's line box height.

## Test plan

- [ ] Open any template (Gengar, Ditgar, etc.) with a name containing descender letters (e.g. "Gragg", "Gjergji", "Page")
- [ ] Export to PDF — descenders should now render fully without clipping
- [ ] Verify header name layout is otherwise unchanged across all templates