### PR TITLE
Updates the Docker quick start instructions to use a shallow clone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The quickest way to run Reactive Resume locally:
 
 ```bash
 # Clone the repository
-git clone https://github.com/amruthpillai/reactive-resume.git
+git clone --depth=1  https://github.com/amruthpillai/reactive-resume.git
 cd reactive-resume
 
 # Start all services


### PR DESCRIPTION
## TL;DR

Update the Docker Compose quick start to use a shallow clone with `--depth=1`.

## Problem

The Docker Compose setup only needs the current working tree for a normal self-hosted run. A full clone also downloads the repository history, which increases the initial checkout size for users who only want to start the app with Docker Compose.

In my local test, a normal clone placed most of the checkout size in `.git/objects`, while a shallow clone reduced the checkout size from around 204 MB to around 53 MB.

## Changes

- Updated the documented clone command to use `git clone --depth=1`
- Kept the existing Docker Compose setup unchanged
- Reduced the amount of Git data downloaded during the quick start flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Optimized Quick Start setup command to use shallow cloning for faster repository installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/amruthpillai/reactive-resume/pull/3096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->