### PR TITLE
fix(auth): map oauth login to correct user id instead of account id

### DIFF
--- a/packages/auth/src/oauth-profile.test.ts
+++ b/packages/auth/src/oauth-profile.test.ts
@@ -75,7 +75,7 @@ describe("createProfileMapper", () => {
 		expect(dbMock.update).toHaveBeenCalledTimes(1);
 		expect(dbMock.updateSet).toHaveBeenCalledWith({ email: "legacy.user@example.com" });
 		expect(result).toEqual({
-			id: "legacy-user-id",
+			id: "user-1",
 			name: "Legacy User",
 			email: "legacy.user@example.com",
 			image: "https://example.com/new.png",
@@ -153,6 +153,7 @@ describe("createProfileMapper", () => {
 
 		expect(dbMock.select).toHaveBeenCalledTimes(2);
 		expect(result).toEqual({
+			id: "user-1",
 			name: "GitHub User",
 			email: "github.user@example.com",
 			image: "https://example.com/new.png",
@@ -189,6 +190,7 @@ describe("createProfileMapper", () => {
 		expect(dbMock.update).toHaveBeenCalledTimes(1);
 		expect(dbMock.updateSet).toHaveBeenCalledWith({ email: "legacy.user@example.com" });
 		expect(result).toEqual({
+			id: "user-1",
 			name: "Legacy User",
 			email: "legacy.user@example.com",
 			image: "https://example.com/new.png",

--- a/packages/auth/src/oauth-profile.ts
+++ b/packages/auth/src/oauth-profile.ts
@@ -186,7 +186,7 @@ export function createProfileMapper<TProfile extends OAuthProfile>({
 			await normalizeExistingUserEmail(existingUser.id, existingUser.email, existingEmail);
 
 			return {
-				...(existingUser.accountId ? { id: existingUser.accountId } : {}),
+				id: existingUser.id,
 				name: existingUser.name,
 				email: existingEmail,
 				image: image ?? existingUser.image,


### PR DESCRIPTION
### Description
Fixes #2901 

When a user logs in with GitHub, the `createProfileMapper` was mistakenly returning the provider's `accountId` instead of the database `user.id`. This caused Better Auth to fail at linking the account, leading to the "missing resumes" issue because it was mapping the user incorrectly. 

This PR fixes the mapping to return `id: existingUser.id` and updates the corresponding unit tests which were previously asserting the buggy behavior.

### Type of Change
- [x] Bug fix

### Checklist
- [x] I have tested these changes locally.
- [x] I have updated the unit tests to reflect this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OAuth profile mapping to consistently use the existing user’s identifier.
  * Improved account reuse behavior for GitHub and email-based sign-ins, including normalized legacy email accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->