### PR TITLE
fix: bullet list indentation on page break

### DIFF
--- a/packages/pdf/src/templates/shared/base-template-styles.ts
+++ b/packages/pdf/src/templates/shared/base-template-styles.ts
@@ -87,6 +87,7 @@ export function createBaseTemplateStyles({ metadata, foreground, r, metrics, pic
 			...bodyText,
 			width: metadata.typography.body.fontSize,
 			textAlign: r.listMarkerTextAlign,
+			alignSelf: "stretch",
 			flex: "initial",
 		} satisfies Style,
 


### PR DESCRIPTION
Hi @amruthpillai, I found another minor issue with page break on bullet list: when it occurs the indentation is broken. Here some screenshot showing the before and after. To fix it, I simply add a "stretch" to the marker flex item.

#### Before:
<img width="718" height="411" alt="Before" src="https://github.com/user-attachments/assets/4f5dc937-162d-4d87-b232-86cae3df2d8f" />


#### After
<img width="765" height="455" alt="After" src="https://github.com/user-attachments/assets/30cf5282-94f0-46dd-bdeb-be7b224c7710" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list item marker alignment in PDF templates, helping rich lists render more consistently across layouts and text directions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->