### PR TITLE
fix: add conditional flex:1 for nested list content to fix layout

### DIFF
--- a/packages/pdf/src/templates/shared/rich-text.tsx
+++ b/packages/pdf/src/templates/shared/rich-text.tsx
@@ -128,6 +128,15 @@ export const RichText = ({ children }: RichTextProps) => {
 						</PdfText>
 					);
 
+          let hasNestedList = false;
+          if (Array.isArray(children)) {
+            hasNestedList = children!.some(
+              (child) =>
+                child?.props?.element?.rawTagName === "ul" ||
+                child?.props?.element?.rawTagName === "ol",
+            );
+          }
+
 					// Same BiDi-injection trick as the <p> renderer — see applyRtlDirectionRecursively.
 					const contentNode = rtl ? (
 						<PdfText
@@ -155,7 +164,7 @@ export const RichText = ({ children }: RichTextProps) => {
 						>
 							<View style={{ flexDirection: "row", alignItems: "flex-start" }}>
 								{markerNode}
-								{children}
+                <View style={hasNestedList ? { flex: 1 } : {}}>{children}</View>
 							</View>
 						</View>
 					);

--- a/packages/pdf/src/templates/shared/rich-text.tsx
+++ b/packages/pdf/src/templates/shared/rich-text.tsx
@@ -130,7 +130,7 @@ export const RichText = ({ children }: RichTextProps) => {
 
           let hasNestedList = false;
           if (Array.isArray(children)) {
-            hasNestedList = children!.some(
+            hasNestedList = children.some(
               (child) =>
                 child?.props?.element?.rawTagName === "ul" ||
                 child?.props?.element?.rawTagName === "ol",


### PR DESCRIPTION
## Problem

Not passing a width to flex children passed to Yoga can cause an overflow or collapse instead of wrapping correctly.

This single change addresses two separate but related issues:
1. Nested bullets render with incorrect layout
2. Nested bullets with several words break the line unnecessarily

As a side effect, this may also help non-nested bullets that overflow at the page edge when their text is too long (see #3185)

## Fix

Set `flex: 1` on the content container so `flex-basis` resolves to `0`, letting Yoga compute the correct available width instead of relying on intrinsic sizing.

## Before / After

**Before**
<img width="258" height="228" alt="issue-3191-before" src="https://github.com/user-attachments/assets/1146e8b3-49c4-41cb-a948-a4df9d5800c8" />

**After**
<img width="311" height="170" alt="issue-3191-after" src="https://github.com/user-attachments/assets/edaedbb2-b7b1-4ba8-ac1e-41c803129a26" />


## Related issues

- Addresses #3191: Addresses comment of @NoUserNameRequired
- Related to #3185: Removing the conditional and applying `flex:1` makes the bullets wrap correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list rendering so nested bullet and numbered lists display more reliably inside list items.
  * Adjusted list-item layout by detecting when content contains sublists and applying the correct flex behavior to prevent spacing/alignment issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->