### PR TITLE
feat(resume): add logo field to experience and education items

### DIFF
--- a/apps/web/src/components/input/logo-upload.tsx
+++ b/apps/web/src/components/input/logo-upload.tsx
@@ -64,7 +64,9 @@ export function LogoUploadField({ value, onChange, onAutoSave }: LogoUploadField
 
 		uploadFile(file, {
 			onSuccess: ({ url }) => {
-				onChange({ ...value, url });
+				const safeSize = value.size >= SIZE_MIN && value.size <= SIZE_MAX ? value.size : 32;
+				setSizeError([]);
+				onChange({ ...value, url, size: safeSize });
 				onAutoSave?.();
 				toast.dismiss(toastId);
 				if (fileInputRef.current) fileInputRef.current.value = "";
@@ -91,6 +93,15 @@ export function LogoUploadField({ value, onChange, onAutoSave }: LogoUploadField
 		}
 		onChange({ ...value, size: num });
 		onAutoSave?.();
+	};
+
+	const onSizeBlur = () => {
+		if (!value.url) return;
+		if (value.size < SIZE_MIN || value.size > SIZE_MAX) {
+			setSizeError([]);
+			onChange({ ...value, size: 32 });
+			onAutoSave?.();
+		}
 	};
 
 	return (
@@ -166,7 +177,7 @@ export function LogoUploadField({ value, onChange, onAutoSave }: LogoUploadField
 						<Trans>Logo Size (pt)</Trans>
 					</FormLabel>
 					<InputGroup>
-						<InputGroupInput type="number" min={SIZE_MIN} max={SIZE_MAX} value={value.size} onChange={onSizeChange} />
+						<InputGroupInput type="number" value={value.size} onChange={onSizeChange} onBlur={onSizeBlur} />
 						<InputGroupAddon align="inline-end">
 							<InputGroupText>pt</InputGroupText>
 						</InputGroupAddon>

--- a/apps/web/src/components/input/logo-upload.tsx
+++ b/apps/web/src/components/input/logo-upload.tsx
@@ -3,10 +3,10 @@ import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { EyeIcon, EyeSlashIcon, TrashSimpleIcon, UploadSimpleIcon } from "@phosphor-icons/react";
 import { useMutation } from "@tanstack/react-query";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@reactive-resume/ui/components/button";
-import { FormControl, FormItem, FormLabel } from "@reactive-resume/ui/components/form";
+import { FormControl, FormItem, FormLabel, FormMessage } from "@reactive-resume/ui/components/form";
 import { Input } from "@reactive-resume/ui/components/input";
 import {
 	InputGroup,
@@ -17,6 +17,9 @@ import {
 import { getReadableErrorMessage } from "@/libs/error-message";
 import { orpc } from "@/libs/orpc/client";
 
+const SIZE_MIN = 16;
+const SIZE_MAX = 128;
+
 interface LogoUploadFieldProps {
 	value: ItemLogo;
 	onChange: (value: ItemLogo) => void;
@@ -25,6 +28,7 @@ interface LogoUploadFieldProps {
 
 export function LogoUploadField({ value, onChange, onAutoSave }: LogoUploadFieldProps) {
 	const fileInputRef = useRef<HTMLInputElement>(null);
+	const [sizeError, setSizeError] = useState<string[]>([]);
 
 	const { mutate: uploadFile } = useMutation(orpc.storage.uploadFile.mutationOptions({ meta: { noInvalidate: true } }));
 	const { mutate: deleteFile } = useMutation(orpc.storage.deleteFile.mutationOptions({ meta: { noInvalidate: true } }));
@@ -47,6 +51,7 @@ export function LogoUploadField({ value, onChange, onAutoSave }: LogoUploadField
 			// ignore invalid URLs
 		}
 
+		setSizeError([]);
 		onChange({ ...value, url: "" });
 		onAutoSave?.();
 	};
@@ -70,6 +75,22 @@ export function LogoUploadField({ value, onChange, onAutoSave }: LogoUploadField
 				});
 			},
 		});
+	};
+
+	const onSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const raw = e.target.value;
+		const num = Number(raw);
+		if (value.url) {
+			if (num < SIZE_MIN) {
+				setSizeError([t`Too small: expected number to be >=${SIZE_MIN}`]);
+			} else if (num > SIZE_MAX) {
+				setSizeError([t`Too large: expected number to be <=${SIZE_MAX}`]);
+			} else {
+				setSizeError([]);
+			}
+		}
+		onChange({ ...value, size: num });
+		onAutoSave?.();
 	};
 
 	return (
@@ -139,26 +160,18 @@ export function LogoUploadField({ value, onChange, onAutoSave }: LogoUploadField
 			</div>
 
 			{/* Size + border radius row */}
-			<div className="grid grid-cols-2 gap-3">
-				<FormItem>
+			<div className="grid grid-cols-2 items-start gap-3">
+				<FormItem hasError={sizeError.length > 0}>
 					<FormLabel>
 						<Trans>Logo Size (pt)</Trans>
 					</FormLabel>
 					<InputGroup>
-						<InputGroupInput
-							type="number"
-							min={16}
-							max={128}
-							value={value.size}
-							onChange={(e) => {
-								onChange({ ...value, size: Number(e.target.value) });
-								onAutoSave?.();
-							}}
-						/>
+						<InputGroupInput type="number" min={SIZE_MIN} max={SIZE_MAX} value={value.size} onChange={onSizeChange} />
 						<InputGroupAddon align="inline-end">
 							<InputGroupText>pt</InputGroupText>
 						</InputGroupAddon>
 					</InputGroup>
+					<FormMessage errors={sizeError} />
 				</FormItem>
 
 				<FormItem>

--- a/apps/web/src/components/input/logo-upload.tsx
+++ b/apps/web/src/components/input/logo-upload.tsx
@@ -1,0 +1,187 @@
+import type { ItemLogo } from "@reactive-resume/schema/resume/data";
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { EyeIcon, EyeSlashIcon, TrashSimpleIcon, UploadSimpleIcon } from "@phosphor-icons/react";
+import { useMutation } from "@tanstack/react-query";
+import { useRef } from "react";
+import { toast } from "sonner";
+import { Button } from "@reactive-resume/ui/components/button";
+import { FormControl, FormItem, FormLabel } from "@reactive-resume/ui/components/form";
+import { Input } from "@reactive-resume/ui/components/input";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+	InputGroupText,
+} from "@reactive-resume/ui/components/input-group";
+import { getReadableErrorMessage } from "@/libs/error-message";
+import { orpc } from "@/libs/orpc/client";
+
+interface LogoUploadFieldProps {
+	value: ItemLogo;
+	onChange: (value: ItemLogo) => void;
+	onAutoSave?: () => void;
+}
+
+export function LogoUploadField({ value, onChange, onAutoSave }: LogoUploadFieldProps) {
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const { mutate: uploadFile } = useMutation(orpc.storage.uploadFile.mutationOptions({ meta: { noInvalidate: true } }));
+	const { mutate: deleteFile } = useMutation(orpc.storage.deleteFile.mutationOptions({ meta: { noInvalidate: true } }));
+
+	const onSelectLogo = () => {
+		fileInputRef.current?.click();
+	};
+
+	const onDeleteLogo = () => {
+		if (!value.url) return;
+
+		const appOrigin = window.location.origin;
+		try {
+			const logoUrl = new URL(value.url, appOrigin);
+			if (logoUrl.origin === appOrigin) {
+				const filename = logoUrl.pathname.split("/").pop();
+				if (filename) deleteFile({ filename });
+			}
+		} catch {
+			// ignore invalid URLs
+		}
+
+		onChange({ ...value, url: "" });
+		onAutoSave?.();
+	};
+
+	const onUploadLogo = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (!file) return;
+
+		const toastId = toast.loading(t`Uploading logo…`);
+
+		uploadFile(file, {
+			onSuccess: ({ url }) => {
+				onChange({ ...value, url });
+				onAutoSave?.();
+				toast.dismiss(toastId);
+				if (fileInputRef.current) fileInputRef.current.value = "";
+			},
+			onError: (error) => {
+				toast.error(getReadableErrorMessage(error, t`Failed to upload logo. Please try again.`), {
+					id: toastId,
+				});
+			},
+		});
+	};
+
+	return (
+		<div className="space-y-3">
+			{/* Preview + URL row */}
+			<div className="flex items-end gap-x-3">
+				<input
+					ref={fileInputRef}
+					type="file"
+					accept="image/*"
+					aria-label={t`Upload logo`}
+					className="hidden"
+					onChange={onUploadLogo}
+				/>
+
+				{/* Logo preview / upload button */}
+				<button
+					type="button"
+					onClick={value.url ? onDeleteLogo : onSelectLogo}
+					aria-label={value.url ? t`Delete logo` : t`Upload logo`}
+					className="group/logo relative size-14 shrink-0 cursor-pointer overflow-hidden rounded-md bg-secondary transition-colors hover:bg-secondary/50"
+				>
+					{value.url && (
+						<img
+							alt=""
+							src={value.url}
+							className="fade-in relative z-10 size-full animate-in rounded-md object-contain transition-opacity group-hover/logo:opacity-20"
+						/>
+					)}
+					<div className="absolute inset-0 z-0 flex size-full items-center justify-center">
+						{value.url ? <TrashSimpleIcon className="size-4" /> : <UploadSimpleIcon className="size-4" />}
+					</div>
+				</button>
+
+				{/* URL input */}
+				<FormItem className="flex-1">
+					<FormLabel>
+						<Trans>Logo URL</Trans>
+					</FormLabel>
+					<FormControl
+						render={
+							<Input
+								value={value.url}
+								placeholder="e.g. /uploads/..."
+								onChange={(e) => {
+									onChange({ ...value, url: e.target.value });
+									onAutoSave?.();
+								}}
+							/>
+						}
+					/>
+				</FormItem>
+
+				{/* Hide / show toggle */}
+				<Button
+					size="icon"
+					type="button"
+					variant="ghost"
+					title={value.hidden ? t`Show logo` : t`Hide logo`}
+					onClick={() => {
+						onChange({ ...value, hidden: !value.hidden });
+						onAutoSave?.();
+					}}
+				>
+					{value.hidden ? <EyeSlashIcon className="size-4" /> : <EyeIcon className="size-4" />}
+				</Button>
+			</div>
+
+			{/* Size + border radius row */}
+			<div className="grid grid-cols-2 gap-3">
+				<FormItem>
+					<FormLabel>
+						<Trans>Logo Size (pt)</Trans>
+					</FormLabel>
+					<InputGroup>
+						<InputGroupInput
+							type="number"
+							min={16}
+							max={128}
+							value={value.size}
+							onChange={(e) => {
+								onChange({ ...value, size: Number(e.target.value) });
+								onAutoSave?.();
+							}}
+						/>
+						<InputGroupAddon align="inline-end">
+							<InputGroupText>pt</InputGroupText>
+						</InputGroupAddon>
+					</InputGroup>
+				</FormItem>
+
+				<FormItem>
+					<FormLabel>
+						<Trans>Border Radius (pt)</Trans>
+					</FormLabel>
+					<InputGroup>
+						<InputGroupInput
+							type="number"
+							min={0}
+							max={50}
+							value={value.borderRadius}
+							onChange={(e) => {
+								onChange({ ...value, borderRadius: Number(e.target.value) });
+								onAutoSave?.();
+							}}
+						/>
+						<InputGroupAddon align="inline-end">
+							<InputGroupText>pt</InputGroupText>
+						</InputGroupAddon>
+					</InputGroup>
+				</FormItem>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/dialogs/resume/sections/education.tsx
+++ b/apps/web/src/dialogs/resume/sections/education.tsx
@@ -14,6 +14,7 @@ import {
 } from "@reactive-resume/ui/components/dialog";
 import { FormControl, FormItem, FormLabel, FormMessage } from "@reactive-resume/ui/components/form";
 import { Switch } from "@reactive-resume/ui/components/switch";
+import { LogoUploadField } from "@/components/input/logo-upload";
 import { RichInput } from "@/components/input/rich-input";
 import { URLInput } from "@/components/input/url-input";
 import { useDialogStore } from "@/dialogs/store";
@@ -38,6 +39,7 @@ const defaultValues: FormValues = {
 	period: "",
 	website: { url: "", label: "", inlineLink: false },
 	description: "",
+	logo: { hidden: false, url: "", size: 32, borderRadius: 0 },
 };
 
 export function CreateEducationDialog({ data }: DialogProps<"resume.sections.education.create">) {
@@ -198,6 +200,18 @@ const EducationForm = withForm({
 							<FormLabel className="mt-0!">
 								<Trans>Show link in title</Trans>
 							</FormLabel>
+						</FormItem>
+					)}
+				</form.Field>
+
+				{/* School Logo */}
+				<form.Field name="logo">
+					{(field) => (
+						<FormItem className="sm:col-span-full">
+							<FormLabel>
+								<Trans>School Logo</Trans>
+							</FormLabel>
+							<LogoUploadField value={field.state.value} onChange={(v) => field.handleChange(v)} />
 						</FormItem>
 					)}
 				</form.Field>

--- a/apps/web/src/dialogs/resume/sections/experience.tsx
+++ b/apps/web/src/dialogs/resume/sections/experience.tsx
@@ -18,6 +18,7 @@ import { FormControl, FormItem, FormLabel, FormMessage } from "@reactive-resume/
 import { Input } from "@reactive-resume/ui/components/input";
 import { Switch } from "@reactive-resume/ui/components/switch";
 import { generateId } from "@reactive-resume/utils/string";
+import { LogoUploadField } from "@/components/input/logo-upload";
 import { RichInput } from "@/components/input/rich-input";
 import { URLInput } from "@/components/input/url-input";
 import { useDialogStore } from "@/dialogs/store";
@@ -41,6 +42,7 @@ const defaultValues: FormValues = {
 	website: { url: "", label: "", inlineLink: false },
 	description: "",
 	roles: [] as RoleItem[],
+	logo: { hidden: false, url: "", size: 32, borderRadius: 0 },
 };
 
 export function CreateExperienceDialog({ data }: DialogProps<"resume.sections.experience.create">) {
@@ -203,6 +205,18 @@ const ExperienceForm = withForm({
 							<FormLabel>
 								<Trans>Show link in title</Trans>
 							</FormLabel>
+						</FormItem>
+					)}
+				</form.Field>
+
+				{/* Company Logo */}
+				<form.Field name="logo">
+					{(field) => (
+						<FormItem className="sm:col-span-full">
+							<FormLabel>
+								<Trans>Company Logo</Trans>
+							</FormLabel>
+							<LogoUploadField value={field.state.value} onChange={(v) => field.handleChange(v)} />
 						</FormItem>
 					)}
 				</form.Field>

--- a/packages/pdf/src/templates/shared/item-image.test.ts
+++ b/packages/pdf/src/templates/shared/item-image.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { hasItemLogo } from "./item-image";
+
+const baseLogo = {
+	hidden: false,
+	url: "/uploads/logo.png",
+	size: 32,
+	borderRadius: 0,
+} as const;
+
+describe("hasItemLogo", () => {
+	it("returns true when not hidden and url is non-empty", () => {
+		expect(hasItemLogo(baseLogo)).toBe(true);
+	});
+
+	it("returns false when hidden is true", () => {
+		expect(hasItemLogo({ ...baseLogo, hidden: true })).toBe(false);
+	});
+
+	it("returns false when url is empty string", () => {
+		expect(hasItemLogo({ ...baseLogo, url: "" })).toBe(false);
+	});
+
+	it("returns false when url is whitespace only", () => {
+		expect(hasItemLogo({ ...baseLogo, url: "   " })).toBe(false);
+	});
+
+	it("returns false when logo is undefined", () => {
+		expect(hasItemLogo(undefined)).toBe(false);
+	});
+});

--- a/packages/pdf/src/templates/shared/item-image.ts
+++ b/packages/pdf/src/templates/shared/item-image.ts
@@ -1,0 +1,10 @@
+import type { ItemLogo } from "@reactive-resume/schema/resume/data";
+
+/**
+ * Returns true when the logo should be rendered:
+ * - the logo object exists
+ * - hidden is false
+ * - a non-empty URL is provided
+ */
+export const hasItemLogo = (logo: ItemLogo | undefined): logo is ItemLogo & { url: string } =>
+	Boolean(logo && !logo.hidden && logo.url.trim() !== "");

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -22,7 +22,7 @@ import type { CustomItemSection, ItemSection } from "./types";
 import { Children, createContext, isValidElement, use } from "react";
 import { match } from "ts-pattern";
 import { useRender } from "../../context";
-import { View } from "../../renderer";
+import { Image, View } from "../../renderer";
 import { getResumeSectionIcon } from "../../section-icon";
 import { getResumeSectionTitle } from "../../section-title";
 import { getSectionItemRows, getSectionItemsLayout, shouldUseSectionTimeline } from "./columns";
@@ -37,6 +37,7 @@ import {
 	useTemplateStyle,
 } from "./context";
 import { filterItems, hasVisibleItems, isSectionVisible, isVisibleSummary } from "./filtering";
+import { hasItemLogo } from "./item-image";
 import { LevelDisplay } from "./level-display";
 import { getTemplateMetrics } from "./metrics";
 import { Bold, Div, Heading, Icon, Link, SectionHeadingIcon, Small, Text } from "./primitives";
@@ -453,7 +454,17 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 					const renderInlineHeader = () => (
 						<InlineItemHeader
 							leading={
-								hasPosition || hasLocation ? (
+								hasItemLogo(item.logo) ? (
+									<Image
+										src={item.logo.url}
+										style={{
+											width: item.logo.size,
+											height: item.logo.size,
+											borderRadius: item.logo.borderRadius,
+											objectFit: "contain",
+										}}
+									/>
+								) : hasPosition || hasLocation ? (
 									<Text>
 										{hasPosition ? item.position : ""}
 										{hasPosition && hasLocation ? " " : ""}
@@ -535,7 +546,17 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 						<>
 							<InlineItemHeader
 								leading={
-									hasArea || hasDegree ? (
+									hasItemLogo(item.logo) ? (
+										<Image
+											src={item.logo.url}
+											style={{
+												width: item.logo.size,
+												height: item.logo.size,
+												borderRadius: item.logo.borderRadius,
+												objectFit: "contain",
+											}}
+										/>
+									) : hasArea || hasDegree ? (
 										<Text>
 											{hasArea ? item.area : ""}
 											{hasArea && hasDegree ? " " : ""}

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -489,7 +489,7 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 
 					const renderSplitHeader = () => (
 						<>
-							<View style={composeStyles(splitRowStyle)}>
+							<View style={composeStyles(splitRowStyle, hasItemLogo(item.logo) ? { alignItems: "center" } : undefined)}>
 								{hasItemLogo(item.logo) ? (
 									<View style={{ flexDirection: "row", alignItems: "center", columnGap: 4 }}>
 										<Image
@@ -608,7 +608,7 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 
 					const renderSplitHeader = () => (
 						<>
-							<View style={composeStyles(splitRowStyle)}>
+							<View style={composeStyles(splitRowStyle, hasItemLogo(item.logo) ? { alignItems: "center" } : undefined)}>
 								{hasItemLogo(item.logo) ? (
 									<View style={{ flexDirection: "row", alignItems: "center", columnGap: 4 }}>
 										<Image

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -74,6 +74,7 @@ type InlineItemHeaderProps = {
 	leading?: ReactNode;
 	middle?: ReactNode;
 	trailing?: ReactNode;
+	center?: boolean;
 };
 
 type SectionItemHeaderProps = {
@@ -307,14 +308,14 @@ const SectionItem = ({ children, style }: SectionItemProps) => {
 	);
 };
 
-const InlineItemHeader = ({ leading, middle, trailing }: InlineItemHeaderProps) => {
+const InlineItemHeader = ({ leading, middle, trailing, center }: InlineItemHeaderProps) => {
 	const inlineItemHeaderStyle = useTemplateStyle("inlineItemHeader");
 	const leadingStyle = useTemplateStyle("inlineItemHeaderLeading");
 	const middleStyle = useTemplateStyle("inlineItemHeaderMiddle");
 	const trailingStyle = useTemplateStyle("inlineItemHeaderTrailing");
 
 	return (
-		<View style={composeStyles(inlineItemHeaderStyle)}>
+		<View style={composeStyles(inlineItemHeaderStyle, center ? { alignItems: "center" } : undefined)}>
 			<View style={composeStyles(leadingStyle)}>{leading}</View>
 			<View style={composeStyles(middleStyle)}>{middle}</View>
 			<View style={composeStyles(trailingStyle)}>{trailing}</View>
@@ -453,18 +454,9 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 
 					const renderInlineHeader = () => (
 						<InlineItemHeader
+							center={hasItemLogo(item.logo)}
 							leading={
-								hasItemLogo(item.logo) ? (
-									<Image
-										src={item.logo.url}
-										style={{
-											width: item.logo.size,
-											height: item.logo.size,
-											borderRadius: item.logo.borderRadius,
-											objectFit: "contain",
-										}}
-									/>
-								) : hasPosition || hasLocation ? (
+								hasPosition || hasLocation ? (
 									<Text>
 										{hasPosition ? item.position : ""}
 										{hasPosition && hasLocation ? " " : ""}
@@ -472,7 +464,25 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 									</Text>
 								) : null
 							}
-							middle={<ItemTitle website={item.website}>{item.company}</ItemTitle>}
+							middle={
+								hasItemLogo(item.logo) ? (
+									<View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+										<Image
+											src={item.logo.url}
+											style={{
+												width: item.logo.size,
+												height: item.logo.size,
+												borderRadius: item.logo.borderRadius,
+												objectFit: "contain",
+												flexShrink: 0,
+											}}
+										/>
+										<ItemTitle website={item.website}>{item.company}</ItemTitle>
+									</View>
+								) : (
+									<ItemTitle website={item.website}>{item.company}</ItemTitle>
+								)
+							}
 							trailing={<Text style={composeStyles(alignEndStyle)}>{item.period}</Text>}
 						/>
 					);
@@ -480,7 +490,23 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 					const renderSplitHeader = () => (
 						<>
 							<View style={composeStyles(splitRowStyle)}>
-								<ItemTitle website={item.website}>{item.company}</ItemTitle>
+								{hasItemLogo(item.logo) ? (
+									<View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+										<Image
+											src={item.logo.url}
+											style={{
+												width: item.logo.size,
+												height: item.logo.size,
+												borderRadius: item.logo.borderRadius,
+												objectFit: "contain",
+												flexShrink: 0,
+											}}
+										/>
+										<ItemTitle website={item.website}>{item.company}</ItemTitle>
+									</View>
+								) : (
+									<ItemTitle website={item.website}>{item.company}</ItemTitle>
+								)}
 								{hasSplitRowText(headerLocation) && <Text style={composeStyles(alignEndStyle)}>{headerLocation}</Text>}
 							</View>
 
@@ -545,18 +571,9 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 					const renderInlineHeader = () => (
 						<>
 							<InlineItemHeader
+								center={hasItemLogo(item.logo)}
 								leading={
-									hasItemLogo(item.logo) ? (
-										<Image
-											src={item.logo.url}
-											style={{
-												width: item.logo.size,
-												height: item.logo.size,
-												borderRadius: item.logo.borderRadius,
-												objectFit: "contain",
-											}}
-										/>
-									) : hasArea || hasDegree ? (
+									hasArea || hasDegree ? (
 										<Text>
 											{hasArea ? item.area : ""}
 											{hasArea && hasDegree ? " " : ""}
@@ -564,7 +581,25 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 										</Text>
 									) : null
 								}
-								middle={<ItemTitle website={item.website}>{item.school}</ItemTitle>}
+								middle={
+									hasItemLogo(item.logo) ? (
+										<View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+											<Image
+												src={item.logo.url}
+												style={{
+													width: item.logo.size,
+													height: item.logo.size,
+													borderRadius: item.logo.borderRadius,
+													objectFit: "contain",
+													flexShrink: 0,
+												}}
+											/>
+											<ItemTitle website={item.website}>{item.school}</ItemTitle>
+										</View>
+									) : (
+										<ItemTitle website={item.website}>{item.school}</ItemTitle>
+									)
+								}
 								trailing={<Text style={composeStyles(alignEndStyle)}>{item.period}</Text>}
 							/>
 							{gradeAndLocation && <Text>{gradeAndLocation}</Text>}
@@ -574,7 +609,23 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 					const renderSplitHeader = () => (
 						<>
 							<View style={composeStyles(splitRowStyle)}>
-								<ItemTitle website={item.website}>{item.school}</ItemTitle>
+								{hasItemLogo(item.logo) ? (
+									<View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+										<Image
+											src={item.logo.url}
+											style={{
+												width: item.logo.size,
+												height: item.logo.size,
+												borderRadius: item.logo.borderRadius,
+												objectFit: "contain",
+												flexShrink: 0,
+											}}
+										/>
+										<ItemTitle website={item.website}>{item.school}</ItemTitle>
+									</View>
+								) : (
+									<ItemTitle website={item.website}>{item.school}</ItemTitle>
+								)}
 								{hasSplitRowText(headerDegreeAndGrade) && (
 									<Text style={composeStyles(alignEndStyle)}>{headerDegreeAndGrade}</Text>
 								)}

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -475,6 +475,7 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 												borderRadius: item.logo.borderRadius,
 												objectFit: "contain",
 												flexShrink: 0,
+												alignSelf: "center",
 											}}
 										/>
 										<ItemTitle website={item.website}>{item.company}</ItemTitle>
@@ -500,6 +501,7 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 												borderRadius: item.logo.borderRadius,
 												objectFit: "contain",
 												flexShrink: 0,
+												alignSelf: "center",
 											}}
 										/>
 										<ItemTitle website={item.website}>{item.company}</ItemTitle>
@@ -592,6 +594,7 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 													borderRadius: item.logo.borderRadius,
 													objectFit: "contain",
 													flexShrink: 0,
+													alignSelf: "center",
 												}}
 											/>
 											<ItemTitle website={item.website}>{item.school}</ItemTitle>
@@ -619,6 +622,7 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 												borderRadius: item.logo.borderRadius,
 												objectFit: "contain",
 												flexShrink: 0,
+												alignSelf: "center",
 											}}
 										/>
 										<ItemTitle website={item.website}>{item.school}</ItemTitle>

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -477,9 +477,7 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 												flexShrink: 0,
 											}}
 										/>
-										<View style={{ flex: 1 }}>
-											<ItemTitle website={item.website}>{item.company}</ItemTitle>
-										</View>
+										<ItemTitle website={item.website}>{item.company}</ItemTitle>
 									</View>
 								) : (
 									<ItemTitle website={item.website}>{item.company}</ItemTitle>
@@ -504,9 +502,7 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 												flexShrink: 0,
 											}}
 										/>
-										<View style={{ flex: 1 }}>
-											<ItemTitle website={item.website}>{item.company}</ItemTitle>
-										</View>
+										<ItemTitle website={item.website}>{item.company}</ItemTitle>
 									</View>
 								) : (
 									<ItemTitle website={item.website}>{item.company}</ItemTitle>
@@ -598,9 +594,7 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 													flexShrink: 0,
 												}}
 											/>
-											<View style={{ flex: 1 }}>
-												<ItemTitle website={item.website}>{item.school}</ItemTitle>
-											</View>
+											<ItemTitle website={item.website}>{item.school}</ItemTitle>
 										</View>
 									) : (
 										<ItemTitle website={item.website}>{item.school}</ItemTitle>
@@ -627,9 +621,7 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 												flexShrink: 0,
 											}}
 										/>
-										<View style={{ flex: 1 }}>
-											<ItemTitle website={item.website}>{item.school}</ItemTitle>
-										</View>
+										<ItemTitle website={item.website}>{item.school}</ItemTitle>
 									</View>
 								) : (
 									<ItemTitle website={item.website}>{item.school}</ItemTitle>

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -466,7 +466,7 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 							}
 							middle={
 								hasItemLogo(item.logo) ? (
-									<View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+									<View style={{ flexDirection: "row", alignItems: "center", columnGap: 4 }}>
 										<Image
 											src={item.logo.url}
 											style={{
@@ -477,7 +477,9 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 												flexShrink: 0,
 											}}
 										/>
-										<ItemTitle website={item.website}>{item.company}</ItemTitle>
+										<View style={{ flex: 1 }}>
+											<ItemTitle website={item.website}>{item.company}</ItemTitle>
+										</View>
 									</View>
 								) : (
 									<ItemTitle website={item.website}>{item.company}</ItemTitle>
@@ -491,7 +493,7 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 						<>
 							<View style={composeStyles(splitRowStyle)}>
 								{hasItemLogo(item.logo) ? (
-									<View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+									<View style={{ flexDirection: "row", alignItems: "center", columnGap: 4 }}>
 										<Image
 											src={item.logo.url}
 											style={{
@@ -502,7 +504,9 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 												flexShrink: 0,
 											}}
 										/>
-										<ItemTitle website={item.website}>{item.company}</ItemTitle>
+										<View style={{ flex: 1 }}>
+											<ItemTitle website={item.website}>{item.company}</ItemTitle>
+										</View>
 									</View>
 								) : (
 									<ItemTitle website={item.website}>{item.company}</ItemTitle>
@@ -583,7 +587,7 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 								}
 								middle={
 									hasItemLogo(item.logo) ? (
-										<View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+										<View style={{ flexDirection: "row", alignItems: "center", columnGap: 4 }}>
 											<Image
 												src={item.logo.url}
 												style={{
@@ -594,7 +598,9 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 													flexShrink: 0,
 												}}
 											/>
-											<ItemTitle website={item.website}>{item.school}</ItemTitle>
+											<View style={{ flex: 1 }}>
+												<ItemTitle website={item.website}>{item.school}</ItemTitle>
+											</View>
 										</View>
 									) : (
 										<ItemTitle website={item.website}>{item.school}</ItemTitle>
@@ -610,7 +616,7 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 						<>
 							<View style={composeStyles(splitRowStyle)}>
 								{hasItemLogo(item.logo) ? (
-									<View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+									<View style={{ flexDirection: "row", alignItems: "center", columnGap: 4 }}>
 										<Image
 											src={item.logo.url}
 											style={{
@@ -621,7 +627,9 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 												flexShrink: 0,
 											}}
 										/>
-										<ItemTitle website={item.website}>{item.school}</ItemTitle>
+										<View style={{ flex: 1 }}>
+											<ItemTitle website={item.website}>{item.school}</ItemTitle>
+										</View>
 									</View>
 								) : (
 									<ItemTitle website={item.website}>{item.school}</ItemTitle>

--- a/packages/schema/src/resume/data.test.ts
+++ b/packages/schema/src/resume/data.test.ts
@@ -3,7 +3,9 @@ import {
 	baseSectionSchema,
 	basicsSchema,
 	customFieldSchema,
+	educationItemSchema,
 	experienceItemSchema,
+	itemLogoSchema,
 	layoutSchema,
 	pageSchema,
 	pictureSchema,
@@ -419,5 +421,119 @@ describe("styleRulesSchema", () => {
 				slots: { heading: { opacity: 2, lineHeight: 10, letterSpacing: -17 } },
 			}).success,
 		).toBe(false);
+	});
+});
+
+describe("itemLogoSchema", () => {
+	it("accepts a valid logo object", () => {
+		expect(
+			itemLogoSchema.safeParse({ hidden: false, url: "/uploads/logo.png", size: 32, borderRadius: 4 }).success,
+		).toBe(true);
+	});
+
+	it("defaults hidden to false when missing", () => {
+		const result = itemLogoSchema.safeParse({ url: "", size: 32, borderRadius: 0 });
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.hidden).toBe(false);
+	});
+
+	it("defaults url to empty string when missing", () => {
+		const result = itemLogoSchema.safeParse({ hidden: false, size: 32, borderRadius: 0 });
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.url).toBe("");
+	});
+
+	it("defaults size to 32 when missing", () => {
+		const result = itemLogoSchema.safeParse({ hidden: false, url: "" });
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.size).toBe(32);
+	});
+
+	it("defaults borderRadius to 0 when missing", () => {
+		const result = itemLogoSchema.safeParse({ hidden: false, url: "" });
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.borderRadius).toBe(0);
+	});
+
+	it("rejects size below 16", () => {
+		const result = itemLogoSchema.safeParse({ hidden: false, url: "", size: 8, borderRadius: 0 });
+		// .catch() means it coerces to default 32, not rejects
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.size).toBe(32);
+	});
+
+	it("rejects borderRadius above 50 (coerces to default)", () => {
+		const result = itemLogoSchema.safeParse({ hidden: false, url: "", size: 32, borderRadius: 999 });
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.borderRadius).toBe(0);
+	});
+});
+
+describe("experienceItemSchema – logo field", () => {
+	const baseExperience = {
+		id: "1",
+		hidden: false,
+		company: "Acme Corp",
+		position: "Developer",
+		location: "NYC",
+		period: "2020–2021",
+		website: { url: "", label: "", inlineLink: false },
+		description: "",
+		roles: [],
+	};
+
+	it("accepts an item with a logo", () => {
+		const result = experienceItemSchema.safeParse({
+			...baseExperience,
+			logo: { hidden: false, url: "/api/uploads/logo.jpeg", size: 32, borderRadius: 4 },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("provides default logo when logo field is absent", () => {
+		const result = experienceItemSchema.safeParse(baseExperience);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.logo).toEqual({ hidden: false, url: "", size: 32, borderRadius: 0 });
+		}
+	});
+
+	it("provides default logo when logo field is invalid", () => {
+		const result = experienceItemSchema.safeParse({ ...baseExperience, logo: "not-an-object" });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.logo).toEqual({ hidden: false, url: "", size: 32, borderRadius: 0 });
+		}
+	});
+});
+
+describe("educationItemSchema – logo field", () => {
+	const baseEducation = {
+		id: "1",
+		hidden: false,
+		school: "MIT",
+		degree: "BSc",
+		area: "Computer Science",
+		grade: "4.0",
+		location: "Cambridge, MA",
+		period: "2016–2020",
+		website: { url: "", label: "", inlineLink: false },
+		description: "",
+	};
+
+	it("accepts an item with a logo", () => {
+		const result = educationItemSchema.safeParse({
+			...baseEducation,
+			logo: { hidden: false, url: "/api/uploads/mit.jpeg", size: 48, borderRadius: 8 },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("provides default logo when logo field is absent", () => {
+		const result = educationItemSchema.safeParse(baseEducation);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.logo).toEqual({ hidden: false, url: "", size: 32, borderRadius: 0 });
+		}
 	});
 });

--- a/packages/schema/src/resume/data.ts
+++ b/packages/schema/src/resume/data.ts
@@ -75,6 +75,28 @@ export const pictureSchema = z.object({
 		.describe("The width of the shadow of the picture to display on the resume, defined in points (pt)."),
 });
 
+export const itemLogoSchema = z.object({
+	hidden: z.boolean().catch(false).describe("Whether to hide the logo from the resume."),
+	url: z
+		.string()
+		.catch("")
+		.describe(
+			"The URL to the logo to display on the resume. Prefer local app-served paths (for example /uploads/...) populated via upload.",
+		),
+	size: z
+		.number()
+		.min(16)
+		.max(128)
+		.catch(32)
+		.describe("The size of the logo to display on the resume, defined in points (pt)."),
+	borderRadius: z
+		.number()
+		.min(0)
+		.max(50)
+		.catch(0)
+		.describe("The border radius of the logo to display on the resume, defined in points (pt)."),
+});
+
 export const customFieldSchema = z.object({
 	id: z.string().describe("The unique identifier for the custom field. Usually generated as a UUID."),
 	icon: iconSchema,
@@ -141,6 +163,9 @@ export const educationItemSchema = baseItemSchema.extend({
 	period: z.string().describe("The period of time the education was obtained over."),
 	website: itemWebsiteSchema.describe("The website of the school or institution, if any."),
 	description: z.string().describe("The description of the education. This should be a HTML-formatted string."),
+	logo: itemLogoSchema
+		.catch({ hidden: false, url: "", size: 32, borderRadius: 0 })
+		.describe("The logo of the school or institution, if any."),
 });
 
 export const roleItemSchema = z.object({
@@ -171,6 +196,9 @@ export const experienceItemSchema = baseItemSchema.extend({
 		.array(roleItemSchema)
 		.catch([])
 		.describe("List of individual roles held at this company to show career progression."),
+	logo: itemLogoSchema
+		.catch({ hidden: false, url: "", size: 32, borderRadius: 0 })
+		.describe("The logo of the company or organization, if any."),
 });
 
 export const interestItemSchema = baseItemSchema.extend({
@@ -679,5 +707,6 @@ export type ReferencesSection = z.infer<typeof referencesSectionSchema>;
 export type SkillsSection = z.infer<typeof skillsSectionSchema>;
 export type VolunteerSection = z.infer<typeof volunteerSectionSchema>;
 export type Picture = z.infer<typeof pictureSchema>;
+export type ItemLogo = z.infer<typeof itemLogoSchema>;
 export type CustomField = z.infer<typeof customFieldSchema>;
 export type Website = z.infer<typeof websiteSchema>;


### PR DESCRIPTION
## Summary

Adds an optional logo image to **Experience** and **Education** section items, so users can display company or school logos directly on their resume.

---

## Changes

### Schema (`packages/schema`)
- Add `itemLogoSchema` with `hidden`, `url`, `size` (16–128 pt), `borderRadius` (0–50 pt) fields
- Extend `experienceItemSchema` and `educationItemSchema` with `logo` field
- Backward-compatible: existing items without `logo` default to `{ hidden: false, url: "", size: 32, borderRadius: 0 }` via `.catch()`
- Export new `ItemLogo` type

### UI (`apps/web`)
- New `LogoUploadField` component (`apps/web/src/components/input/logo-upload.tsx`)
  - Image upload / delete with preview
  - Direct URL input
  - Eye/EyeSlash toggle to show/hide logo (default: visible)
  - Size and border-radius numeric controls
- `Company Logo` field added to the Experience dialog
- `School Logo` field added to the Education dialog

### PDF rendering (`packages/pdf`)
- New `hasItemLogo()` helper (`templates/shared/item-image.ts`)
- Logo rendered inline, immediately left of the company/school name, in both `renderInlineHeader` and `renderSplitHeader`
- `InlineItemHeader` gains an optional `center` prop: when a logo is present the entire row (`leading` / `middle` / `trailing`) aligns to `center` instead of `flex-start`, keeping position text and date vertically centred against the logo
- All 15 templates supported automatically (logic lives in shared `sections.tsx`)

### Tests
- `itemLogoSchema` validation (defaults, min/max coercion)
- `experienceItemSchema` and `educationItemSchema` logo field (presence, absence, invalid input)
- `hasItemLogo()` helper (hidden, empty URL, whitespace, undefined)
- All 315 existing tests continue to pass

---

## Screenshots

### Experience item with logo — live preview

<img width="652" height="36" alt="image" src="https://github.com/user-attachments/assets/a86a207f-a758-4c1b-998a-4dd713d795dc" />

<img width="641" height="30" alt="image" src="https://github.com/user-attachments/assets/b5093e96-983c-4922-8f12-aa33e1dbec21" />


### Education item with logo — live preview

<img width="738" height="76" alt="image" src="https://github.com/user-attachments/assets/ed4ba204-a99f-47d9-98b0-923b3d98474e" />


### Logo upload UI in the item dialog

<img width="662" height="190" alt="image" src="https://github.com/user-attachments/assets/1e6969b0-302e-4d97-a6e5-349ea019caed" />

<img width="666" height="205" alt="image" src="https://github.com/user-attachments/assets/85d16689-1629-425a-ba8c-b5925341cdcd" />

<img width="677" height="239" alt="image" src="https://github.com/user-attachments/assets/971a76a0-6f97-48fc-b99c-c534e53f6dda" />

---

## How to test

1. Open any resume in the builder
2. Edit an **Experience** or **Education** item
3. Scroll to the new **Company Logo** / **School Logo** field
4. Upload an image or paste a URL
5. Toggle the eye icon to verify hide/show behaviour
6. Preview the resume and export as PDF — logo should appear left of the company/school name
7. Confirm that items without a logo render identically to before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload and manage logos for education and experience entries (preview, URL entry, hide/show, size and border-radius controls).
  * Logos now appear alongside titles in generated resume PDFs.
* **Schema / Validation**
  * Added logo schema with defaults and bounds for size and border radius.
* **Tests**
  * Added unit tests covering logo schema defaults, bounds, and presence checks used by PDF rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->