### PR TITLE
Problem in word wrapping in the templates

### DIFF
--- a/packages/pdf/src/hooks/use-register-fonts.test.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.test.ts
@@ -156,24 +156,8 @@ describe("registerFonts", () => {
 
 		const hyphenationCallback = registerHyphenationSpy.mock.calls.at(-1)?.[0];
 		expect(hyphenationCallback?.("翠翠红红处处")).toEqual(["翠", "", "翠", "", "红", "", "红", "", "处", "", "处", ""]);
-		expect(hyphenationCallback?.("Reactive")).toEqual([
-			"R",
-			"",
-			"e",
-			"",
-			"a",
-			"",
-			"c",
-			"",
-			"t",
-			"",
-			"i",
-			"",
-			"v",
-			"",
-			"e",
-			"",
-		]);
+		// Latin words must stay intact even in CJK mode — no character-level breaking.
+		expect(hyphenationCallback?.("Reactive")).toEqual(["Reactive"]);
 	});
 
 	it("returns typography with font weights sorted ascending", async () => {

--- a/packages/pdf/src/hooks/use-register-fonts.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.ts
@@ -115,7 +115,11 @@ export const registerFonts = (typography: Typography, locale: Locale, hasCjkCont
 	Font.registerHyphenationCallback((word) => {
 		if (needsCjkTextSupport) {
 			if (word === " ") return ["\u200C "];
-			return [...word].flatMap((l) => [l, ""]);
+			// Only break at every character for words that contain CJK characters.
+			// Latin/non-CJK words must stay intact even in a CJK-locale resume.
+			if (cjkLetterRegex.test(word)) {
+				return [...word].flatMap((l) => [l, ""]);
+			}
 		}
 
 		return [word];


### PR DESCRIPTION
#fix:3107, problem with Word Breaking solved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved text hyphenation for PDFs containing mixed CJK and Latin characters. Latin words now remain unbroken while CJK content preserves character-level breaking behavior for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->