### PR TITLE
fix: clamp page margin values to [0, 100] to prevent crash on paste

### DIFF
--- a/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
@@ -53,11 +53,16 @@ function PageSectionForm() {
 		persist({ ...form.state.values, [name]: value });
 	};
 
-	const pageNumberFields = [
-		{ name: "marginX" as const, label: <Trans>Margin (Horizontal)</Trans>, min: 0, max: 100 as number | undefined },
-		{ name: "marginY" as const, label: <Trans>Margin (Vertical)</Trans>, min: 0, max: 100 as number | undefined },
-		{ name: "gapX" as const, label: <Trans>Spacing (Horizontal)</Trans>, min: 0, max: undefined },
-		{ name: "gapY" as const, label: <Trans>Spacing (Vertical)</Trans>, min: 0, max: undefined },
+	const CLAMP_MIN = 0;
+const CLAMP_MAX = 100;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const pageNumberFields = [
+	{ name: "marginX" as const, label: <Trans>Margin (Horizontal)</Trans>, min: CLAMP_MIN, max: CLAMP_MAX },
+	{ name: "marginY" as const, label: <Trans>Margin (Vertical)</Trans>, min: CLAMP_MIN, max: CLAMP_MAX },
+	{ name: "gapX" as const, label: <Trans>Spacing (Horizontal)</Trans>, min: 0, max: undefined },
+	{ name: "gapY" as const, label: <Trans>Spacing (Vertical)</Trans>, min: 0, max: undefined },
 	];
 
 	const pageSwitchFields = [
@@ -151,7 +156,8 @@ function PageSectionForm() {
 											onBlur={field.handleBlur}
 											onChange={(e) => {
 												const v = e.target.value;
-												const num = v === "" ? ("" as unknown as number) : Number(v);
+												const raw = v === "" ? ("" as unknown as number) : Number(v);
+												const num = max !== undefined && typeof raw === "number" ? clamp(raw, min ?? 0, max) : raw;
 												field.handleChange(num);
 												handleAutoSave(name, num);
 											}}

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
@@ -29,6 +29,11 @@ const formSchema = pageSchema;
 
 type FormValues = z.infer<typeof formSchema>;
 
+const CLAMP_MIN = 0;
+const CLAMP_MAX = 100;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
 function PageSectionForm() {
 	const resume = useResume();
 	const page = resume?.data.metadata.page;
@@ -53,16 +58,11 @@ function PageSectionForm() {
 		persist({ ...form.state.values, [name]: value });
 	};
 
-	const CLAMP_MIN = 0;
-const CLAMP_MAX = 100;
-
-const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
-
-const pageNumberFields = [
-	{ name: "marginX" as const, label: <Trans>Margin (Horizontal)</Trans>, min: CLAMP_MIN, max: CLAMP_MAX },
-	{ name: "marginY" as const, label: <Trans>Margin (Vertical)</Trans>, min: CLAMP_MIN, max: CLAMP_MAX },
-	{ name: "gapX" as const, label: <Trans>Spacing (Horizontal)</Trans>, min: 0, max: undefined },
-	{ name: "gapY" as const, label: <Trans>Spacing (Vertical)</Trans>, min: 0, max: undefined },
+	const pageNumberFields = [
+		{ name: "marginX" as const, label: <Trans>Margin (Horizontal)</Trans>, min: CLAMP_MIN, max: CLAMP_MAX },
+		{ name: "marginY" as const, label: <Trans>Margin (Vertical)</Trans>, min: CLAMP_MIN, max: CLAMP_MAX },
+		{ name: "gapX" as const, label: <Trans>Spacing (Horizontal)</Trans>, min: 0, max: undefined },
+		{ name: "gapY" as const, label: <Trans>Spacing (Vertical)</Trans>, min: 0, max: undefined },
 	];
 
 	const pageSwitchFields = [
@@ -156,8 +156,13 @@ const pageNumberFields = [
 											onBlur={field.handleBlur}
 											onChange={(e) => {
 												const v = e.target.value;
-												const raw = v === "" ? ("" as unknown as number) : Number(v);
-												const num = max !== undefined && typeof raw === "number" ? clamp(raw, min ?? 0, max) : raw;
+												// Ignore transient empty/invalid input so resume metadata stays numeric
+												if (v === "") return;
+
+												const raw = Number(v);
+												if (!Number.isFinite(raw)) return;
+
+												const num = max !== undefined ? clamp(raw, min ?? 0, max) : Math.max(raw, min ?? 0);
 												field.handleChange(num);
 												handleAutoSave(name, num);
 											}}

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
@@ -55,7 +55,12 @@ function PageSectionForm() {
 	useSyncFormValues(form, page);
 
 	const handleAutoSave = <K extends keyof FormValues>(name: K, value: FormValues[K]) => {
-		persist({ ...form.state.values, [name]: value });
+		const next = { ...form.state.values, [name]: value };
+		// Keep last-saved numeric page fields when the form holds a transient empty/NaN value
+		for (const key of ["marginX", "marginY", "gapX", "gapY"] as const) {
+			if (!Number.isFinite(next[key])) next[key] = page?.[key] ?? 0;
+		}
+		persist(next);
 	};
 
 	const pageNumberFields = [
@@ -148,7 +153,7 @@ function PageSectionForm() {
 									render={
 										<InputGroupInput
 											name={field.name}
-											value={field.state.value}
+											value={Number.isFinite(field.state.value) ? field.state.value : ""}
 											min={min}
 											{...(max !== undefined ? { max } : {})}
 											step={1}
@@ -156,8 +161,11 @@ function PageSectionForm() {
 											onBlur={field.handleBlur}
 											onChange={(e) => {
 												const v = e.target.value;
-												// Ignore transient empty/invalid input so resume metadata stays numeric
-												if (v === "") return;
+												if (v === "") {
+													// Allow clearing the controlled input without persisting invalid metadata
+													field.handleChange(Number.NaN);
+													return;
+												}
 
 												const raw = Number(v);
 												if (!Number.isFinite(raw)) return;

--- a/packages/schema/src/resume/data.test.ts
+++ b/packages/schema/src/resume/data.test.ts
@@ -260,6 +260,19 @@ describe("pageSchema", () => {
 		expect(pageSchema.safeParse(invalid).success).toBe(false);
 	});
 
+	it("falls back to default margins when out of range via .catch", () => {
+		const result = pageSchema.safeParse({
+			...defaultResumeData.metadata.page,
+			marginX: 1224,
+			marginY: 999,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.marginX).toBe(14);
+			expect(result.data.marginY).toBe(12);
+		}
+	});
+
 	it("falls back to 'a4' for unknown format via .catch", () => {
 		const invalid = { ...defaultResumeData.metadata.page, format: "huge" };
 		const result = pageSchema.safeParse(invalid);

--- a/packages/schema/src/resume/data.ts
+++ b/packages/schema/src/resume/data.ts
@@ -444,8 +444,8 @@ export const layoutSchema = z.object({
 export const pageSchema = z.object({
 	gapX: z.number().min(0).describe("The horizontal gap between the sections of the page, defined in points (pt)."),
 	gapY: z.number().min(0).describe("The vertical gap between the sections of the page, defined in points (pt)."),
-	marginX: z.number().min(0).max(100).describe("The horizontal margin of the page, defined in points (pt)."),
-	marginY: z.number().min(0).max(100).describe("The vertical margin of the page, defined in points (pt)."),
+	marginX: z.number().min(0).max(100).catch(14).describe("The horizontal margin of the page, defined in points (pt)."),
+	marginY: z.number().min(0).max(100).catch(12).describe("The vertical margin of the page, defined in points (pt)."),
 	format: z
 		.enum(["a4", "letter", "free-form"])
 		.describe("The format of the page. Can be 'a4', 'letter', or 'free-form'.")

--- a/packages/schema/src/resume/data.ts
+++ b/packages/schema/src/resume/data.ts
@@ -444,8 +444,8 @@ export const layoutSchema = z.object({
 export const pageSchema = z.object({
 	gapX: z.number().min(0).describe("The horizontal gap between the sections of the page, defined in points (pt)."),
 	gapY: z.number().min(0).describe("The vertical gap between the sections of the page, defined in points (pt)."),
-	marginX: z.number().min(0).describe("The horizontal margin of the page, defined in points (pt)."),
-	marginY: z.number().min(0).describe("The vertical margin of the page, defined in points (pt)."),
+	marginX: z.number().min(0).max(100).describe("The horizontal margin of the page, defined in points (pt)."),
+	marginY: z.number().min(0).max(100).describe("The vertical margin of the page, defined in points (pt)."),
 	format: z
 		.enum(["a4", "letter", "free-form"])
 		.describe("The format of the page. Can be 'a4', 'letter', or 'free-form'.")


### PR DESCRIPTION
## Description

When a user pastes a large value (e.g., "1224") into the **Margin (Vertical)** or **Margin (Horizontal)** input field — whether accidentally or intentionally — the value bypasses the HTML `<input type="number" max="100">` limit and is stored directly into the resume metadata. React PDF then cannot handle an absurdly large margin, which causes the builder to crash entirely.

This fix adds **two layers of defense**:

1. **Zod schema**: Added `.max(100)` to `marginX` and `marginY` in `pageSchema`, so any value > 100 is rejected at the validation level.
2. **Input handler**: The `onChange` handler now clamps the value to `[0, max]` so the input never even temporarily stores an out-of-range value.

## How to reproduce

1. Open a resume in the builder
2. Go to the Page section in the right sidebar
3. Paste a value like "1224" into the **Margin (Vertical)** field
4. Observe that the builder crashes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [contributing guidelines](https://docs.reactive-resume.com/contributing/development)
- [x] My code follows the code style of this project
- [x] My commit message follows the commit style of this project

Fixes #3263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page margin controls by enforcing valid values within **0–100** for both horizontal and vertical margins.
  * Updated numeric input behavior: non-finite values now render as empty, and clearing a field won’t persist invalid temporary metadata.
  * Added consistent clamping for margin values (and related spacing) to prevent out-of-range results from being saved.

* **Tests**
  * Added coverage to confirm out-of-range margin inputs fall back to the expected defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash in the resume builder caused by pasting large values (e.g. `1224`) into margin input fields, which bypassed the HTML `max` attribute and corrupted React PDF's render. Two coordinated layers of defense are added.

- **Schema layer**: `marginX` and `marginY` in `pageSchema` now have `.max(100).catch(defaultValue)`, so any out-of-range value stored in the database is silently repaired to the field's original default (14 pt horizontal, 12 pt vertical) instead of failing validation.
- **UI layer**: The `onChange` handler clamps typed/pasted values to `[0, 100]` immediately; clearing the field stores `NaN` in form state (showing a blank input) without persisting it, and `handleAutoSave` guards all four numeric page fields against accidental NaN persistence by falling back to the last-saved `page` value.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge; both previously flagged concerns (missing `.catch()` for backward compatibility and inability to clear numeric fields) have been addressed in this revision.

The schema fix adds `.catch()` with sensible defaults so existing resumes with large margin values load cleanly. The UI handler correctly threads `NaN` through the controlled input to allow clearing, while guarding `handleAutoSave` from ever persisting non-finite values. All three files have matching test coverage for the new schema constraint.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/schema/src/resume/data.ts | Adds `.max(100).catch(14)` / `.max(100).catch(12)` to `marginX` / `marginY` in `pageSchema`, capping out-of-range values and restoring the correct default instead of failing validation. |
| apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx | Adds `clamp` utility, clamps margin inputs in `onChange`, uses `Number.NaN` to represent a cleared-but-unsaved field, and guards `handleAutoSave` against persisting NaN by falling back to the last-saved `page` value. |
| packages/schema/src/resume/data.test.ts | Adds a test verifying that out-of-range `marginX`/`marginY` values trigger `.catch()` and return the schema defaults (14 and 12 respectively). |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile review on margin c..."](https://github.com/amruthpillai/reactive-resume/commit/1aca52b0d789eef8b0115447dd8ae60f67cb0cf0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48262719)</sub>

<!-- /greptile_comment -->