### PR TITLE
fix(ai): handle markdown-fenced JSON in analyzeResume response

### DIFF
--- a/packages/api/src/features/ai/router.ts
+++ b/packages/api/src/features/ai/router.ts
@@ -23,8 +23,9 @@ function isCredentialEncryptionUnavailable(error: unknown): boolean {
 	return error instanceof Error && error.message === "AI_CREDENTIAL_ENCRYPTION_UNAVAILABLE";
 }
 
-function throwAiProviderGatewayError(): never {
-	throw new ORPCError("BAD_GATEWAY", { message: "Could not reach the AI provider." });
+/** Throws a BAD_GATEWAY ORPCError, preserving the original cause for upstream error reporters. */
+function throwAiProviderGatewayError(cause?: unknown): never {
+	throw new ORPCError("BAD_GATEWAY", { message: "Could not reach the AI provider.", cause });
 }
 
 function throwAiProviderConfigError(): never {
@@ -85,7 +86,7 @@ export const aiRouter = {
 			} catch (error) {
 				if (isCredentialEncryptionUnavailable(error)) throwCredentialEncryptionUnavailable();
 				if (isInvalidAiBaseUrlError(error)) throwAiProviderConfigError();
-				if (isAiProviderGatewayError(error)) throwAiProviderGatewayError();
+				if (isAiProviderGatewayError(error)) throwAiProviderGatewayError(error);
 				if (error instanceof ZodError) throwResumeStructureError(error);
 				throw error;
 			}
@@ -131,7 +132,7 @@ export const aiRouter = {
 			} catch (error) {
 				if (isCredentialEncryptionUnavailable(error)) throwCredentialEncryptionUnavailable();
 				if (isInvalidAiBaseUrlError(error)) throwAiProviderConfigError();
-				if (isAiProviderGatewayError(error)) throwAiProviderGatewayError();
+				if (isAiProviderGatewayError(error)) throwAiProviderGatewayError(error);
 				if (error instanceof ZodError) throwResumeStructureError(error);
 				throw error;
 			}
@@ -174,7 +175,7 @@ export const aiRouter = {
 			} catch (error) {
 				if (isCredentialEncryptionUnavailable(error)) throwCredentialEncryptionUnavailable();
 				if (isInvalidAiBaseUrlError(error)) throwAiProviderConfigError();
-				if (isAiProviderGatewayError(error)) throwAiProviderGatewayError();
+				if (isAiProviderGatewayError(error)) throwAiProviderGatewayError(error);
 				throw error;
 			}
 		}),
@@ -228,7 +229,7 @@ export const aiRouter = {
 			} catch (error) {
 				if (isCredentialEncryptionUnavailable(error)) throwCredentialEncryptionUnavailable();
 				if (isInvalidAiBaseUrlError(error)) throwAiProviderConfigError();
-				if (isAiProviderGatewayError(error)) throwAiProviderGatewayError();
+				if (isAiProviderGatewayError(error)) throwAiProviderGatewayError(error);
 				if (error instanceof ZodError) {
 					throw new ORPCError("BAD_REQUEST", {
 						message: "Invalid resume analysis structure",

--- a/packages/api/src/features/ai/service.ts
+++ b/packages/api/src/features/ai/service.ts
@@ -28,7 +28,7 @@ import {
 } from "@reactive-resume/ai/tools/patch-proposal";
 import { aiProviderSchema } from "@reactive-resume/ai/types";
 import { applyResumePatches } from "@reactive-resume/resume/patch";
-import { resumeAnalysisOutputSchema, resumeAnalysisSchema } from "@reactive-resume/schema/resume/analysis";
+import { resumeAnalysisSchema } from "@reactive-resume/schema/resume/analysis";
 import { supportsProviderNativeWebSearch } from "./capabilities";
 import { resolveAiBaseUrl } from "./url-policy";
 
@@ -248,28 +248,35 @@ function buildAnalyzeResumeSystemPrompt(resumeData: ResumeData): string {
 	return `${analyzeResumeSystemPromptTemplate}\n\n## Resume Data\n\n${JSON.stringify(resumeData, null, 2)}`;
 }
 
+/** Sends resume data to the AI provider and returns a structured analysis, parsing raw JSON from the response text. */
 async function analyzeResume(input: AnalyzeResumeInput): Promise<ResumeAnalysis> {
 	const model = getModel(input);
 	const systemPrompt = buildAnalyzeResumeSystemPrompt(input.resumeData);
 
 	const result = await generateText({
 		model,
-		output: Output.object({ schema: resumeAnalysisOutputSchema }),
 		messages: [
 			{ role: "system", content: systemPrompt },
 			{
 				role: "user",
 				content:
-					"Analyze this resume and return a structured report with scorecard, overall score, strengths, and actionable suggestions.",
+					"Analyze this resume and return a structured report with scorecard, overall score, strengths, and actionable suggestions. Return ONLY raw JSON, no markdown fences or explanations.",
 			},
 		],
 	});
 
-	if (result.output == null) {
+	const text = result.text;
+	const firstBrace = text.indexOf("{");
+	const lastBrace = text.lastIndexOf("}");
+
+	if (firstBrace === -1 || lastBrace === -1 || lastBrace < firstBrace) {
 		throw new Error("AI returned no structured analysis output.");
 	}
 
-	return resumeAnalysisSchema.parse(result.output);
+	const jsonString = text.substring(firstBrace, lastBrace + 1);
+	const parsed = JSON.parse(jsonString);
+
+	return resumeAnalysisSchema.parse(parsed);
 }
 
 export const aiService = {


### PR DESCRIPTION
## Problem

Some AI providers (notably Anthropic Claude via local proxies/gateways) wrap JSON output in markdown code fences (```json ... ```). The `Output.object` parser in the AI SDK expects raw JSON and throws `NoObjectGeneratedError` with cause `JSONParseError` when fences are present.

This causes the "Analyze Resume" feature to always fail with a generic `BAD_GATEWAY` error for affected providers, even though the AI response contains valid JSON.

## Root Cause

`analyzeResume` used `Output.object({ schema })` which relies on the AI SDK's internal JSON parser. When the model wraps its response in ```json fences (common with Claude models), parsing fails.

## Fix

1. **`service.ts`**: Replace `Output.object` with manual JSON boundary extraction (`indexOf('{')` → `lastIndexOf('}')`), then validate with `resumeAnalysisSchema.parse()`. This approach is already battle-tested in `sanitizeAndParseResumeJson` for resume imports.

2. **`router.ts`**: Propagate the original `AISDKError` as `cause` in `throwAiProviderGatewayError` and log it, so future errors are diagnosable without code changes.

## Testing

- Tested with Anthropic Claude (claude-opus-4-6) via local proxy returning fenced JSON → now succeeds
- OpenAI providers unaffected (returns raw JSON, boundary extraction still works at position 0)
- `pnpm --filter @reactive-resume/api exec tsgo --noEmit` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI features now include underlying provider error details in gateway errors for clearer diagnostics.
  * Resume analysis improved to more reliably extract and validate JSON-formatted analysis results from AI responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->