### PR TITLE
fix: ensure Atlas Cloud sponsor logo links to website

### DIFF
--- a/apps/web/src/routes/_home/-sections/sponsors.test.tsx
+++ b/apps/web/src/routes/_home/-sections/sponsors.test.tsx
@@ -33,12 +33,19 @@ describe("Sponsors", () => {
 		expect(link).toHaveAttribute("rel", "noopener noreferrer");
 	});
 
-	it("renders the full Atlas Cloud logo", () => {
-		const { getByAltText } = renderSponsors(true);
+	it("renders the full Atlas Cloud logo inside the sponsor link", () => {
+		const { container, getByRole } = renderSponsors(true);
 
-		const logo = getByAltText("Atlas Cloud");
-		expect(logo).toHaveAttribute("src", "/sponsors/atlas-cloud-logo-black.svg");
-		expect(logo).toHaveClass("h-20");
+		const link = getByRole("link", { name: "Atlas Cloud" });
+		const logos = container.querySelectorAll("a[aria-label='Atlas Cloud'] img");
+
+		expect(logos).toHaveLength(2);
+		expect(logos[0]).toHaveAttribute("src", "/sponsors/atlas-cloud-logo-black.svg");
+		expect(logos[0]).toHaveClass("h-20", "pointer-events-none");
+		expect(logos[0]).toHaveAttribute("draggable", "false");
+		expect(logos[1]).toHaveAttribute("src", "/sponsors/atlas-cloud-logo-white.svg");
+		expect(link).toContainElement(logos[0] as HTMLElement);
+		expect(link).toContainElement(logos[1] as HTMLElement);
 	});
 
 	it("thanks sponsors and links sponsorship inquiries to email", () => {

--- a/apps/web/src/routes/_home/-sections/sponsors.tsx
+++ b/apps/web/src/routes/_home/-sections/sponsors.tsx
@@ -28,18 +28,23 @@ export const Sponsors = ({ show }: SponsorsProps) => {
 					target="_blank"
 					rel="noopener noreferrer"
 					aria-label="Atlas Cloud"
-					className="mt-12 block"
+					className="mt-12 inline-block"
 				>
+					<span className="sr-only">Atlas Cloud</span>
 					<img
 						src="/sponsors/atlas-cloud-logo-black.svg"
-						alt="Atlas Cloud"
-						className="h-20 w-auto md:h-24 dark:hidden"
+						alt=""
+						aria-hidden="true"
+						draggable={false}
+						className="pointer-events-none h-20 w-auto md:h-24 dark:hidden"
 						loading="lazy"
 					/>
 					<img
 						src="/sponsors/atlas-cloud-logo-white.svg"
 						alt=""
-						className="hidden h-20 w-auto md:h-24 dark:block"
+						aria-hidden="true"
+						draggable={false}
+						className="pointer-events-none hidden h-20 w-auto md:h-24 dark:block"
 						loading="lazy"
 					/>
 				</a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Atlas Cloud sponsor logo on the homepage so clicks reliably open [atlascloud.ai](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=reactive-resume) instead of the SVG asset in a new tab.

## Changes

- Keep the sponsor logo wrapped in an external anchor with the existing UTM-tagged Atlas Cloud URL
- Add `pointer-events-none` and `draggable={false}` to the light/dark logo images so pointer events go to the anchor
- Add screen-reader-only link text for accessibility
- Extend sponsor section tests to verify both logo variants are inside the link and non-interactive

## Testing

- `pnpm --filter web test -- src/routes/_home/-sections/sponsors.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-640f4bbe-0ad2-41fd-b374-449f862aa6a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-640f4bbe-0ad2-41fd-b374-449f862aa6a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility for sponsor logos with improved screen reader support and visually-hidden text.

* **Style**
  * Adjusted sponsor link layout and disabled logo dragging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->