### PR TITLE
fix: remove overflow hidden from safeTextStyle

### DIFF
--- a/packages/pdf/src/templates/shared/safe-text-style.ts
+++ b/packages/pdf/src/templates/shared/safe-text-style.ts
@@ -4,5 +4,4 @@ export const safeTextStyle = {
 	minWidth: 0,
 	maxWidth: "100%",
 	flexShrink: 1,
-	overflow: "hidden",
 } satisfies Style;

--- a/packages/pdf/src/templates/shared/styles.ts
+++ b/packages/pdf/src/templates/shared/styles.ts
@@ -31,10 +31,6 @@ export const mergeStyles = (...styles: StyleInput[]): Style => Object.assign({},
 export const mergeLinkStyles = (options: LinkStyleOptions = {}, ...styles: StyleInput[]): Style =>
 	mergeStyles(...styles, resolveLinkDecorationStyle(options));
 
-// Increased from 1.2 to 1.3 to prevent descenders (g, p, y, etc.) from being
-// clipped by the overflow:hidden applied in safeTextStyle on all Heading elements.
-// At 1.5× heading font size, a lineHeight of 1.2 leaves insufficient room for
-// the descender depth of many fonts, causing letters to appear visually cut off.
 export const headerNameLineHeight = 1.3;
 
 export type ResolvePlacementColorOptions = {


### PR DESCRIPTION
found the root cause of the text wrapping issue - `overflow: hidden` in `safeTextStyle` was being applied to all Text primitives in the PDF renderer. in `@react-pdf/renderer` v4.x this clips the element at its initial computed height, so any text after a line break just gets hidden.

fix is a one-liner: remove `overflow: hidden` from `safeTextStyle`. the other properties (`minWidth: 0`, `maxWidth: 100%`, `flexShrink: 1`) already handle horizontal containment so nothing else breaks.

also removed the stale comment in `styles.ts` that was documenting a lineHeight workaround for the same overflow clipping issue on headings.

## changes
- `packages/pdf/src/templates/shared/safe-text-style.ts` - removed `overflow: hidden`
- `packages/pdf/src/templates/shared/styles.ts` - removed stale workaround comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved link-style handling for PDF content, helping link appearance stay consistent when styling is combined.

* **Bug Fixes**
  * Adjusted text styling to avoid clipping issues in narrow layouts by changing how overflow is handled.
  * Cleaned up heading spacing behavior without changing the visible layout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

referencing issue #3184 and #3185 