### PR TITLE
docs: align pnpm version with packageManager field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Internal packages are source-consumed through `package.json` export maps that po
 
 - **Node.js 24** (matches Dockerfile `ARG NODE_VERSION=24`). Use `nvm install 24 && nvm use 24` if needed.
 - **Docker** is required to run PostgreSQL. Start it with `sudo dockerd &` if the daemon isn't running.
-- **pnpm 11.1.2** is managed via corepack (`corepack enable`).
+- **pnpm 11.17.0** is managed via corepack (`corepack enable`).
 
 ### Codebase map
 

--- a/docs/contributing/development.mdx
+++ b/docs/contributing/development.mdx
@@ -4,7 +4,7 @@ description: "Set up a local development environment for Reactive Resume with pn
 ---
 
 <Info>
-  **Prerequisites**: - [Node.js](https://nodejs.org/) v24 - [pnpm](https://pnpm.io/) v11.1.2 through Corepack -
+  **Prerequisites**: - [Node.js](https://nodejs.org/) v24 - [pnpm](https://pnpm.io/) v11.17.0 through Corepack -
   [Docker](https://docs.docker.com/get-docker/) and Docker Compose - [Git](https://git-scm.com/)
 </Info>
 


### PR DESCRIPTION
## Problem

Contributor docs still say **pnpm 11.1.2**, but `package.json` pins **`pnpm@11.17.0`** via the `packageManager` field. New contributors following `AGENTS.md` or `docs/contributing/development.mdx` can install the wrong pnpm release and hit Corepack/version mismatch friction during setup.

Self-sourced docs drift fix.

## Triage / Root cause

`package.json` was bumped to `pnpm@11.17.0` on current `main`, but the prerequisite bullets in `AGENTS.md` and `docs/contributing/development.mdx` were not updated and still reference `11.1.2`.

## Fix

- Update `AGENTS.md` prerequisite bullet to **pnpm 11.17.0**.
- Update `docs/contributing/development.mdx` prerequisites to **v11.17.0**.

## Verification

- `python3 scripts/preflight_ship.py --repo amruthpillai/reactive-resume --local reactive-resume --branch main --file AGENTS.md --must-contain 'pnpm 11.1.2' --must-not-contain 'pnpm 11.17.0' --search 'pnpm 11.1.2 OR packageManager pnpm'` → **PREFLIGHT CLEAR**
- `git grep '11\.1\.2' AGENTS.md docs/contributing/development.mdx` on branch → no matches
- Docs-only change; no runtime behavior affected.

## Notes / Risks

- No open or merged PR duplicates found for this drift.
- `CLAUDE.md` on upstream is a one-line pointer to `AGENTS.md`, so only the two updated files needed changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR synchronises the pnpm version mentioned in contributor docs with the `packageManager` field in `package.json`, which is pinned to `pnpm@11.17.0`.

- **`AGENTS.md`**: prerequisite bullet updated from `pnpm 11.1.2` → `pnpm 11.17.0`.
- **`docs/contributing/development.mdx`**: Info callout prerequisite updated from `v11.1.2` → `v11.17.0`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change that corrects a version number in two files; no runtime code is touched.

Both updated version strings (pnpm 11.17.0) match the packageManager field in package.json exactly. The change is purely additive to docs and carries no risk to application behaviour.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Single-line update: pnpm version in prerequisites corrected from 11.1.2 to 11.17.0, matching package.json packageManager field. |
| docs/contributing/development.mdx | Single-line update: pnpm prerequisite version corrected from v11.1.2 to v11.17.0 in the Info callout, consistent with AGENTS.md and package.json. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json\npackageManager: pnpm@11.17.0"] -->|"source of truth"| B["AGENTS.md\n(updated: 11.1.2 → 11.17.0)"]
    A -->|"source of truth"| C["docs/contributing/development.mdx\n(updated: v11.1.2 → v11.17.0)"]
    B & C --> D["New contributor\ninstalls correct pnpm via Corepack"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: align pnpm version with packageMan..."](https://github.com/amruthpillai/reactive-resume/commit/d81d1ea8d60e5803714e12945e61042efd724b85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48582032)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development prerequisites to require pnpm v11.17.0 through Corepack.
  * Confirmed the existing Node.js v24 requirement remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
