### PR TITLE
docs(contributing): fix troubleshooting accordion code block formatting

### DIFF
--- a/docs/contributing/development.mdx
+++ b/docs/contributing/development.mdx
@@ -270,24 +270,43 @@ pnpm run typecheck
 <AccordionGroup>
 	<Accordion title="Port 3000 or 3001 is already in use">
 		The Vite web server uses `PORT` (default `3000`), and the Hono server uses `SERVER_PORT` (default `3001`).
-		Either stop the conflicting process or choose alternate ports: ```bash PORT=3002 SERVER_PORT=3003 pnpm dev ```
+		Either stop the conflicting process or choose alternate ports:
+		```bash
+		PORT=3002 SERVER_PORT=3003 pnpm dev
+		```
 	</Accordion>
 
-    <Accordion title="Database connection refused">
-    	Ensure Docker containers are running: ```bash docker compose -f compose.dev.yml ps docker compose -f compose.dev.yml
-    	up -d ``` Check that PostgreSQL is healthy and accessible on port 5432.
-    </Accordion>
+	<Accordion title="Database connection refused">
+		Ensure Docker containers are running:
+		```bash
+		docker compose -f compose.dev.yml ps
+		docker compose -f compose.dev.yml up -d
+		```
+		Check that PostgreSQL is healthy and accessible on port 5432.
+	</Accordion>
 
-    <Accordion title="S3/Storage errors">
-    	Verify SeaweedFS is running and the bucket exists: ```bash docker compose -f compose.dev.yml logs seaweedfs docker
-    	compose -f compose.dev.yml logs seaweedfs_create_bucket ``` If the bucket wasn't created, restart the bucket
-    	creation service: ```bash docker compose -f compose.dev.yml restart seaweedfs_create_bucket ```
-    </Accordion>
+	<Accordion title="S3/Storage errors">
+		Verify SeaweedFS is running and the bucket exists:
+		```bash
+		docker compose -f compose.dev.yml logs seaweedfs
+		docker compose -f compose.dev.yml logs seaweedfs_create_bucket
+		```
+		If the bucket wasn't created, restart the bucket creation service:
+		```bash
+		docker compose -f compose.dev.yml restart seaweedfs_create_bucket
+		```
+	</Accordion>
 
-    <Accordion title="Type errors after pulling changes">
-    	The route tree may need regeneration. Run the dev server which auto-generates routes: ```bash pnpm run dev ``` Or
-    	run type checking to see specific errors: ```bash pnpm run typecheck ```
-    </Accordion>
+	<Accordion title="Type errors after pulling changes">
+		The route tree may need regeneration. Run the dev server which auto-generates routes:
+		```bash
+		pnpm run dev
+		```
+		Or run type checking to see specific errors:
+		```bash
+		pnpm run typecheck
+		```
+	</Accordion>
 
 </AccordionGroup>
 


### PR DESCRIPTION
## Problem

The Troubleshooting accordion in `docs/contributing/development.mdx` embeds multi-line bash commands inside single-line inline code spans, e.g.

```text
```bash docker compose -f compose.dev.yml ps docker compose -f compose.dev.yml up -d ```
```

This causes commands to wrap onto one line, making them hard to read and copy.

## Root cause

The MDX uses inline triple-backtick spans instead of fenced code blocks and mixes 4-space and tab indentation.

## Fix

- Split each inline ` ```bash ... ``` ` snippet into a standalone fenced code block.
- Normalize the accordion indentation to tabs (matching the rest of the file and `biome.json` `indentStyle: "tab"`).
- No changes to the actual commands or documentation content.

## Verification

- `python3 ../scripts/preflight_ship.py --repo amruthpillai/reactive-resume --local .` → **PREFLIGHT CLEAR**
- `git diff --check` → no whitespace errors
- Confirmed the broken inline blocks are still on `upstream/main` in `docs/contributing/development.mdx` (Troubleshooting section).
- Searched `gh pr list --repo amruthpillai/reactive-resume --state all --search "accordion"` and `"development.mdx"`; no duplicate found.

## Notes / Risks

- Self-sourced documentation fix; no runtime impact.
- Merge cadence check: 5 PRs merged in the last ~2 days (active).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved troubleshooting instructions with clearly formatted Bash command blocks.
  * Enhanced readability for guidance covering port conflicts, database connection issues, storage errors, and type errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->