### PR TITLE
fix(db): attach an error handler to the pg pool

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -11,7 +11,21 @@ declare global {
 
 export function getPool() {
 	if (!globalThis.__pool) {
-		globalThis.__pool = new Pool({ connectionString: env.DATABASE_URL });
+		const pool = new Pool({ connectionString: env.DATABASE_URL });
+		const logPgError = (error: unknown) => {
+			console.error("[db] postgres connection error:", error);
+		};
+		// A Postgres connection can drop at any time — e.g. a serverless Postgres such as Neon
+		// terminating the connection (code 57P01). `pg` surfaces this as an 'error' event, and
+		// without a listener node re-throws it as an unhandled 'error' that crashes the process.
+		// Idle clients emit on the pool; a client that is connecting or checked out emits on the
+		// client itself, so we must listen on both. The pool then discards the dead client and
+		// opens a fresh one on the next query.
+		pool.on("error", logPgError);
+		pool.on("connect", (client) => {
+			client.on("error", logPgError);
+		});
+		globalThis.__pool = pool;
 	}
 	return globalThis.__pool;
 }


### PR DESCRIPTION
**What**
Add an `'error'` listener to the shared `pg` `Pool` in `packages/db/src/client.ts`.

**Why**
`node-postgres` emits an `error` event on the pool when an **idle** pooled client loses its connection. Per the [node-postgres docs](https://node-postgres.com/apis/pool#error), if there is no listener, the error is re-emitted as an unhandled `'error'` event on an `EventEmitter`, which **crashes the Node process**. The pool is currently created with no listener, so a single idle-connection drop takes down the whole server.

I hit this in a self-hosted setup backed by a serverless Postgres: the database terminated an idle connection (`FATAL 57P01 admin_shutdown`) and the API process exited with:
```
error: terminating connection due to administrator command
  severity: 'FATAL', code: '57P01', routine: 'ProcessInterrupts'
  at .../pg-protocol/src/index.ts
```

**Fix**
Log the pool error instead of letting it go unhandled. The pool then discards the dead client and opens a fresh one on the next query, so the server survives transient/idle disconnects.
```ts
pool.on("error", (error) ={
  console.error("[db] idle pool client error:", error);
});
```

**Impact**
- No behavior change on the no error path; purely prevents a process crash from an idle-client error.
- Improves resilience on any Postgres that recycles idle connections (serverless/managed Postgres, PgBouncer, failovers, network blips), not just one provider.

**Testing**
- `pnpm --filter @reactive-resume/db typecheck` ✓
- `pnpm --filter @reactive-resume/db test` ✓ (34 passed)
- `pnpm exec biome check packages/db/src/client.ts` ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection stability by adding robust error handling for PostgreSQL connection and pool failures.
  * Error events from both the pool and newly created connections are now captured and logged more reliably, helping prevent unexpected crashes in serverless PostgreSQL environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->