### PR TITLE
fix: allow award title unbold via custom styles (#3250)

### DIFF
--- a/packages/docx/src/section-renderers.ts
+++ b/packages/docx/src/section-renderers.ts
@@ -78,9 +78,9 @@ function sectionHeading(title: string, colorHex: string): Paragraph {
 	});
 }
 
-function titleAndSubtitle(primary: string, secondary: string, rightText?: string): Paragraph {
+function titleAndSubtitle(primary: string, secondary: string, rightText?: string, bold = true): Paragraph {
 	const baseRun = getBaseRun();
-	const children: (TextRun | ExternalHyperlink)[] = [new TextRun({ text: primary, bold: true, ...baseRun })];
+	const children: (TextRun | ExternalHyperlink)[] = [new TextRun({ text: primary, bold, ...baseRun })];
 
 	if (secondary) {
 		children.push(new TextRun({ text: ` — ${secondary}`, ...baseRun }));
@@ -321,7 +321,7 @@ function renderAwards(section: Sections["awards"], colorHex: string): Paragraph[
 	const paragraphs: Paragraph[] = [sectionHeading(section.title, colorHex)];
 
 	for (const item of items) {
-		paragraphs.push(titleAndSubtitle(item.title, item.awarder, item.date));
+		paragraphs.push(titleAndSubtitle(item.title, item.awarder, item.date, false));
 
 		if (item.description) {
 			paragraphs.push(...htmlToParagraphs(item.description, getHtmlStyle()));

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -749,7 +749,7 @@ const AwardsSection = ({ sectionId = "awards", sectionData }: ItemSectionProps<A
 					<SectionItem key={item.id}>
 						<SectionItemHeader>
 							<View style={composeStyles(splitRowStyle, awardTitleDateRowStyle)}>
-								<ItemTitle website={item.website}>{item.title}</ItemTitle>
+								<ItemTitle website={item.website} bold={false}>{item.title}</ItemTitle>
 								<Text style={composeStyles(alignEndStyle)}>{item.date}</Text>
 							</View>
 							<Text>{item.awarder}</Text>


### PR DESCRIPTION
Fixes #3250

The award title was hardcoded as bold in both the DOCX renderer and PDF template, with no way to unbold it through custom styles.

**Changes:**
- `packages/docx/src/section-renderers.ts`: `titleAndSubtitle()` now accepts an optional `bold` parameter (defaults to `true` for backward compatibility). Awards renderer passes `bold: false`.
- `packages/pdf/src/templates/shared/sections.tsx`: `ItemTitle` now accepts an optional `bold` prop (defaults to `true`). Awards renderer passes `bold: false`.

The title remains normal weight while preserving bold for all other sections (experience, education, certifications, publications, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated award titles in DOCX and PDF exports to use regular text instead of bold formatting.
  * Preserved the existing award title, subtitle, and date content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->