### PR TITLE
fix(pdf): add flex to skill name to participate in layout sizing

### DIFF
--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -664,7 +664,7 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 						<SectionItemHeader>
 							<View style={composeStyles(inlineStyle)}>
 								<Icon name={item.icon as IconName} />
-								<Bold>{item.name}</Bold>
+								<Bold style={{ flex: 1 }}>{item.name}</Bold>
 							</View>
 						</SectionItemHeader>
 


### PR DESCRIPTION
## Problem

Without a width constraint, the `Bold` element uses the intrinsic size of the text, which can cause it to overflow its flex container in the skills section.

## Fix

Add `flex:1` to make the text participate in Yoga's layout sizing and respect the available space.

## Before / After

**Before**
<img width="990" height="191" alt="before" src="https://github.com/user-attachments/assets/597ab6e0-c0f4-4194-80fc-200836182673" />

**After**
<img width="999" height="172" alt="after" src="https://github.com/user-attachments/assets/f1756b37-aeec-4a4a-9bfd-65780a73e23f" />


## Related issues

- Addresses #3040: Improves layout for different columns configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the Skills section layout so skill names expand naturally within their rows, improving alignment and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->