### PR TITLE
fix: profile picture delete icon should reset image correctly (#3176)

### DIFF
--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -471,6 +471,19 @@ function PictureSectionForm() {
 		fileInputRef.current?.click();
 	};
 
+	const defaultPicture: PictureValues = {
+		hidden: false,
+		url: "",
+		size: 80,
+		rotation: 0,
+		aspectRatio: 1,
+		borderRadius: 0,
+		borderColor: "rgba(0, 0, 0, 0.5)",
+		borderWidth: 0,
+		shadowColor: "rgba(0, 0, 0, 0.5)",
+		shadowWidth: 0,
+	};
+
 	const onDeletePicture = () => {
 		if (!picture.url) return;
 
@@ -484,8 +497,18 @@ function PictureSectionForm() {
 		// If the picture is from the same origin, attempt to delete it
 		if (pictureOrigin === appOrigin) deleteFile({ filename });
 
+		// Reset all picture fields and persist
 		form.setFieldValue("url", "");
-		handleAutoSave();
+		form.setFieldValue("hidden", false);
+		form.setFieldValue("size", 80);
+		form.setFieldValue("rotation", 0);
+		form.setFieldValue("aspectRatio", 1);
+		form.setFieldValue("borderRadius", 0);
+		form.setFieldValue("borderColor", "rgba(0, 0, 0, 0.5)");
+		form.setFieldValue("borderWidth", 0);
+		form.setFieldValue("shadowColor", "rgba(0, 0, 0, 0.5)");
+		form.setFieldValue("shadowWidth", 0);
+		persist(form.state.values);
 	};
 
 	const uploadPictureFile = (file: File) => {

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -15,6 +15,7 @@ import { useRef, useState } from "react";
 import Cropper from "react-easy-crop";
 import { toast } from "sonner";
 import { pictureSchema } from "@reactive-resume/schema/resume/data";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
 import { Button } from "@reactive-resume/ui/components/button";
 import { ButtonGroup } from "@reactive-resume/ui/components/button-group";
 import {
@@ -471,19 +472,6 @@ function PictureSectionForm() {
 		fileInputRef.current?.click();
 	};
 
-	const defaultPicture: PictureValues = {
-		hidden: false,
-		url: "",
-		size: 80,
-		rotation: 0,
-		aspectRatio: 1,
-		borderRadius: 0,
-		borderColor: "rgba(0, 0, 0, 0.5)",
-		borderWidth: 0,
-		shadowColor: "rgba(0, 0, 0, 0.5)",
-		shadowWidth: 0,
-	};
-
 	const onDeletePicture = () => {
 		if (!picture.url) return;
 
@@ -497,18 +485,8 @@ function PictureSectionForm() {
 		// If the picture is from the same origin, attempt to delete it
 		if (pictureOrigin === appOrigin) deleteFile({ filename });
 
-		// Reset all picture fields and persist
-		form.setFieldValue("url", "");
-		form.setFieldValue("hidden", false);
-		form.setFieldValue("size", 80);
-		form.setFieldValue("rotation", 0);
-		form.setFieldValue("aspectRatio", 1);
-		form.setFieldValue("borderRadius", 0);
-		form.setFieldValue("borderColor", "rgba(0, 0, 0, 0.5)");
-		form.setFieldValue("borderWidth", 0);
-		form.setFieldValue("shadowColor", "rgba(0, 0, 0, 0.5)");
-		form.setFieldValue("shadowWidth", 0);
-		persist(form.state.values);
+		form.reset(defaultResumeData.picture);
+		persist(defaultResumeData.picture);
 	};
 
 	const uploadPictureFile = (file: File) => {


### PR DESCRIPTION
Fixes #3176

## Problem
After uploading a profile picture, clicking the delete (trash) icon that appears on hover did nothing. The picture URL remained set in the form and persisted to the store.

## Root Cause
The delete handler only cleared `url` via `form.setFieldValue("url", "")` but left all other picture fields (size, rotation, aspectRatio, etc.) in their previous state. The `handleAutoSave()` call wrote `form.state.values` which still contained stale field values. Under certain conditions (form validation, React reconciliation), the picture wouldn't properly reset to empty.

## Fix
- Explicitly reset all picture fields to their default values before persisting (url, hidden, size, rotation, aspectRatio, borderRadius, borderColor, borderWidth, shadowColor, shadowWidth)
- Use `persist(form.state.values)` directly instead of `handleAutoSave()` so the reset form is guaranteed to be persisted

## Changes
```diff
+1 line (defaultPicture constant)
+11 lines (explicit field resets)
-1 line (handleAutoSave replaced by persist)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a profile picture now fully resets all picture settings (not just the image URL), including size, rotation, aspect ratio, borders, shadows, and colors.
  * Reset picture settings are now persisted consistently after deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->