### PR TITLE
perf(api): lazy-load PDF renderer to cut server cold-start

### DIFF
--- a/packages/api/src/features/resume/export.ts
+++ b/packages/api/src/features/resume/export.ts
@@ -1,7 +1,6 @@
 import type { ResumeExportTarget } from "@reactive-resume/resume/export-sections";
 import { ORPCError } from "@orpc/server";
 import z from "zod";
-import { createResumePdfFile } from "@reactive-resume/pdf/server";
 import { getResumeExportData, resumeHasCoverLetter } from "@reactive-resume/resume/export-sections";
 import { generateFilename } from "@reactive-resume/utils/file";
 import { protectedProcedure } from "../../context";
@@ -30,6 +29,11 @@ export async function createResumePdfDownload(input: CreateResumePdfDownloadInpu
 	const filename = generateFilename(target === "cover-letter" ? `${resume.name} Cover Letter` : resume.name, "pdf");
 
 	try {
+		// Lazy-load the PDF renderer (@reactive-resume/pdf → @react-pdf/renderer +
+		// phosphor-icons-react-pdf, ~10.6k icon modules) only when a PDF is actually
+		// exported, instead of at server boot. Slashes cold-start file I/O on
+		// constrained/slow-disk hosts. See fork perf/lazy-load-pdf.
+		const { createResumePdfFile } = await import("@reactive-resume/pdf/server");
 		const body = await createResumePdfFile({ data: getResumeExportData(resume.data, target), filename });
 
 		return {


### PR DESCRIPTION
## Summary
- `export.ts` statically imported `createResumePdfFile` from `@reactive-resume/pdf/server` at module scope. Since ESM static imports are resolved before any application code runs, this pulled in the entire `@react-pdf`/phosphor-icons tree on **every** server boot, even though PDF export is a comparatively rare request path.
- Converts that import to a dynamic `import()` inside `createResumePdfDownload`, its only call site, so the cost is paid on first PDF export instead of on every process start.

## Measurements (self-hosted, single instance, cold start to `/api/health` 200)
- Before: **16.8s**
- After: **4.8s**
- ~3.5x faster boot / ~12s saved. Confirmed via `strace -e trace=openat`: baseline opens 10,600 files under `phosphor-icons` at startup; this branch opens 0 (deferred until export is actually invoked).

This matters most for anyone running Reactive Resume behind an idle/scale-to-zero proxy (e.g. systemd socket activation, Kubernetes scale-to-zero) where server start latency is directly user-facing.

## Test plan
- [x] Built and booted both versions locally with identical env/secrets, compared time-to-ready
- [x] Confirmed via strace that the PDF renderer's dependency tree is no longer touched at boot
- [ ] Manual PDF export still works (dynamic import resolves correctly) — please confirm in review/CI since I don't have a full account-flow test setup wired up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume PDF download reliability by loading the PDF generation service when needed.
  * Preserved existing filename handling, cover-letter validation, response headers, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->