### PR TITLE
Show experience position with role progression

### DIFF
--- a/packages/pdf/src/templates/shared/sections.test.ts
+++ b/packages/pdf/src/templates/shared/sections.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(fileURLToPath(new URL("./sections.tsx", import.meta.url)), "utf8");
+
+describe("ExperienceSection", () => {
+	it("does not hide the item position header when role progression is present", () => {
+		expect(source).not.toContain("item.roles.length === 0 && (hasPosition || hasSplitRowText(headerPeriod))");
+	});
+
+	it("does not repeat the summary period after rendering it in a role-progression header", () => {
+		expect(source).not.toContain("item.roles.length > 0 && <Text>{item.period}</Text>");
+	});
+});

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -415,7 +415,7 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 								{hasSplitRowText(headerLocation) && <Text style={composeStyles(alignEndStyle)}>{headerLocation}</Text>}
 							</View>
 
-							{item.roles.length === 0 && (hasPosition || hasSplitRowText(headerPeriod)) && (
+							{(hasPosition || hasSplitRowText(headerPeriod)) && (
 								<View style={composeStyles(splitRowStyle)}>
 									{hasPosition && <Text>{item.position}</Text>}
 									{hasSplitRowText(headerPeriod) && <Text style={composeStyles(alignEndStyle)}>{headerPeriod}</Text>}
@@ -427,8 +427,6 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 					return (
 						<SectionItem key={item.id}>
 							<SectionItemHeader>{inlineItemHeader ? renderInlineHeader() : renderSplitHeader()}</SectionItemHeader>
-
-							{item.roles.length > 0 && <Text>{item.period}</Text>}
 
 							{item.roles.map((role) => (
 								<View key={role.id}>


### PR DESCRIPTION
## Summary
- render the experience item position header even when role progression roles are present
- avoid repeating the summary period outside the header for role-progression entries
- add a focused regression guard for the shared experience renderer

## Root cause
The shared PDF experience renderer only printed the item-level position header row when `item.roles.length === 0`, so role-progression entries dropped the company-level position across templates.

## Validation
- `pnpm --filter @reactive-resume/pdf test -- src/templates/shared/sections.test.ts`
- `pnpm --filter @reactive-resume/pdf typecheck`
- `pnpm exec biome check packages/pdf/src/templates/shared/sections.tsx packages/pdf/src/templates/shared/sections.test.ts`
- `git diff --check`

Resolves #3115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for experience section rendering and period display behavior.

* **Refactor**
  * Improved experience section header and period rendering logic to ensure consistent display across role progressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/amruthpillai/reactive-resume/pull/3116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->