### PR TITLE
fix: wrap list item content in flex View so bullets respect margin

### DIFF
--- a/packages/pdf/src/templates/shared/rich-text.tsx
+++ b/packages/pdf/src/templates/shared/rich-text.tsx
@@ -155,7 +155,7 @@ export const RichText = ({ children }: RichTextProps) => {
 						>
 							<View style={{ flexDirection: "row", alignItems: "flex-start" }}>
 								{markerNode}
-								<View style={{ flex: 1 }}>{children}</View>
+								<View style={{ flex: 1, minWidth: 0 }}>{children}</View>
 							</View>
 						</View>
 					);

--- a/packages/pdf/src/templates/shared/rich-text.tsx
+++ b/packages/pdf/src/templates/shared/rich-text.tsx
@@ -128,13 +128,6 @@ export const RichText = ({ children }: RichTextProps) => {
 						</PdfText>
 					);
 
-					let hasNestedList = false;
-					if (Array.isArray(children)) {
-						hasNestedList = children.some(
-							(child) => child?.props?.element?.rawTagName === "ul" || child?.props?.element?.rawTagName === "ol",
-						);
-					}
-
 					// Same BiDi-injection trick as the <p> renderer — see applyRtlDirectionRecursively.
 					const contentNode = rtl ? (
 						<PdfText
@@ -162,7 +155,7 @@ export const RichText = ({ children }: RichTextProps) => {
 						>
 							<View style={{ flexDirection: "row", alignItems: "flex-start" }}>
 								{markerNode}
-								<View style={hasNestedList ? { flex: 1 } : {}}>{children}</View>
+								<View style={{ flex: 1 }}>{children}</View>
 							</View>
 						</View>
 					);


### PR DESCRIPTION
## Problem
Bullet points in rich-text fields (e.g. Experience, Summary) render past the right page margin in the exported PDF instead of wrapping. Long bullet lines run off the edge of the page.

## Fix screenshot
Nested or not, the points are rendering correctly

### Before
<img width="663" height="247" alt="image" src="https://github.com/user-attachments/assets/9ca89520-e98a-4fec-bafd-bb39ccc574ee" />

### After
<img width="665" height="283" alt="image" src="https://github.com/user-attachments/assets/95fce8d1-aba9-4c9b-bb04-fc9ce92db774" />

## Related issues
- https://github.com/amruthpillai/reactive-resume/issues/3201
- https://github.com/amruthpillai/reactive-resume/issues/3191
- https://github.com/amruthpillai/reactive-resume/issues/3185



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
* **Bug Fixes**
  * Improved right-to-left list item layout by using a consistent flex wrapper for list content.
  * Prevented nested lists from causing misalignment or spacing issues in right-to-left documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->