### PR TITLE
fix(fonts): register Noto Armenian fallback fonts for Armenian script

### DIFF
--- a/packages/fonts/src/index.test.ts
+++ b/packages/fonts/src/index.test.ts
@@ -196,6 +196,11 @@ describe("getPdfFallbackFontFamilies", () => {
 		expect(getPdfFallbackFontFamilies("Helvetica", { locale: "th-TH" })).toEqual(["Noto Sans Thai"]);
 	});
 
+	it("uses the category-matching Armenian Noto font (real sans and serif variants exist)", () => {
+		expect(getPdfFallbackFontFamilies("Helvetica", { scripts: ["armenian"] })).toEqual(["Noto Sans Armenian"]);
+		expect(getPdfFallbackFontFamilies("Times-Roman", { scripts: ["armenian"] })).toEqual(["Noto Serif Armenian"]);
+	});
+
 	it("does not append the Simplified Chinese safety net for non-CJK scripts", () => {
 		expect(getPdfFallbackFontFamilies("Helvetica", { scripts: ["arabic"] })).toEqual(["Noto Sans Arabic"]);
 		expect(getPdfFallbackFontFamilies("Helvetica", { scripts: ["thai"] })).not.toContain("Noto Sans SC");
@@ -226,7 +231,7 @@ describe("getPdfFallbackFontFamilies", () => {
 	it("only returns fonts that exist in the webfontlist", () => {
 		const families = getPdfFallbackFontFamilies("Helvetica", {
 			locale: "ko-KR",
-			scripts: ["hangul", "kana", "han-simplified", "arabic", "hebrew", "thai"],
+			scripts: ["hangul", "kana", "han-simplified", "arabic", "hebrew", "thai", "armenian"],
 		});
 		for (const family of families) {
 			expect(getWebFont(family)).toBeDefined();

--- a/packages/fonts/src/index.ts
+++ b/packages/fonts/src/index.ts
@@ -98,6 +98,7 @@ const scriptFonts: Record<Script, { serif: string; sansSerif: string }> = {
 	arabic: { serif: "Noto Naskh Arabic", sansSerif: "Noto Sans Arabic" },
 	hebrew: { serif: "Noto Sans Hebrew", sansSerif: "Noto Sans Hebrew" },
 	thai: { serif: "Noto Sans Thai", sansSerif: "Noto Sans Thai" },
+	armenian: { serif: "Noto Serif Armenian", sansSerif: "Noto Sans Armenian" },
 };
 
 const genericFontFamilies = new Set([

--- a/packages/fonts/src/webfontlist.json
+++ b/packages/fonts/src/webfontlist.json
@@ -5248,6 +5248,42 @@
 	},
 	{
 		"type": "web",
+		"category": "sans-serif",
+		"family": "Noto Sans Armenian",
+		"weights": ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+		"preview": "https://fonts.gstatic.com/s/notosansarmenian/v47/ZgN0jOZKPa7CHqq0h37c7ReDUubm2SEdFXp7ig73qtTY5idb74R9UdM3y2nZLorxb60i.ttf",
+		"files": {
+			"100": "https://fonts.gstatic.com/s/notosansarmenian/v47/ZgN0jOZKPa7CHqq0h37c7ReDUubm2SEdFXp7ig73qtTY5idb74R9UdM3y2nZLorxbq0i.ttf",
+			"200": "https://fonts.gstatic.com/s/notosansarmenian/v47/ZgN0jOZKPa7CHqq0h37c7ReDUubm2SEdFXp7ig73qtTY5idb74R9UdM3y2nZLopxb60i.ttf",
+			"300": "https://fonts.gstatic.com/s/notosansarmenian/v47/ZgN0jOZKPa7CHqq0h37c7ReDUubm2SEdFXp7ig73qtTY5idb74R9UdM3y2nZLoqvb60i.ttf",
+			"400": "https://fonts.gstatic.com/s/notosansarmenian/v47/ZgN0jOZKPa7CHqq0h37c7ReDUubm2SEdFXp7ig73qtTY5idb74R9UdM3y2nZLorxb60i.ttf",
+			"500": "https://fonts.gstatic.com/s/notosansarmenian/v47/ZgN0jOZKPa7CHqq0h37c7ReDUubm2SEdFXp7ig73qtTY5idb74R9UdM3y2nZLorDb60i.ttf",
+			"600": "https://fonts.gstatic.com/s/notosansarmenian/v47/ZgN0jOZKPa7CHqq0h37c7ReDUubm2SEdFXp7ig73qtTY5idb74R9UdM3y2nZLoovaK0i.ttf",
+			"700": "https://fonts.gstatic.com/s/notosansarmenian/v47/ZgN0jOZKPa7CHqq0h37c7ReDUubm2SEdFXp7ig73qtTY5idb74R9UdM3y2nZLooWaK0i.ttf",
+			"800": "https://fonts.gstatic.com/s/notosansarmenian/v47/ZgN0jOZKPa7CHqq0h37c7ReDUubm2SEdFXp7ig73qtTY5idb74R9UdM3y2nZLopxaK0i.ttf",
+			"900": "https://fonts.gstatic.com/s/notosansarmenian/v47/ZgN0jOZKPa7CHqq0h37c7ReDUubm2SEdFXp7ig73qtTY5idb74R9UdM3y2nZLopYaK0i.ttf"
+		}
+	},
+	{
+		"type": "web",
+		"category": "serif",
+		"family": "Noto Serif Armenian",
+		"weights": ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+		"preview": "https://fonts.gstatic.com/s/notoserifarmenian/v30/3XFMEqMt3YoFsciDRZxptyCUKJmytZ0kVU-XvF7QaZuL85rnQ_zDNzDe5xNnKxyZi8Kbxg.ttf",
+		"files": {
+			"100": "https://fonts.gstatic.com/s/notoserifarmenian/v30/3XFMEqMt3YoFsciDRZxptyCUKJmytZ0kVU-XvF7QaZuL85rnQ_zDNzDe5xNnKxyZi8Obxg.ttf",
+			"200": "https://fonts.gstatic.com/s/notoserifarmenian/v30/3XFMEqMt3YoFsciDRZxptyCUKJmytZ0kVU-XvF7QaZuL85rnQ_zDNzDe5xNnKxyZC8Kbxg.ttf",
+			"300": "https://fonts.gstatic.com/s/notoserifarmenian/v30/3XFMEqMt3YoFsciDRZxptyCUKJmytZ0kVU-XvF7QaZuL85rnQ_zDNzDe5xNnKxyZ1cKbxg.ttf",
+			"400": "https://fonts.gstatic.com/s/notoserifarmenian/v30/3XFMEqMt3YoFsciDRZxptyCUKJmytZ0kVU-XvF7QaZuL85rnQ_zDNzDe5xNnKxyZi8Kbxg.ttf",
+			"500": "https://fonts.gstatic.com/s/notoserifarmenian/v30/3XFMEqMt3YoFsciDRZxptyCUKJmytZ0kVU-XvF7QaZuL85rnQ_zDNzDe5xNnKxyZucKbxg.ttf",
+			"600": "https://fonts.gstatic.com/s/notoserifarmenian/v30/3XFMEqMt3YoFsciDRZxptyCUKJmytZ0kVU-XvF7QaZuL85rnQ_zDNzDe5xNnKxyZVcWbxg.ttf",
+			"700": "https://fonts.gstatic.com/s/notoserifarmenian/v30/3XFMEqMt3YoFsciDRZxptyCUKJmytZ0kVU-XvF7QaZuL85rnQ_zDNzDe5xNnKxyZbMWbxg.ttf",
+			"800": "https://fonts.gstatic.com/s/notoserifarmenian/v30/3XFMEqMt3YoFsciDRZxptyCUKJmytZ0kVU-XvF7QaZuL85rnQ_zDNzDe5xNnKxyZC8Wbxg.ttf",
+			"900": "https://fonts.gstatic.com/s/notoserifarmenian/v30/3XFMEqMt3YoFsciDRZxptyCUKJmytZ0kVU-XvF7QaZuL85rnQ_zDNzDe5xNnKxyZIsWbxg.ttf"
+		}
+	},
+	{
+		"type": "web",
 		"category": "monospace",
 		"family": "VT323",
 		"weights": ["400"],

--- a/packages/pdf/src/hooks/use-register-fonts.test.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.test.ts
@@ -160,6 +160,18 @@ describe("registerFonts", () => {
 		expect(registerSpy).toHaveBeenCalledWith(expect.objectContaining({ family: "Noto Sans Thai" }));
 	});
 
+	it("registers the Armenian Noto fallback for Latin locale when content contains Armenian (no SC safety net)", async () => {
+		const registerSpy = vi.spyOn(Font, "register").mockImplementation(() => {});
+		vi.spyOn(Font, "registerHyphenationCallback").mockImplementation(() => {});
+		const { registerFonts } = await import("./use-register-fonts");
+
+		const pdfTypography = registerFonts(typography, "en-US", false, new Set(["armenian"]));
+
+		expect(pdfTypography.body.fontFamily).toEqual(["IBM Plex Serif", "Noto Serif Armenian"]);
+		expect(registerSpy).toHaveBeenCalledWith(expect.objectContaining({ family: "Noto Serif Armenian" }));
+		expect(registerSpy).not.toHaveBeenCalledWith(expect.objectContaining({ family: "Noto Serif SC" }));
+	});
+
 	it("does NOT enable CJK per-character line breaking for non-CJK fallback scripts", async () => {
 		const registerHyphenationSpy = vi.spyOn(Font, "registerHyphenationCallback").mockImplementation(() => {});
 		vi.spyOn(Font, "register").mockImplementation(() => {});
@@ -352,6 +364,11 @@ describe("resumeContentScripts", () => {
 	it("detects Thai", async () => {
 		const { resumeContentScripts } = await import("./use-register-fonts");
 		expect([...resumeContentScripts(withSummary("สวัสดี"))]).toEqual(["thai"]);
+	});
+
+	it("detects Armenian", async () => {
+		const { resumeContentScripts } = await import("./use-register-fonts");
+		expect([...resumeContentScripts(withSummary("Բարև Ձեզ"))]).toEqual(["armenian"]);
 	});
 
 	it("detects multiple scripts in mixed content", async () => {

--- a/packages/pdf/src/hooks/use-register-fonts.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.ts
@@ -169,6 +169,9 @@ const hanRegex = /[㐀-䶿一-鿿豈-﫿]/;
 const arabicRegex = /[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-ﻼ]/;
 const hebrewRegex = /[֐-׿יִ-ﭏ]/;
 const thaiRegex = /[฀-๿]/;
+// Armenian block (U+0531-U+058F) + Armenian ligatures in the Alphabetic
+// Presentation Forms block (U+FB13-U+FB17, e.g. ﬓ ﬔ ﬕ ﬖ ﬗ).
+const armenianRegex = /[Ա-֏ﬓ-ﬗ]/;
 
 const scriptDetectors: { script: Script; regex: RegExp }[] = [
 	{ script: "hangul", regex: hangulRegex },
@@ -177,6 +180,7 @@ const scriptDetectors: { script: Script; regex: RegExp }[] = [
 	{ script: "arabic", regex: arabicRegex },
 	{ script: "hebrew", regex: hebrewRegex },
 	{ script: "thai", regex: thaiRegex },
+	{ script: "armenian", regex: armenianRegex },
 ];
 
 const collectScripts = (value: unknown, scripts: Set<Script>): void => {

--- a/packages/utils/src/locale.ts
+++ b/packages/utils/src/locale.ts
@@ -75,7 +75,15 @@ export function isCJKLocale(locale: Locale): boolean {
 // a glyph only renders if a registered font contains it. We pick the matching
 // Noto font per script so e.g. Hangul → Noto KR, Arabic → Noto Arabic, instead
 // of falling back to a Latin/Han-only font and producing tofu.
-export type Script = "hangul" | "kana" | "han-traditional" | "han-simplified" | "arabic" | "hebrew" | "thai";
+export type Script =
+	| "hangul"
+	| "kana"
+	| "han-traditional"
+	| "han-simplified"
+	| "arabic"
+	| "hebrew"
+	| "thai"
+	| "armenian";
 
 // The CJK subset of `Script`. CJK needs extra per-character line breaking that
 // must NOT be applied to Arabic (cursive, joined letters) or Thai (combining


### PR DESCRIPTION
## Problem

Armenian text (e.g. a resume written in Հայերեն) renders as tofu (□□□) in **both the PDF export and the on-screen preview**. react-pdf only renders glyphs from registered fonts, and for a resume using a Latin font (e.g. the default IBM Plex Serif) no Armenian-capable font is registered, so Armenian codepoints have no glyph.

## Root cause

v4 bundled the full Google Fonts catalog, which included `Noto Sans Armenian` and `Noto Serif Armenian`. v5 trimmed this to a curated `webfontlist.json` and introduced a per-script Noto fallback mechanism — but that mechanism only covers CJK, Arabic, Hebrew and Thai. Armenian was dropped from the catalog and never added to the fallback system, so it regressed.

## Fix

Adds Armenian to the existing per-script fallback mechanism, mirroring the Arabic/Hebrew/Thai pattern exactly:

- **`packages/fonts/src/webfontlist.json`** — add `Noto Sans Armenian` + `Noto Serif Armenian` (all weights).
- **`packages/utils/src/locale.ts`** — add `"armenian"` to the `Script` union.
- **`packages/fonts/src/index.ts`** — map `armenian → { serif: "Noto Serif Armenian", sansSerif: "Noto Sans Armenian" }`. Unlike Hebrew/Thai, a real Noto **Serif** Armenian exists, so the serif slot uses it rather than reusing the sans font.
- **`packages/pdf/src/hooks/use-register-fonts.ts`** — detect the Armenian block (U+0531–U+058F) and Armenian ligatures (U+FB13–U+FB17) in resume content so the fallback is auto-registered.

Armenian content now resolves against a Noto Armenian font in both the preview and the PDF regardless of the selected primary font, and the fonts remain directly selectable. The detector does not match Latin or Cyrillic, so other languages are unaffected.

## Testing

- `@reactive-resume/fonts` — 62/62 pass (incl. new Armenian fallback-selection cases)
- `@reactive-resume/pdf` — 246/246 pass (incl. new Armenian detection + registration cases)
- `@reactive-resume/utils` `locale.test.ts` — 22/22 pass
- `biome check` on all changed files — clean

## Notes

- No schema/API/DB/migration surface is touched.
- One small judgment call worth flagging: the serif slot maps to the real `Noto Serif Armenian` (a real serif variant exists), whereas Hebrew/Thai reuse their sans font for serif because no serif Noto exists for those scripts. Happy to align to the reuse pattern if maintainers prefer consistency over correct serif glyphs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Armenian language support with native fonts in PDF generation, including automatic script detection for Armenian text

* **Tests**
  * Added test coverage for Armenian script detection and font fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->