### PR TITLE
fix(pdf): render Times New Roman and plain rich text

### DIFF
--- a/packages/fonts/src/index.test.ts
+++ b/packages/fonts/src/index.test.ts
@@ -261,7 +261,7 @@ describe("buildResumeFontFamily", () => {
 
 describe("legacy font compatibility (#2989)", () => {
 	it.each([
-		["Times New Roman", "Tinos"],
+		["Times New Roman", "Times-Roman"],
 		["Arial", "Arimo"],
 		["Garamond", "EB Garamond"],
 		["Calibri", "Carlito"],
@@ -277,7 +277,7 @@ describe("legacy font compatibility (#2989)", () => {
 	});
 
 	it("every alias target is actually registered as a known font", () => {
-		const aliasTargets = ["Tinos", "Arimo", "EB Garamond", "Carlito"];
+		const aliasTargets = ["Times-Roman", "Tinos", "Arimo", "EB Garamond", "Carlito"];
 		for (const target of aliasTargets) {
 			expect(getFont(target), `alias target ${target} must be a known font`).toBeDefined();
 		}
@@ -286,7 +286,7 @@ describe("legacy font compatibility (#2989)", () => {
 	it("getFont resolves a legacy family to its alias target", () => {
 		const tnr = getFont("Times New Roman");
 		expect(tnr).toBeDefined();
-		expect(tnr?.family).toBe("Tinos");
+		expect(tnr?.family).toBe("Times-Roman");
 	});
 
 	it("getFont still returns the direct font when both legacy and direct lookup would succeed", () => {

--- a/packages/fonts/src/index.ts
+++ b/packages/fonts/src/index.ts
@@ -132,7 +132,7 @@ const legacyFontAliases: Record<string, string> = {
 	Cambria: "Tinos",
 	Calibri: "Carlito",
 	Garamond: "EB Garamond",
-	"Times New Roman": "Tinos",
+	"Times New Roman": "Times-Roman",
 };
 
 export function resolveLegacyFontAlias(family: string): string | null {

--- a/packages/pdf/src/templates/shared/rich-text-renderers.ts
+++ b/packages/pdf/src/templates/shared/rich-text-renderers.ts
@@ -1,0 +1,31 @@
+import type { Style } from "@react-pdf/types";
+import type { ReactNode } from "react";
+import { Text as PdfText } from "@react-pdf/renderer";
+import { createElement } from "react";
+import {
+	getRichTextEdgeTrimStyle,
+	isRichTextElementInsideListItem,
+	stripRichTextVerticalMargins,
+} from "./rich-text-spacing";
+import { composeStyles } from "./styles";
+
+export const toRichTextStyleArray = (style: Style | Style[] | undefined): Style[] => {
+	if (!style) return [];
+	if (Array.isArray(style)) return style.filter(Boolean);
+
+	return [style];
+};
+
+type RichTextParagraphRendererProps = {
+	children: ReactNode;
+	element: Parameters<typeof isRichTextElementInsideListItem>[0];
+	style: Style | Style[] | undefined;
+};
+
+export const renderRichTextParagraph = ({ element, style, children }: RichTextParagraphRendererProps) => {
+	const paragraphStyles = isRichTextElementInsideListItem(element)
+		? toRichTextStyleArray(style).map(stripRichTextVerticalMargins)
+		: style;
+
+	return createElement(PdfText, { style: composeStyles(paragraphStyles, getRichTextEdgeTrimStyle(element)) }, children);
+};

--- a/packages/pdf/src/templates/shared/rich-text.test.ts
+++ b/packages/pdf/src/templates/shared/rich-text.test.ts
@@ -1,5 +1,14 @@
+import type { ReactElement } from "react";
 import { describe, expect, it } from "vitest";
+import { Text as PdfText } from "@react-pdf/renderer";
+import { parse } from "node-html-parser";
+import { createElement } from "react";
 import { normalizeRichTextHtml } from "./rich-text-html";
+import { renderRichTextParagraph } from "./rich-text-renderers";
+
+type PdfElement = ReactElement<{ children?: unknown; style?: unknown }>;
+
+const getPdfElementProps = (element: unknown) => (element as PdfElement).props;
 
 describe("normalizeRichTextHtml", () => {
 	it("wraps top-level inline rich text in a paragraph", () => {
@@ -21,5 +30,23 @@ describe("normalizeRichTextHtml", () => {
 		expect(normalizeRichTextHtml("Intro <strong>text</strong><ul><li><p>Item</p></li></ul>Outro")).toBe(
 			"<p>Intro <strong>text</strong></p><ul><li><p>Item</p></li></ul><p>Outro</p>",
 		);
+	});
+});
+
+describe("renderRichTextParagraph", () => {
+	it("keeps unmarked paragraph text inside a PDF text node", () => {
+		const paragraph = parse("<p>Plain <strong>bold</strong> text</p>").querySelector("p");
+
+		if (!paragraph) throw new Error("Expected paragraph to exist.");
+
+		const rendered = renderRichTextParagraph({
+			element: paragraph,
+			style: { fontSize: 10 },
+			children: ["Plain ", createElement(PdfText, { key: "bold" }, "bold"), " text"],
+		});
+		const props = getPdfElementProps(rendered);
+
+		expect(rendered.type).toBe(PdfText);
+		expect(props.children).toEqual(["Plain ", expect.any(Object), " text"]);
 	});
 });

--- a/packages/pdf/src/templates/shared/rich-text.tsx
+++ b/packages/pdf/src/templates/shared/rich-text.tsx
@@ -4,10 +4,10 @@ import { Html } from "react-pdf-html";
 import { useTemplateStyle } from "./context";
 import { safeTextStyle } from "./primitives";
 import { normalizeRichTextHtml, richTextMarkClassName } from "./rich-text-html";
+import { renderRichTextParagraph, toRichTextStyleArray } from "./rich-text-renderers";
 import {
 	createRichTextProseSpacing,
 	getRichTextEdgeTrimStyle,
-	isRichTextElementInsideListItem,
 	isRichTextElementInsideOrderedList,
 	resolveRichTextBodyLineHeight,
 	stripRichTextVerticalMargins,
@@ -21,13 +21,6 @@ const richListItemContentStackStyle = {
 const richMarkStyle = {
 	backgroundColor: "#ffff00",
 } satisfies Style;
-
-const toStyleArray = (style: Style | Style[] | undefined): Style[] => {
-	if (!style) return [];
-	if (Array.isArray(style)) return style.filter(Boolean);
-
-	return [style];
-};
 
 export const RichText = ({ children }: { children: string }) => {
 	const boldStyle = useTemplateStyle("bold");
@@ -48,17 +41,11 @@ export const RichText = ({ children }: { children: string }) => {
 			resetStyles
 			renderers={{
 				b: ({ children }) => <PdfText style={composeStyles(boldStyle, safeTextStyle)}>{children}</PdfText>,
-				p: ({ element, style, children }) => {
-					const paragraphStyles = isRichTextElementInsideListItem(element)
-						? toStyleArray(style).map(stripRichTextVerticalMargins)
-						: style;
-
-					return <View style={composeStyles(paragraphStyles, getRichTextEdgeTrimStyle(element))}>{children}</View>;
-				},
+				p: renderRichTextParagraph,
 				li: ({ element, style, children }) => {
 					const isOrderedList = isRichTextElementInsideOrderedList(element);
 					const marker = isOrderedList ? `${element.indexOfType + 1}.` : "•";
-					const itemStyles = toStyleArray(style);
+					const itemStyles = toRichTextStyleArray(style);
 					const contentItemStyles = itemStyles.map(stripRichTextVerticalMargins);
 
 					return (


### PR DESCRIPTION
## Summary

Fixes missing text in resume PDF previews/thumbnails when using rich text content and `Times New Roman`.

## Problem

Some generated resume PDFs only showed styled fragments such as italic, bold, or linked text, while normal paragraph text appeared missing. This affected the builder preview and dashboard thumbnails.

<img width="955" height="1371" alt="image" src="https://github.com/user-attachments/assets/3f400978-7688-4fc7-bc5f-1c9c49b1b6c0" />

The issue had two contributing causes:

- Rich text paragraphs were rendered as PDF `View` nodes, so plain string children were not reliably painted by React PDF.
- `Times New Roman` was aliased to the embedded Tinos web font, where the regular face could embed but render blank in the PDF output.

## Changes

- Render rich text paragraphs as React PDF `Text` nodes so plain paragraph text and nested styled runs are preserved.
- Extract rich text paragraph rendering into a small testable helper.
- Map `Times New Roman` to the standard PDF `Times-Roman` font for PDF rendering.
- Update font alias and rich text renderer tests.

## Verification

- `biome check` on changed files
- `packages/fonts` focused test: `src/index.test.ts`
- `packages/pdf` focused tests:
  - `src/templates/shared/rich-text.test.ts`
  - `src/templates/shared/rich-text-html.test.ts`
  - `src/hooks/use-register-fonts.test.ts`
- Manually rasterized the affected resume PDF and confirmed normal paragraph text renders visibly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Times New Roman font alias resolution for improved compatibility.

* **New Features**
  * Enhanced rich-text styling support in PDF templates with improved paragraph and style handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/amruthpillai/reactive-resume/pull/3094?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->