### PR TITLE
bugfix: fix list break with marker (#3177)

### DIFF
--- a/packages/pdf/src/templates/shared/rich-text.tsx
+++ b/packages/pdf/src/templates/shared/rich-text.tsx
@@ -18,6 +18,10 @@ import { createRichTextStylesheet } from "./rich-text-stylesheet";
 import { safeTextStyle } from "./safe-text-style";
 import { composeStyles } from "./styles";
 
+const richListItemMarkerMargin = {
+	marginRight: 4,
+} satisfies Style;
+
 const richListItemContentStackStyle = {
 	flexDirection: "column",
 } satisfies Style;
@@ -118,10 +122,11 @@ export const RichText = ({ children }: RichTextProps) => {
 					const contentItemStyles = itemStyles.map(stripRichTextVerticalMargins);
 
 					const markerNode = (
-						<PdfText key="marker" style={composeStyles(richListItemMarkerStyle)}>
+						<PdfText key="marker" style={composeStyles(richListItemMarkerStyle, richListItemMarkerMargin)}>
 							{marker}
 						</PdfText>
 					);
+
 					// Same BiDi-injection trick as the <p> renderer — see applyRtlDirectionRecursively.
 					const contentNode = rtl ? (
 						<PdfText
@@ -147,7 +152,10 @@ export const RichText = ({ children }: RichTextProps) => {
 								safeTextStyle,
 							)}
 						>
-							{children}
+							<View style={{ flexDirection: "row", alignItems: "flex-start" }}>
+								{markerNode}
+								{children}
+							</View>
 						</View>
 					);
 
@@ -162,7 +170,7 @@ export const RichText = ({ children }: RichTextProps) => {
 								getRichTextEdgeTrimStyle(element),
 							)}
 						>
-							{rtl ? [contentNode, markerNode] : [markerNode, contentNode]}
+							{rtl ? [contentNode, markerNode] : contentNode}
 						</View>
 					);
 				},

--- a/packages/pdf/src/templates/shared/rich-text.tsx
+++ b/packages/pdf/src/templates/shared/rich-text.tsx
@@ -18,10 +18,6 @@ import { createRichTextStylesheet } from "./rich-text-stylesheet";
 import { safeTextStyle } from "./safe-text-style";
 import { composeStyles } from "./styles";
 
-const richListItemMarkerMargin = {
-	marginRight: 4,
-} satisfies Style;
-
 const richListItemContentStackStyle = {
 	flexDirection: "column",
 } satisfies Style;
@@ -64,6 +60,11 @@ const applyRtlDirectionRecursively = (node: ReactNode): ReactNode => {
 export const RichText = ({ children }: RichTextProps) => {
 	const { metadata, rtl } = useRender();
 	const rtlTextWrapStyle: Style | undefined = rtl ? { direction: "rtl", textAlign: "right" } : undefined;
+
+	const richListItemMarkerMargin: Style = {
+		marginLeft: rtl ? 4 : 0,
+		marginRight: rtl ? 0 : 4
+	};
 	const boldStyle = useTemplateStyle("bold");
 	const linkStyle = useTemplateStyle("link");
 	const richParagraphStyle = useTemplateStyle("richParagraph");


### PR DESCRIPTION
Linked to the issue #3177 

### Summarize:
Wrapped the marker (•) and first child in a nested flexDirection: "row" <View> inside the LTR content node, so react-pdf can't separate them across pages. Added marginRight: 4 on the marker for spacing. Remaining children (rare in practice) can still break independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list item marker spacing consistency in PDF rendering.
  * Enhanced left-to-right and right-to-left list item layout so markers align reliably across directions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->