### PR TITLE
fix: clamp custom style numeric inputs

### DIFF
--- a/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.test.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.test.tsx
@@ -269,6 +269,48 @@ describe("CustomStylesSectionBuilder", () => {
 		]);
 	});
 
+	it("clamps manually typed style values to the schema bounds", () => {
+		styleRules.splice(0, styleRules.length);
+		renderCustomStyles();
+
+		fireEvent.change(screen.getByLabelText("Margin Top"), { target: { value: "100" } });
+		fireEvent.change(screen.getByLabelText("Font Size"), { target: { value: "2" } });
+
+		expect(updateResumeData).toHaveBeenCalledTimes(2);
+
+		const marginRecipe = updateResumeData.mock.calls[0]?.[0] as (draft: {
+			metadata: { styleRules: unknown[] };
+		}) => void;
+		const marginDraft = { metadata: { styleRules: [] } };
+		marginRecipe(marginDraft);
+
+		expect(marginDraft.metadata.styleRules).toEqual([
+			{
+				id: "style-global-heading",
+				label: "All sections: Section heading",
+				enabled: true,
+				target: { scope: "global" },
+				slots: { heading: { marginTop: 72 } },
+			},
+		]);
+
+		const fontSizeRecipe = updateResumeData.mock.calls[1]?.[0] as (draft: {
+			metadata: { styleRules: unknown[] };
+		}) => void;
+		const fontSizeDraft = { metadata: { styleRules: [] } };
+		fontSizeRecipe(fontSizeDraft);
+
+		expect(fontSizeDraft.metadata.styleRules).toEqual([
+			{
+				id: "style-global-heading",
+				label: "All sections: Section heading",
+				enabled: true,
+				target: { scope: "global" },
+				slots: { heading: { fontSize: 6 } },
+			},
+		]);
+	});
+
 	it("stores list slot rules for rich text lists", async () => {
 		styleRules.splice(0, styleRules.length);
 		renderCustomStyles();

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.test.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.test.tsx
@@ -329,6 +329,34 @@ describe("CustomStylesSectionBuilder", () => {
 		expect(updateResumeData).toHaveBeenCalledTimes(2);
 	});
 
+	it("commits normalized legacy values when the input loses focus", () => {
+		styleRules[0] = {
+			id: "style-global-heading",
+			label: "All sections: Section heading",
+			enabled: true,
+			target: { scope: "global" },
+			slots: { heading: { borderWidth: 100 } },
+		};
+		renderCustomStyles();
+
+		const borderWidthInput = screen.getByLabelText("Border Width");
+		expect(borderWidthInput).toHaveValue(100);
+
+		fireEvent.focus(borderWidthInput);
+		fireEvent.blur(borderWidthInput);
+
+		expect(borderWidthInput).toHaveValue(24);
+		expect(updateResumeData).toHaveBeenCalledTimes(1);
+
+		const recipe = updateResumeData.mock.calls[0]?.[0] as (draft: {
+			metadata: { styleRules: StyleRule[] };
+		}) => void;
+		const draft = { metadata: { styleRules: structuredClone(styleRules) } };
+		recipe(draft);
+
+		expect(draft.metadata.styleRules[0]?.slots.heading?.borderWidth).toBe(24);
+	});
+
 	it("stores list slot rules for rich text lists", async () => {
 		styleRules.splice(0, styleRules.length);
 		renderCustomStyles();

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.test.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.test.tsx
@@ -311,6 +311,24 @@ describe("CustomStylesSectionBuilder", () => {
 		]);
 	});
 
+	it("keeps intermediate numeric text while the input is focused", () => {
+		styleRules.splice(0, styleRules.length);
+		renderCustomStyles();
+
+		const fontSizeInput = screen.getByLabelText("Font Size");
+		fireEvent.focus(fontSizeInput);
+		fireEvent.change(fontSizeInput, { target: { value: "1" } });
+
+		expect(fontSizeInput).toHaveValue(1);
+
+		fireEvent.change(fontSizeInput, { target: { value: "12" } });
+		expect(fontSizeInput).toHaveValue(12);
+
+		fireEvent.blur(fontSizeInput);
+		expect(fontSizeInput).toHaveValue(12);
+		expect(updateResumeData).toHaveBeenCalledTimes(2);
+	});
+
 	it("stores list slot rules for rich text lists", async () => {
 		styleRules.splice(0, styleRules.length);
 		renderCustomStyles();

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.tsx
@@ -9,7 +9,7 @@ import type { ReactNode } from "react";
 import type { ComboboxOption } from "@/components/ui/combobox";
 import { Trans } from "@lingui/react/macro";
 import { EyeIcon, EyeSlashIcon, PencilSimpleIcon, TrashSimpleIcon } from "@phosphor-icons/react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { sectionTypeSchema } from "@reactive-resume/schema/resume/data";
 import { Button } from "@reactive-resume/ui/components/button";
 import { Input } from "@reactive-resume/ui/components/input";
@@ -338,20 +338,52 @@ function parseBoundedNumberInput(value: string, min: number, max: number): numbe
 	return Math.min(max, Math.max(min, number));
 }
 
+function useBoundedNumberInput(
+	value: number | undefined,
+	min: number,
+	max: number,
+	onChange: (value: number | undefined) => void,
+) {
+	const [inputValue, setInputValue] = useState(value?.toString() ?? "");
+	const isFocused = useRef(false);
+
+	useEffect(() => {
+		if (!isFocused.current) setInputValue(value?.toString() ?? "");
+	}, [value]);
+
+	return {
+		inputValue,
+		onFocus: () => {
+			isFocused.current = true;
+		},
+		onBlur: () => {
+			isFocused.current = false;
+			setInputValue((currentValue) => parseBoundedNumberInput(currentValue, min, max)?.toString() ?? "");
+		},
+		onInputChange: (nextValue: string) => {
+			setInputValue(nextValue);
+			onChange(parseBoundedNumberInput(nextValue, min, max));
+		},
+	};
+}
+
 function NumberInput({ label, id, value, min, max, step = 1, onChange }: NumberInputProps) {
 	const inputId = id ?? `style-${label.toLowerCase().replaceAll(" ", "-")}`;
+	const boundedInput = useBoundedNumberInput(value, min, max, onChange);
 
 	return (
 		<Field label={label} id={inputId}>
 			<Input
 				id={inputId}
 				className="tabular-nums"
-				value={value ?? ""}
+				value={boundedInput.inputValue}
 				type="number"
 				min={min}
 				max={max}
 				step={step}
-				onChange={(event) => onChange(parseBoundedNumberInput(event.target.value, min, max))}
+				onFocus={boundedInput.onFocus}
+				onBlur={boundedInput.onBlur}
+				onChange={(event) => boundedInput.onInputChange(event.target.value)}
 			/>
 		</Field>
 	);
@@ -839,18 +871,22 @@ function CompactNumberInput({
 	step = 1,
 	onChange,
 }: CompactNumberInputProps) {
+	const boundedInput = useBoundedNumberInput(value, min, max, onChange);
+
 	return (
 		<Input
 			id={id}
 			aria-label={ariaLabel}
 			className={compactSpacingInputClassName}
-			value={value ?? ""}
+			value={boundedInput.inputValue}
 			placeholder={placeholder}
 			type="number"
 			min={min}
 			max={max}
 			step={step}
-			onChange={(event) => onChange(parseBoundedNumberInput(event.target.value, min, max))}
+			onFocus={boundedInput.onFocus}
+			onBlur={boundedInput.onBlur}
+			onChange={(event) => boundedInput.onInputChange(event.target.value)}
 		/>
 	);
 }

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.tsx
@@ -329,6 +329,15 @@ type NumberInputProps = {
 	onChange: (value: number | undefined) => void;
 };
 
+function parseBoundedNumberInput(value: string, min: number, max: number): number | undefined {
+	if (value === "") return undefined;
+
+	const number = Number(value);
+	if (!Number.isFinite(number)) return undefined;
+
+	return Math.min(max, Math.max(min, number));
+}
+
 function NumberInput({ label, id, value, min, max, step = 1, onChange }: NumberInputProps) {
 	const inputId = id ?? `style-${label.toLowerCase().replaceAll(" ", "-")}`;
 
@@ -342,10 +351,7 @@ function NumberInput({ label, id, value, min, max, step = 1, onChange }: NumberI
 				min={min}
 				max={max}
 				step={step}
-				onChange={(event) => {
-					const value = event.target.value;
-					onChange(value === "" ? undefined : Number(value));
-				}}
+				onChange={(event) => onChange(parseBoundedNumberInput(event.target.value, min, max))}
 			/>
 		</Field>
 	);
@@ -844,10 +850,7 @@ function CompactNumberInput({
 			min={min}
 			max={max}
 			step={step}
-			onChange={(event) => {
-				const value = event.target.value;
-				onChange(value === "" ? undefined : Number(value));
-			}}
+			onChange={(event) => onChange(parseBoundedNumberInput(event.target.value, min, max))}
 		/>
 	);
 }

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.tsx
@@ -358,7 +358,9 @@ function useBoundedNumberInput(
 		},
 		onBlur: () => {
 			isFocused.current = false;
-			setInputValue((currentValue) => parseBoundedNumberInput(currentValue, min, max)?.toString() ?? "");
+			const normalizedValue = parseBoundedNumberInput(inputValue, min, max);
+			setInputValue(normalizedValue?.toString() ?? "");
+			if (normalizedValue !== value) onChange(normalizedValue);
 		},
 		onInputChange: (nextValue: string) => {
 			setInputValue(nextValue);


### PR DESCRIPTION
## Summary

- clamp manually typed custom-style numbers to each input's declared bounds before updating resume state
- apply the same normalization to regular and compact numeric controls
- add regression coverage for spacing and font-size values outside the schema range

## Problem

HTML number inputs allow users to type values beyond their `min` and `max` attributes. Those values were written into `metadata.styleRules`, then rejected by the server-side schema on the next round-trip. This made the style appear to roll back with a sync notification.

## Validation

- `pnpm --filter web test -- 'src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.test.tsx'` (89 files, 468 tests passed)
- `pnpm --filter web typecheck`
- `pnpm exec biome check 'apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.tsx' 'apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/custom-styles.test.tsx'`

Closes #3260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric custom styling inputs to handle empty, invalid, and non-finite values more safely.
  * Values are now clamped to the supported min/max range for margin and font size.
  * Focus/blur editing behavior is corrected so intermediate typing stays visible, while only the last committed value is applied.
  * Legacy numeric inputs (e.g., border width) are normalized on blur before being saved.
* **Tests**
  * Added coverage for clamping behavior, focus/blur update timing, and legacy normalization during resume updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->