### PR TITLE
Hyphenation on line-broken text

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -58,6 +58,7 @@
 		"es-toolkit": "^1.49.0",
 		"fast-json-patch": "^3.1.1",
 		"hono": "^4.12.27",
+		"hyphen": "1.14.1",
 		"jsonrepair": "^3.14.1",
 		"node-html-parser": "^8.0.3",
 		"nodemailer": "^9.0.1",

--- a/compose.yml
+++ b/compose.yml
@@ -82,6 +82,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    restart: unless-stopped
     networks:
       - data_network
       - storage_network

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -27,6 +27,7 @@
 		"@reactive-resume/schema": "workspace:*",
 		"@reactive-resume/utils": "workspace:*",
 		"cjk-regex": "^3.4.0",
+		"hyphen": "1.14.1",
 		"node-html-parser": "^8.0.3",
 		"phosphor-icons-react-pdf": "^0.1.3",
 		"react": "^19.2.7",

--- a/packages/pdf/src/hooks/use-register-fonts.test.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.test.ts
@@ -269,22 +269,10 @@ describe("registerFonts", () => {
 
 		const hyphenationCallback = registerHyphenationSpy.mock.calls.at(-1)?.[0];
 		expect(hyphenationCallback?.("Reactive")).toEqual(["Reactive"]);
-		expect(hyphenationCallback?.("Information")).toEqual(["In", "", "for", "", "ma", "", "tion"]);
-		expect(hyphenationCallback?.("Produktivitet")).toEqual(["Pro", "", "duk", "", "ti", "", "vi", "", "tet"]);
-		expect(hyphenationCallback?.("Tidsplanlægning,")).toEqual(["Tids", "", "plan", "", "læg", "", "ning,"]);
-		expect(hyphenationCallback?.("Informationsstyring")).toEqual([
-			"In",
-			"",
-			"for",
-			"",
-			"ma",
-			"",
-			"tions",
-			"",
-			"sty",
-			"",
-			"ring",
-		]);
+		expect(hyphenationCallback?.("Information")).toEqual(["In", "for", "ma", "tion"]);
+		expect(hyphenationCallback?.("Produktivitet")).toEqual(["Pro", "duk", "ti", "vi", "tet"]);
+		expect(hyphenationCallback?.("Tidsplanlægning,")).toEqual(["Tids", "plan", "læg", "ning,"]);
+		expect(hyphenationCallback?.("Informationsstyring")).toEqual(["In", "for", "ma", "tions", "sty", "ring"]);
 	});
 
 	it("does not apply Danish hyphenation to English pages", async () => {
@@ -294,18 +282,8 @@ describe("registerFonts", () => {
 		registerFonts(typography, "en-US");
 
 		const hyphenationCallback = registerHyphenationSpy.mock.calls.at(-1)?.[0];
-		expect(hyphenationCallback?.("Productivity")).toEqual(["Pro", "", "duc", "", "tiv", "", "i", "", "ty"]);
-		expect(hyphenationCallback?.("Informationsstyring")).toEqual([
-			"In",
-			"",
-			"for",
-			"",
-			"ma",
-			"",
-			"tion",
-			"",
-			"sstyring",
-		]);
+		expect(hyphenationCallback?.("Productivity")).toEqual(["Pro", "duc", "tiv", "i", "ty"]);
+		expect(hyphenationCallback?.("Informationsstyring")).toEqual(["In", "for", "ma", "tion", "sstyring"]);
 	});
 
 	it("returns typography with font weights sorted ascending", async () => {

--- a/packages/pdf/src/hooks/use-register-fonts.test.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.test.ts
@@ -261,6 +261,53 @@ describe("registerFonts", () => {
 		expect(hyphenationCallback?.("Reactive")).toEqual(["Reactive"]);
 	});
 
+	it("adds locale-specific break points for long Latin words", async () => {
+		const registerHyphenationSpy = vi.spyOn(Font, "registerHyphenationCallback").mockImplementation(() => {});
+		const { registerFonts } = await import("./use-register-fonts");
+
+		registerFonts(typography, "da-DK");
+
+		const hyphenationCallback = registerHyphenationSpy.mock.calls.at(-1)?.[0];
+		expect(hyphenationCallback?.("Reactive")).toEqual(["Reactive"]);
+		expect(hyphenationCallback?.("Information")).toEqual(["In", "", "for", "", "ma", "", "tion"]);
+		expect(hyphenationCallback?.("Produktivitet")).toEqual(["Pro", "", "duk", "", "ti", "", "vi", "", "tet"]);
+		expect(hyphenationCallback?.("Tidsplanlægning,")).toEqual(["Tids", "", "plan", "", "læg", "", "ning,"]);
+		expect(hyphenationCallback?.("Informationsstyring")).toEqual([
+			"In",
+			"",
+			"for",
+			"",
+			"ma",
+			"",
+			"tions",
+			"",
+			"sty",
+			"",
+			"ring",
+		]);
+	});
+
+	it("does not apply Danish hyphenation to English pages", async () => {
+		const registerHyphenationSpy = vi.spyOn(Font, "registerHyphenationCallback").mockImplementation(() => {});
+		const { registerFonts } = await import("./use-register-fonts");
+
+		registerFonts(typography, "en-US");
+
+		const hyphenationCallback = registerHyphenationSpy.mock.calls.at(-1)?.[0];
+		expect(hyphenationCallback?.("Productivity")).toEqual(["Pro", "", "duc", "", "tiv", "", "i", "", "ty"]);
+		expect(hyphenationCallback?.("Informationsstyring")).toEqual([
+			"In",
+			"",
+			"for",
+			"",
+			"ma",
+			"",
+			"tion",
+			"",
+			"sstyring",
+		]);
+	});
+
 	it("returns typography with font weights sorted ascending", async () => {
 		vi.spyOn(Font, "register").mockImplementation(() => {});
 		const { registerFonts } = await import("./use-register-fonts");

--- a/packages/pdf/src/hooks/use-register-fonts.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.ts
@@ -2,8 +2,8 @@ import type { FontWeight } from "@reactive-resume/fonts";
 import type { ResumeData, Typography } from "@reactive-resume/schema/resume/data";
 import type { Locale, Script } from "@reactive-resume/utils/locale";
 import { letters as cjkLetters } from "cjk-regex";
-import daHyphenator from "hyphen/da";
-import enUsHyphenator from "hyphen/en-us";
+import daHyphenator from "hyphen/da/index.js";
+import enUsHyphenator from "hyphen/en-us/index.js";
 import {
 	getFont,
 	getPdfFallbackFontFamilies,

--- a/packages/pdf/src/hooks/use-register-fonts.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.ts
@@ -150,9 +150,6 @@ const chunkGraphemes = (value: string, maxChunkLength: number): string[] => {
 	return chunks;
 };
 
-const createEmergencyBreaks = (chunks: string[]): string[] =>
-	chunks.flatMap((chunk, index) => (index === chunks.length - 1 ? [chunk] : [chunk, ""]));
-
 const hyphenateWith = (word: string, hyphenator: Hyphenator): string[] | null => {
 	const hyphenated = hyphenator.hyphenateSync(word, { hyphenChar: hyphenationSeparator });
 	const chunks = hyphenated.split(hyphenationSeparator);
@@ -165,7 +162,7 @@ const hyphenateWithLocale = (word: string, locale: Locale): string[] | null => {
 	if (!hyphenator) return null;
 
 	const chunks = hyphenateWith(word, hyphenator);
-	return chunks ? createEmergencyBreaks(chunks) : null;
+	return chunks;
 };
 
 const hyphenateLatinWord = (word: string, locale: Locale): string[] => {
@@ -179,11 +176,9 @@ const hyphenateLatinWord = (word: string, locale: Locale): string[] => {
 	if (localeHyphenation) return localeHyphenation;
 
 	const chunks = chunkGraphemes(body, latinEmergencyBreakMaxChunkLength);
-	const prefixedChunks = chunks.map(
+	return chunks.map(
 		(chunk, index) => `${index === 0 ? prefix : ""}${chunk}${index === chunks.length - 1 ? suffix : ""}`,
 	);
-
-	return createEmergencyBreaks(prefixedChunks);
 };
 
 // Resolves the user-stored family to the one we hand to Font.register:

--- a/packages/pdf/src/hooks/use-register-fonts.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.ts
@@ -2,8 +2,8 @@ import type { FontWeight } from "@reactive-resume/fonts";
 import type { ResumeData, Typography } from "@reactive-resume/schema/resume/data";
 import type { Locale, Script } from "@reactive-resume/utils/locale";
 import { letters as cjkLetters } from "cjk-regex";
-import daHyphenator from "hyphen/da/index.js";
-import enUsHyphenator from "hyphen/en-us/index.js";
+import daHyphenator from "hyphen/da";
+import enUsHyphenator from "hyphen/en-us";
 import {
 	getFont,
 	getPdfFallbackFontFamilies,

--- a/packages/pdf/src/hooks/use-register-fonts.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.ts
@@ -2,6 +2,8 @@ import type { FontWeight } from "@reactive-resume/fonts";
 import type { ResumeData, Typography } from "@reactive-resume/schema/resume/data";
 import type { Locale, Script } from "@reactive-resume/utils/locale";
 import { letters as cjkLetters } from "cjk-regex";
+import daHyphenator from "hyphen/da/index.js";
+import enUsHyphenator from "hyphen/en-us/index.js";
 import {
 	getFont,
 	getPdfFallbackFontFamilies,
@@ -18,11 +20,24 @@ type FontWeightRange = {
 	highest: number;
 };
 
+type Hyphenator = {
+	hyphenateSync: (text: string, options?: { hyphenChar?: string }) => string;
+};
+
 const registeredFontVariants = new Set<string>();
 const fallbackFontFamily = "IBM Plex Serif";
 const cjkLetterRegex = cjkLetters().toRegExp();
 const fontWeightValues = new Set<FontWeight>(["100", "200", "300", "400", "500", "600", "700", "800", "900"]);
 const preferredFallbackFontWeights = ["400", "700", "600", "500"] satisfies FontWeight[];
+const latinEmergencyBreakMinLength = 11;
+const latinEmergencyBreakMaxChunkLength = 6;
+const hyphenationSeparator = "\u001F";
+const latinTokenRegex = /^([^\p{L}\p{M}\p{N}]*)([\p{L}\p{M}\p{N}]+)([^\p{L}\p{M}\p{N}]*)$/u;
+const localeHyphenators: Partial<Record<Locale, Hyphenator>> = {
+	"da-DK": daHyphenator as Hyphenator,
+	"en-GB": enUsHyphenator as Hyphenator,
+	"en-US": enUsHyphenator as Hyphenator,
+};
 
 // `fontFamily` is widened to `string | string[]` so react-pdf can do
 // glyph-level font fallback for CJK characters (#2986).
@@ -115,6 +130,60 @@ const collectFontRangeWeights = (ranges: FontWeightRange[]): number[] => {
 	}
 
 	return [...weights];
+};
+
+const chunkGraphemes = (value: string, maxChunkLength: number): string[] => {
+	const graphemes = [...value];
+	const chunkCount = Math.ceil(graphemes.length / maxChunkLength);
+	const chunks: string[] = [];
+	let cursor = 0;
+
+	for (let index = 0; index < chunkCount; index++) {
+		const remainingGraphemes = graphemes.length - cursor;
+		const remainingChunks = chunkCount - index;
+		const chunkLength = Math.ceil(remainingGraphemes / remainingChunks);
+
+		chunks.push(graphemes.slice(cursor, cursor + chunkLength).join(""));
+		cursor += chunkLength;
+	}
+
+	return chunks;
+};
+
+const createEmergencyBreaks = (chunks: string[]): string[] =>
+	chunks.flatMap((chunk, index) => (index === chunks.length - 1 ? [chunk] : [chunk, ""]));
+
+const hyphenateWith = (word: string, hyphenator: Hyphenator): string[] | null => {
+	const hyphenated = hyphenator.hyphenateSync(word, { hyphenChar: hyphenationSeparator });
+	const chunks = hyphenated.split(hyphenationSeparator);
+
+	return chunks.length > 1 ? chunks : null;
+};
+
+const hyphenateWithLocale = (word: string, locale: Locale): string[] | null => {
+	const hyphenator = localeHyphenators[locale];
+	if (!hyphenator) return null;
+
+	const chunks = hyphenateWith(word, hyphenator);
+	return chunks ? createEmergencyBreaks(chunks) : null;
+};
+
+const hyphenateLatinWord = (word: string, locale: Locale): string[] => {
+	const match = latinTokenRegex.exec(word);
+	const [, prefix = "", body = "", suffix = ""] = match ?? [];
+	const graphemeCount = [...body].length;
+
+	if (!match || graphemeCount < latinEmergencyBreakMinLength) return [word];
+
+	const localeHyphenation = hyphenateWithLocale(word, locale);
+	if (localeHyphenation) return localeHyphenation;
+
+	const chunks = chunkGraphemes(body, latinEmergencyBreakMaxChunkLength);
+	const prefixedChunks = chunks.map(
+		(chunk, index) => `${index === 0 ? prefix : ""}${chunk}${index === chunks.length - 1 ? suffix : ""}`,
+	);
+
+	return createEmergencyBreaks(prefixedChunks);
 };
 
 // Resolves the user-stored family to the one we hand to Font.register:
@@ -231,7 +300,7 @@ export const registerFonts = (
 			}
 		}
 
-		return [word];
+		return hyphenateLatinWord(word, locale);
 	});
 
 	const pdfTypography = resolvePdfTypography(typography);

--- a/packages/pdf/src/hyphen.d.ts
+++ b/packages/pdf/src/hyphen.d.ts
@@ -1,4 +1,4 @@
-declare module "hyphen/da" {
+declare module "hyphen/da/index.js" {
 	const hyphenator: {
 		hyphenateSync: (text: string, options?: { hyphenChar?: string }) => string;
 	};
@@ -6,7 +6,7 @@ declare module "hyphen/da" {
 	export default hyphenator;
 }
 
-declare module "hyphen/en-us" {
+declare module "hyphen/en-us/index.js" {
 	const hyphenator: {
 		hyphenateSync: (text: string, options?: { hyphenChar?: string }) => string;
 	};

--- a/packages/pdf/src/hyphen.d.ts
+++ b/packages/pdf/src/hyphen.d.ts
@@ -1,4 +1,4 @@
-declare module "hyphen/da/index.js" {
+declare module "hyphen/da" {
 	const hyphenator: {
 		hyphenateSync: (text: string, options?: { hyphenChar?: string }) => string;
 	};
@@ -6,7 +6,7 @@ declare module "hyphen/da/index.js" {
 	export default hyphenator;
 }
 
-declare module "hyphen/en-us/index.js" {
+declare module "hyphen/en-us" {
 	const hyphenator: {
 		hyphenateSync: (text: string, options?: { hyphenChar?: string }) => string;
 	};

--- a/packages/pdf/src/hyphen.d.ts
+++ b/packages/pdf/src/hyphen.d.ts
@@ -1,0 +1,15 @@
+declare module "hyphen/da/index.js" {
+	const hyphenator: {
+		hyphenateSync: (text: string, options?: { hyphenChar?: string }) => string;
+	};
+
+	export default hyphenator;
+}
+
+declare module "hyphen/en-us/index.js" {
+	const hyphenator: {
+		hyphenateSync: (text: string, options?: { hyphenChar?: string }) => string;
+	};
+
+	export default hyphenator;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       hono:
         specifier: ^4.12.27
         version: 4.12.27
+      hyphen:
+        specifier: 1.14.1
+        version: 1.14.1
       jsonrepair:
         specifier: ^3.14.1
         version: 3.14.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -947,6 +947,9 @@ importers:
       cjk-regex:
         specifier: ^3.4.0
         version: 3.4.0
+      hyphen:
+        specifier: 1.14.1
+        version: 1.14.1
       node-html-parser:
         specifier: ^8.0.3
         version: 8.0.3


### PR DESCRIPTION
Long words were not wrapping properly on cells and lacked automatic hyphenation.

For now it only involves english and danish hyphenation as those are my main languages. You are welcome to add your languages or modify for a more general-purpose hyphenation across all languages


A section element title being hyphenated due to its length
<img width="341" height="519" alt="image" src="https://github.com/user-attachments/assets/14c10b8d-b63b-4e01-8a79-7e558c43c16c" />


A section element text being hyphenated due to the cell size
<img width="381" height="523" alt="image" src="https://github.com/user-attachments/assets/050d6a3b-0caf-48b6-98e0-9205215332ef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved locale-aware hyphenation for PDF text to enhance line wrapping for long Latin words (including Danish and US English).
* **Bug Fixes**
  * Resolved hyphenation behavior when line breaking is enabled: non-CJK text now wraps using hyphenated chunks instead of staying unbroken.
  * Danish hyphenation is applied only for the Danish locale, avoiding incorrect English results.
* **Tests**
  * Added hyphenation test coverage for Danish and US English scenarios.
* **Chores**
  * Added a Docker restart policy to keep the server running unless explicitly stopped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->