### PR TITLE
fix(pdf): avoid toReversed in icon size resolution

### DIFF
--- a/packages/pdf/src/templates/shared/icon-size.ts
+++ b/packages/pdf/src/templates/shared/icon-size.ts
@@ -17,7 +17,12 @@ export const parseStyleFontSize = (fontSize: Style["fontSize"] | undefined): num
 
 export const resolveStyleFontSize = (...styles: StyleInput[]): number | undefined => {
 	for (let index = styles.length - 1; index >= 0; index -= 1) {
-		for (const style of composeStyles(styles[index]).toReversed()) {
+		const composedStyles = composeStyles(styles[index]);
+
+		for (let styleIndex = composedStyles.length - 1; styleIndex >= 0; styleIndex -= 1) {
+			const style = composedStyles[styleIndex];
+			if (style === undefined) continue;
+
 			const fontSize = parseStyleFontSize(style.fontSize);
 			if (fontSize !== undefined) return fontSize;
 		}


### PR DESCRIPTION
Replaces `toReversed()` in PDF icon size resolution with manual reverse iteration so typecheck passes without requiring ES2023 array typings.

The style precedence behavior is unchanged: later composed styles are still checked first.

Validated with `pnpm typecheck`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal style resolution logic for improved performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/amruthpillai/reactive-resume/pull/3129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->