### PR TITLE
fix(api): support HTTPS job posting fetches

### DIFF
--- a/packages/api/src/features/applications/ai.test.ts
+++ b/packages/api/src/features/applications/ai.test.ts
@@ -104,6 +104,27 @@ describe("fetchJobPostingText", () => {
 		await expect(fetchJobPostingText("https://jobs.example/posting")).resolves.toBe("Senior Engineer");
 		expect(pinnedAddress).toBe("93.184.216.34");
 	});
+
+	it("supports Node lookup calls with all=true", async () => {
+		lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+		let lookupResult: unknown;
+		requestMock.mockImplementation((_url, options, callback) => {
+			options.lookup("jobs.example", { all: true }, (_error: Error | null, result: unknown) => {
+				lookupResult = result;
+			});
+			const response = Readable.from([Buffer.from("<html><body>Senior Engineer</body></html>")]) as Readable & {
+				statusCode: number;
+				headers: Record<string, string>;
+			};
+			response.statusCode = 200;
+			response.headers = { "content-type": "text/html" };
+			callback(response);
+			return { on: vi.fn(), end: vi.fn() };
+		});
+
+		await expect(fetchJobPostingText("https://jobs.example/posting")).resolves.toBe("Senior Engineer");
+		expect(lookupResult).toEqual([{ address: "93.184.216.34", family: 4 }]);
+	});
 });
 
 describe("autofillInputSchema", () => {

--- a/packages/api/src/features/applications/ai.ts
+++ b/packages/api/src/features/applications/ai.ts
@@ -163,7 +163,14 @@ function requestJobPosting(parsed: URL, address: ValidatedAddress, signal: Abort
 					accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
 					"accept-language": "en-US,en;q=0.9",
 				},
-				lookup: (_hostname, _options, callback) => callback(null, address.address, address.family),
+				lookup: (_hostname, options, callback) => {
+					if (options.all) {
+						callback(null, [address]);
+						return;
+					}
+
+					callback(null, address.address, address.family);
+				},
 			},
 			resolve,
 		);


### PR DESCRIPTION
## Summary

Fixes job posting autofill failures for valid public HTTPS pages such as Jobstreet.

## Root Cause

The custom Node.js HTTPS `lookup` callback did not support calls where `options.all === true`. Node then received an invalid address and failed with:

```text
ERR_INVALID_IP_ADDRESS Invalid IP address: undefined
```

The error was masked as:

```text
Couldn't read the job posting. Paste the description instead.
```

## Changes

- Return the validated address as an array when Node requests `all: true`.
- Preserve the existing single-address callback behavior.
- Add a regression test for the `all: true` lookup path.
- Keep SSRF protections unchanged.

## Verification

- API application AI tests: 8 passed
- API typecheck: passed
- Production Docker build: passed
- Verified against:
  `https://id.jobstreet.com/id/job/93229386?ref=search-standalone&type=standard&origin=jobTitle`

The deployed instance successfully reads the Jobstreet page after this fix.

Fixes #3266


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job posting retrieval by ensuring DNS lookups correctly support requests for all resolved addresses.
  * Preserved compatibility with standard single-address DNS lookups.
  * Added coverage to verify job titles continue to be extracted correctly after DNS resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->