### PR TITLE
Filter invalid style intents to preserve valid custom styles

### DIFF
--- a/packages/schema/src/resume/data.test.ts
+++ b/packages/schema/src/resume/data.test.ts
@@ -318,9 +318,73 @@ describe("summarySchema", () => {
 });
 
 describe("styleRulesSchema", () => {
+	const educationHeadingRule = {
+		id: "education-heading",
+		label: "Education heading",
+		enabled: true,
+		target: { scope: "sectionType", sectionType: "education" },
+		slots: { heading: { fontSize: 20 } },
+	};
+
 	it("defaults to an empty rule list on default resume metadata", () => {
 		expect(defaultResumeData.metadata.styleRules).toEqual([]);
 		expect(styleRulesSchema.safeParse(defaultResumeData.metadata.styleRules).success).toBe(true);
+	});
+
+	it("preserves valid rules when another rule has an invalid style intent", () => {
+		expect(
+			styleRulesSchema.parse([
+				educationHeadingRule,
+				{
+					id: "experience-heading",
+					label: "Experience heading",
+					enabled: true,
+					target: { scope: "sectionType", sectionType: "experience" },
+					slots: { heading: { fontSize: -1 } },
+				},
+			]),
+		).toEqual([educationHeadingRule]);
+	});
+
+	it("drops invalid style fields without dropping the whole rule", () => {
+		expect(
+			styleRulesSchema.parse([
+				{
+					id: "partial-heading",
+					label: "Partial heading",
+					enabled: true,
+					target: { scope: "global" },
+					slots: { heading: { color: "rgba(0, 0, 0, 1)", fontSize: -1 } },
+				},
+			]),
+		).toEqual([
+			{
+				id: "partial-heading",
+				label: "Partial heading",
+				enabled: true,
+				target: { scope: "global" },
+				slots: { heading: { color: "rgba(0, 0, 0, 1)" } },
+			},
+		]);
+	});
+
+	it("falls back to an empty rule list for non-array persisted values", () => {
+		expect(styleRulesSchema.parse({})).toEqual([]);
+	});
+
+	it("drops rules with unknown slot keys", () => {
+		expect(
+			styleRulesSchema.parse([
+				{
+					id: "unknown-slot",
+					label: "Unknown slot",
+					enabled: true,
+					target: { scope: "global" },
+					slots: { richListItemMarker: { color: "rgba(0, 0, 0, 1)" } },
+				},
+				educationHeadingRule,
+			]),
+		).toEqual([educationHeadingRule]);
 	});
 
 	it("accepts global, section-type, and section-id targets", () => {

--- a/packages/schema/src/resume/data.ts
+++ b/packages/schema/src/resume/data.ts
@@ -580,33 +580,36 @@ const filterStyleIntent = (intent: unknown): StyleIntent | undefined => {
 	return filteredIntent.length > 0 ? (Object.fromEntries(filteredIntent) as StyleIntent) : undefined;
 };
 
-export const styleRulesSchema = z.array(z.unknown()).transform((arr) =>
-	arr
-		.map((item) => {
-			const base = z
-				.strictObject({
-					id: z.string().min(1),
-					label: z.string().catch(""),
-					enabled: z.boolean().catch(true),
-					target: styleRuleTargetSchema,
-					slots: z.record(z.string(), z.unknown()),
-				})
-				.safeParse(item);
+export const styleRulesSchema = z
+	.array(z.unknown())
+	.transform((arr) =>
+		arr
+			.map((item) => {
+				const base = z
+					.strictObject({
+						id: z.string().min(1),
+						label: z.string().catch(""),
+						enabled: z.boolean().catch(true),
+						target: styleRuleTargetSchema,
+						slots: z.partialRecord(styleSlotSchema, z.unknown()),
+					})
+					.safeParse(item);
 
-			if (!base.success) return undefined;
+				if (!base.success) return undefined;
 
-			const cleanedSlots = Object.fromEntries(
-				Object.entries(base.data.slots)
-					.map(([slot, intent]) => [slot, filterStyleIntent(intent)])
-					.filter((entry): entry is [string, StyleIntent] => entry[1] !== undefined),
-			);
+				const cleanedSlots = Object.fromEntries(
+					Object.entries(base.data.slots)
+						.map(([slot, intent]) => [slot, filterStyleIntent(intent)])
+						.filter((entry): entry is [string, StyleIntent] => entry[1] !== undefined),
+				);
 
-			if (Object.keys(cleanedSlots).length === 0) return undefined;
+				if (Object.keys(cleanedSlots).length === 0) return undefined;
 
-			return { ...base.data, slots: cleanedSlots };
-		})
-		.filter((rule): rule is StyleRule => rule !== undefined),
-);
+				return { ...base.data, slots: cleanedSlots };
+			})
+			.filter((rule): rule is StyleRule => rule !== undefined),
+	)
+	.catch([]);
 
 export type StyleRule = z.infer<typeof styleRuleSchema>;
 export type StyleRuleTarget = z.infer<typeof styleRuleTargetSchema>;

--- a/packages/schema/src/resume/data.ts
+++ b/packages/schema/src/resume/data.ts
@@ -569,7 +569,44 @@ export const styleRuleSchema = z.strictObject({
 	slots: styleRuleSlotsSchema.describe("The semantic style slots configured by this rule."),
 });
 
-export const styleRulesSchema = z.array(styleRuleSchema).catch([]);
+const filterStyleIntent = (intent: unknown): StyleIntent | undefined => {
+	const styleIntentShape = styleIntentSchema.shape;
+	if (typeof intent !== "object" || intent === null) return undefined;
+	const filteredIntent = Object.entries(intent).filter(([key, value]) => {
+		const fieldSchema = styleIntentSchema.shape[key as keyof typeof styleIntentShape];
+		if (!fieldSchema) return false;
+		return fieldSchema.safeParse(value).success;
+	});
+	return filteredIntent.length > 0 ? (Object.fromEntries(filteredIntent) as StyleIntent) : undefined;
+};
+
+export const styleRulesSchema = z.array(z.unknown()).transform((arr) =>
+	arr
+		.map((item) => {
+			const base = z
+				.strictObject({
+					id: z.string().min(1),
+					label: z.string().catch(""),
+					enabled: z.boolean().catch(true),
+					target: styleRuleTargetSchema,
+					slots: z.record(z.string(), z.unknown()),
+				})
+				.safeParse(item);
+
+			if (!base.success) return undefined;
+
+			const cleanedSlots = Object.fromEntries(
+				Object.entries(base.data.slots)
+					.map(([slot, intent]) => [slot, filterStyleIntent(intent)])
+					.filter((entry): entry is [string, StyleIntent] => entry[1] !== undefined),
+			);
+
+			if (Object.keys(cleanedSlots).length === 0) return undefined;
+
+			return { ...base.data, slots: cleanedSlots };
+		})
+		.filter((rule): rule is StyleRule => rule !== undefined),
+);
 
 export type StyleRule = z.infer<typeof styleRuleSchema>;
 export type StyleRuleTarget = z.infer<typeof styleRuleTargetSchema>;


### PR DESCRIPTION
## Problem

An invalid custom style can cause all custom styles to be removed.
Currently, invalid style intents cause the entire `styleRules` array to be silently replaced with an empty array:


```ts
export const styleRulesSchema = z.array(styleRuleSchema).catch([]);
```

The frontend keeps the invalid input in local state and sends it to the server. The server-side Zod validation fails and the response returns:

```json
{
  "styleRules": []
}
```

This causes valid custom styles to be lost.


## Reproduce

Note: 
In dev mode this is immediately visible because the client refetches the resume (getById) after saving.
In the production app, local state can hide the issue until a refresh, where the resume is loaded again through `getById` and the server state (`styleRules: []`) is loaded.


Steps: 

1. Create an Education section with font size `20` for section type / section heading.
2. Create an Experience section with font size `-1` for section type / section heading.
3. Click outside the input field to trigger save.

Current behavior:
- All custom styles are removed.


## Fix

Iterate through style rules and safely parse each style intent individually. Invalid intents are filtered out while valid custom styles are preserved.

## Related issues

- Addresses #3199
- Addresses #3174


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and parsing of resume style rules to handle malformed or partially valid entries more reliably.
  * Preserve valid style rules while removing invalid style intent details within them, instead of discarding entire rule sets.
  * Automatically drop rules with empty or unknown slot data and fall back to an empty list when stored style rules are in an unexpected format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->