### PR TITLE
docs: align pnpm version with packageManager field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Internal packages are source-consumed through `package.json` export maps that po
 
 - **Node.js 24** (matches Dockerfile `ARG NODE_VERSION=24`). Use `nvm install 24 && nvm use 24` if needed.
 - **Docker** is required to run PostgreSQL. Start it with `sudo dockerd &` if the daemon isn't running.
-- **pnpm 11.17.0** is managed via corepack (`corepack enable`).
+- **pnpm 11.18.0** is managed via corepack (`corepack enable`).
 
 ### Codebase map
 

--- a/docs/contributing/development.mdx
+++ b/docs/contributing/development.mdx
@@ -4,7 +4,7 @@ description: "Set up a local development environment for Reactive Resume with pn
 ---
 
 <Info>
-  **Prerequisites**: - [Node.js](https://nodejs.org/) v24 - [pnpm](https://pnpm.io/) v11.17.0 through Corepack -
+  **Prerequisites**: - [Node.js](https://nodejs.org/) v24 - [pnpm](https://pnpm.io/) v11.18.0 through Corepack -
   [Docker](https://docs.docker.com/get-docker/) and Docker Compose - [Git](https://git-scm.com/)
 </Info>
 


### PR DESCRIPTION
## Problem

Contributors following `AGENTS.md` or the development guide install **pnpm 11.17.0**, but `package.json` pins **`pnpm@11.18.0`** via the `packageManager` field on current `main`. This regressed after upstream bumped pnpm in #3278's wake (our prior docs fix landed at 11.17.0).

## Triage / Root cause

- `package.json` → `"packageManager": "pnpm@11.18.0"`
- `AGENTS.md:15` and `docs/contributing/development.mdx:7` still said **11.17.0**

## Fix

- Update both doc locations to **11.18.0** so they match `packageManager`.
- `CLAUDE.md` already matched upstream at 11.18.0 — no change needed.

## Verification

- Docs-only change (2 lines).
- `grep -r '11.17.0' AGENTS.md docs/` → no matches after fix.
- Self-sourced; preflight cleared against `upstream/main` @ `b071a118a`.

## Notes / Risks

- Same lane as merged #3278; minimal maintainer-review surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development prerequisites to specify pnpm v11.18.0 via Corepack.
  * Synchronized the documented pnpm version across contributor guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR syncs the documented pnpm version in `AGENTS.md` and `docs/contributing/development.mdx` from `11.17.0` to `11.18.0`, aligning contributor setup instructions with the `packageManager` field in `package.json`.

- `AGENTS.md` line 15: prerequisite pnpm version updated to `11.18.0`.
- `docs/contributing/development.mdx` line 7: prerequisite pnpm version updated to `11.18.0`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — two documentation lines updated, no code or configuration changed.

Both changes are single-line doc updates that bring contributor-facing setup instructions in sync with the authoritative packageManager field in package.json. The updated version (11.18.0) is confirmed correct against the root manifest.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Single-line change updating pnpm prerequisite from 11.17.0 to 11.18.0; now matches package.json packageManager field. |
| docs/contributing/development.mdx | Single-line change updating pnpm prerequisite from 11.17.0 to 11.18.0; consistent with AGENTS.md and package.json. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json\npackageManager: pnpm@11.18.0"] -->|"source of truth"| B{"Docs aligned?"}
    B -->|"Before PR"| C["AGENTS.md: 11.17.0 ❌\ndocs/contributing/development.mdx: 11.17.0 ❌\nCLAUDE.md: 11.18.0 ✅"]
    B -->|"After PR"| D["AGENTS.md: 11.18.0 ✅\ndocs/contributing/development.mdx: 11.18.0 ✅\nCLAUDE.md: 11.18.0 ✅"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: align pnpm version with packageMan..."](https://github.com/amruthpillai/reactive-resume/commit/31c273db8b124c36b0c4608ef15bb1eb61e39c78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48717985)</sub>

<!-- /greptile_comment -->