### PR TITLE
fix(web): stop custom styles from sticking on Checking

### DIFF
--- a/apps/web/src/features/resume/stylesheet/store.test.ts
+++ b/apps/web/src/features/resume/stylesheet/store.test.ts
@@ -741,6 +741,97 @@ describe("stylesheet store runtime", () => {
 		);
 	});
 
+	it("does not leave Checking stuck when compile rejects for the current edit", async () => {
+		const runtime = createStylesheetStoreRuntime({
+			resumeId: "resume-1",
+			initial,
+			resumeData: defaultResumeData,
+			debounceMs: 0,
+			compile: () => Promise.reject(new Error("Discarded stale stylesheet compiler result.")),
+			preflight: vi.fn(),
+			mutate: vi.fn(),
+		});
+
+		runtime.store.getState().setSourceText("edited source");
+		await vi.runAllTimersAsync();
+
+		expect(runtime.store.getState().status).not.toBe("compiling");
+		expect(runtime.store.getState().status).toBe("error");
+	});
+
+	it("finishes an edit when refreshIntelligence interleaves through the shared compile client", async () => {
+		const { createCompileWorkerClient } = await import("./worker-client");
+		const listeners = new Map<string, Set<EventListener>>();
+		const fake = {
+			postMessage: vi.fn(),
+			terminate: vi.fn(),
+			addEventListener: vi.fn((type: string, listener: EventListener) => {
+				const bucket = listeners.get(type) ?? new Set();
+				bucket.add(listener);
+				listeners.set(type, bucket);
+			}),
+			removeEventListener: vi.fn((type: string, listener: EventListener) => {
+				listeners.get(type)?.delete(listener);
+			}),
+			emit(data: unknown) {
+				for (const listener of listeners.get("message") ?? []) {
+					(listener as (event: MessageEvent) => void)(new MessageEvent("message", { data }));
+				}
+			},
+		};
+		const client = createCompileWorkerClient(() => fake);
+		const runtime = createStylesheetStoreRuntime({
+			resumeId: "resume-1",
+			initial,
+			resumeData: defaultResumeData,
+			debounceMs: 0,
+			compile: client.compile,
+			preflight: async ({ editGeneration }) => ({
+				type: "preflight_result",
+				requestId: editGeneration,
+				editGeneration,
+				result: { ok: true, pageCount: 1, byteCount: 1, diagnostics: [], pdf: new ArrayBuffer(1) },
+			}),
+			mutate: async ({ editGeneration }) => ({
+				stylesheet: stylesheet("edited source"),
+				revision: 4,
+				renderDataVersion: 7,
+				editGeneration,
+				diagnostics: [],
+			}),
+		});
+
+		runtime.store.getState().setSourceText("edited source");
+		await vi.runAllTimersAsync();
+		expect(runtime.store.getState().status).toBe("compiling");
+		expect(fake.postMessage).toHaveBeenCalledTimes(1);
+
+		// Mobile Design remount / accordion reopen refreshes intelligence while the edit is compiling.
+		runtime.store.getState().refreshIntelligence();
+		expect(fake.postMessage).toHaveBeenCalledTimes(2);
+
+		fake.emit({
+			type: "compile_result",
+			requestId: 1,
+			editGeneration: 1,
+			program: { languageVersion: 1, rules: [] },
+			diagnostics: [],
+			colorTokens: [],
+		});
+		fake.emit({
+			type: "compile_result",
+			requestId: 2,
+			editGeneration: 1,
+			program: { languageVersion: 1, rules: [] },
+			diagnostics: [],
+			colorTokens: [],
+		});
+		await vi.runAllTimersAsync();
+
+		expect(runtime.store.getState().status).toBe("applied");
+		expect(runtime.store.getState().applied.text).toBe("edited source");
+	});
+
 	it("terminates both worker clients and clears the store on cleanup", () => {
 		const destroy = vi.fn();
 		let mutationSignal: AbortSignal | undefined;

--- a/apps/web/src/features/resume/stylesheet/store.ts
+++ b/apps/web/src/features/resume/stylesheet/store.ts
@@ -349,6 +349,9 @@ export function createStylesheetStoreRuntime(options: CreateStylesheetStoreRunti
 				compileInput(resumeData, source, candidate.generation, editorMetadata.semanticTree),
 			);
 		} catch {
+			if (candidateValidationEpoch !== validationEpoch) return;
+			if (destroyed || candidate.generation !== store.getState().editGeneration) return;
+			patch({ status: "error" });
 			return;
 		}
 		if (candidateValidationEpoch !== validationEpoch) return;

--- a/apps/web/src/features/resume/stylesheet/worker-client.test.ts
+++ b/apps/web/src/features/resume/stylesheet/worker-client.test.ts
@@ -5,20 +5,33 @@ import { createCompileWorkerClient, createPreflightWorkerClient } from "./worker
 type Listener = (event: MessageEvent) => void;
 
 function worker() {
-	const listeners = new Set<Listener>();
+	const listeners = new Map<string, Set<EventListener>>();
 	return {
 		postMessage: vi.fn(),
 		terminate: vi.fn(),
-		addEventListener: vi.fn((_type: string, listener: Listener) => listeners.add(listener)),
-		removeEventListener: vi.fn((_type: string, listener: Listener) => listeners.delete(listener)),
+		addEventListener: vi.fn((type: string, listener: EventListener) => {
+			const bucket = listeners.get(type) ?? new Set();
+			bucket.add(listener);
+			listeners.set(type, bucket);
+		}),
+		removeEventListener: vi.fn((type: string, listener: EventListener) => {
+			listeners.get(type)?.delete(listener);
+		}),
 		emit(data: unknown) {
-			for (const listener of listeners) listener(new MessageEvent("message", { data }));
+			for (const listener of listeners.get("message") ?? []) {
+				(listener as Listener)(new MessageEvent("message", { data }));
+			}
+		},
+		emitError(event: ErrorEvent) {
+			for (const listener of listeners.get("error") ?? []) {
+				listener(event);
+			}
 		},
 	};
 }
 
 describe("stylesheet worker clients", () => {
-	it("rejects stale compiler results by request id", async () => {
+	it("resolves older compiler results so callers can generation-check without aborting", async () => {
 		const fake = worker();
 		const client = createCompileWorkerClient(() => fake);
 		const first = client.compile({ editGeneration: 1 } as never);
@@ -27,8 +40,18 @@ describe("stylesheet worker clients", () => {
 		fake.emit({ type: "compile_result", requestId: 1, editGeneration: 1, program: null, diagnostics: [] });
 		fake.emit({ type: "compile_result", requestId: 2, editGeneration: 2, program: null, diagnostics: [] });
 
-		await expect(first).rejects.toThrow("stale");
-		await expect(second).resolves.toMatchObject({ requestId: 2 });
+		await expect(first).resolves.toMatchObject({ requestId: 1, editGeneration: 1 });
+		await expect(second).resolves.toMatchObject({ requestId: 2, editGeneration: 2 });
+	});
+
+	it("rejects pending compiles when the worker reports an error", async () => {
+		const fake = worker();
+		const client = createCompileWorkerClient(() => fake);
+		const pending = client.compile({ editGeneration: 1 } as never);
+
+		fake.emitError({ message: "Failed to load compiler worker" } as ErrorEvent);
+
+		await expect(pending).rejects.toThrow("Failed to load compiler worker");
 	});
 
 	it("terminates and recreates a timed-out preflight worker", async () => {
@@ -68,7 +91,9 @@ describe("stylesheet worker clients", () => {
 		client.warmup();
 
 		expect(createWorker).toHaveBeenCalledOnce();
-		expect(fake.addEventListener).toHaveBeenCalledOnce();
+		expect(fake.addEventListener).toHaveBeenCalledTimes(2);
+		expect(fake.addEventListener).toHaveBeenCalledWith("message", expect.any(Function));
+		expect(fake.addEventListener).toHaveBeenCalledWith("error", expect.any(Function));
 		expect(fake.postMessage).not.toHaveBeenCalled();
 	});
 

--- a/apps/web/src/features/resume/stylesheet/worker-client.ts
+++ b/apps/web/src/features/resume/stylesheet/worker-client.ts
@@ -10,12 +10,15 @@ import type {
 } from "./protocol";
 
 type WorkerListener = (event: MessageEvent<unknown>) => void;
+type WorkerErrorListener = (event: ErrorEvent) => void;
 
 export type StylesheetWorker = {
 	postMessage(message: unknown, transfer?: Transferable[]): void;
 	terminate(): void;
 	addEventListener(type: "message", listener: WorkerListener): void;
+	addEventListener(type: "error", listener: WorkerErrorListener): void;
 	removeEventListener(type: "message", listener: WorkerListener): void;
+	removeEventListener(type: "error", listener: WorkerErrorListener): void;
 };
 
 type Pending<T> = {
@@ -34,13 +37,17 @@ export function createCompileWorkerClient(createWorker: () => StylesheetWorker) 
 		const request = pending.get(response.requestId);
 		if (!request) return;
 		pending.delete(response.requestId);
-		if (response.requestId !== latestRequestId) {
-			request.reject(new Error("Discarded stale stylesheet compiler result."));
-			return;
-		}
+		// Resolve every in-flight compile. Callers already generation-check; rejecting "stale"
+		// results aborts the edit pipeline and can leave the editor stuck on Checking.
 		request.resolve(response);
 	};
+	const onError: WorkerErrorListener = (event) => {
+		const error = new Error(event.message || "Stylesheet compiler worker failed to load.");
+		for (const request of pending.values()) request.reject(error);
+		pending.clear();
+	};
 	worker.addEventListener("message", onMessage);
+	worker.addEventListener("error", onError);
 
 	return {
 		compile(input: CompileWorkerInput): Promise<CompileWorkerResponse> {
@@ -53,6 +60,7 @@ export function createCompileWorkerClient(createWorker: () => StylesheetWorker) 
 		},
 		destroy() {
 			worker.removeEventListener("message", onMessage);
+			worker.removeEventListener("error", onError);
 			worker.terminate();
 			for (const request of pending.values()) request.reject(new Error("Stylesheet compiler worker was terminated."));
 			pending.clear();
@@ -120,10 +128,14 @@ export function createPreflightWorkerClient(
 		pending.delete(response.requestId);
 		request.resolve(response);
 	};
+	const onError: WorkerErrorListener = () => {
+		terminate();
+	};
 
 	const terminate = () => {
 		if (!worker) return;
 		worker.removeEventListener("message", onMessage);
+		worker.removeEventListener("error", onError);
 		worker.terminate();
 		worker = undefined;
 		ready = false;
@@ -140,6 +152,7 @@ export function createPreflightWorkerClient(
 		if (readiness) return readiness.promise;
 		worker = createWorker();
 		worker.addEventListener("message", onMessage);
+		worker.addEventListener("error", onError);
 		let resolve!: (value: StylesheetWorker) => void;
 		let reject!: (error: Error) => void;
 		const promise = new Promise<StylesheetWorker>((resolvePromise, rejectPromise) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On production, editing Custom Styles could leave the status badge stuck on **Checking** and never apply the stylesheet.

## Root cause

The Semantic CSS editor shares one compile worker client between:

1. the edit pipeline (`compiling` → preflight → save)
2. `refreshIntelligence()` (runs whenever the editor mounts)

When intelligence started a newer compile while an edit was compiling (common on mobile when the Design tab remounts), the client **rejected** the in-flight edit compile as stale. The store caught that rejection and returned **without leaving `compiling`**, so the UI stayed on Checking and never preflighted/saved.

## Fix

- Resolve all in-flight compile results instead of rejecting older ones; callers already generation-check.
- If compile still fails for the current edit, set status to `error` instead of leaving `compiling`.
- Listen for compiler/preflight worker `error` events so load failures fail closed.

## Test plan

- [x] `pnpm --filter web exec vitest run src/features/resume/stylesheet/store.test.ts src/features/resume/stylesheet/worker-client.test.ts src/features/resume/stylesheet/preflight.worker.test.ts`
- [ ] Manually: open Design → Custom Styles on mobile, edit CSS, switch Preview/Design, confirm status reaches Applied and styles render

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9ea8d30-1b1e-4a5c-815d-512e16ee87f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9ea8d30-1b1e-4a5c-815d-512e16ee87f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stylesheet compilation failures now immediately show an error state instead of remaining stuck in “Checking.”
  - Worker errors now correctly reject pending compilation requests and clean up processing.
  - Preflight workers now terminate properly when errors occur.
  - Concurrent stylesheet refreshes and edits now complete reliably with the correct applied content.

- **Tests**
  - Added coverage for compilation failures, worker errors, and overlapping refresh requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the Custom Styles editor badge could get permanently stuck on "Checking" on mobile when `refreshIntelligence()` fired a second compile while an edit compile was already in flight, causing the shared worker client to reject the edit compile as stale and leave the store in `compiling` status indefinitely.

- **Core fix**: The compile worker client now resolves all in-flight results instead of rejecting older request IDs as stale; `store.ts`'s catch block now applies epoch/generation guards before setting `status: "error"`, rather than silently returning and leaving `status: "compiling"`.
- **Error robustness**: Both compile and preflight worker clients gain `error` event listeners so worker load failures fail closed; the compile client immediately drains pending requests on error, while the preflight client relies on its existing 5-second timeout.
- **Test coverage**: Two new regression tests cover the interleaved-intelligence scenario and the compile-reject → error-status path, with updated mocks tracking listeners by event type.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the fix is well-scoped, directly addresses the described race condition, and is backed by targeted regression tests.

The `refreshIntelligence` compile call still has no `.catch()` handler; now that the compile client can reject on worker load failure, a worker error during an intelligence refresh will produce an unhandled Promise rejection on the changed code path.

**Files Needing Attention:** store.ts — the `refreshIntelligence` action (lines 520–539) needs a `.catch()` to handle compile rejections that the new `onError` handler can now surface.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/resume/stylesheet/store.ts | Catch block for failed compile now correctly checks epoch/generation guards and sets status to "error" instead of silently returning — fixing the "Checking stuck" bug. The refreshIntelligence compile call still lacks a .catch() handler, leaving a potential unhandled rejection if the worker errors. |
| apps/web/src/features/resume/stylesheet/worker-client.ts | Compile client now resolves all results instead of rejecting stale ones; adds onError handler that immediately drains pending compiles. Preflight client gains an onError handler that calls terminate() but does not drain its own pending map — in-flight preflight requests rely on the 5-second timeout rather than an immediate rejection. |
| apps/web/src/features/resume/stylesheet/store.test.ts | Adds two well-structured regression tests: one verifying the compile-reject → error-status path, and one end-to-end test simulating the refreshIntelligence interleave scenario that triggered the original bug. |
| apps/web/src/features/resume/stylesheet/worker-client.test.ts | Updates worker mock to track listeners by event type, adds emitError helper, and updates/adds tests for the new resolve-all and onError behaviors. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Store
    participant CompileClient
    participant Worker

    User->>Store: setSourceText("edited source")
    Store->>Store: "status = "compiling""
    Store->>CompileClient: "compile(editGen=1, requestId=1)"

    Note over Store: Design tab remounts on mobile
    Store->>CompileClient: "refreshIntelligence() compile(editGen=1, requestId=2)"

    Worker-->>CompileClient: "compile_result {requestId: 1}"
    Note over CompileClient: OLD: reject(requestId=1, stale)<br/>NEW: resolve(requestId=1)
    CompileClient-->>Store: [processCandidate] resolved
    Store->>Store: generation-check passes to preflight to save
    Store->>Store: "status = applied"

    Worker-->>CompileClient: "compile_result {requestId: 2}"
    CompileClient-->>Store: [refreshIntelligence] resolved
    Store->>Store: generation-check to patch diagnostics/colorTokens

    Note over Store,Worker: On worker load error
    Worker-->>CompileClient: error event
    CompileClient->>CompileClient: reject all pending
    CompileClient-->>Store: "catch block epoch/gen guards to status = error"
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/features/resume/stylesheet/store.ts`, line 525-538 ([link](https://github.com/amruthpillai/reactive-resume/blob/5449603530ea6e8a15894c745002455c2136e033/apps/web/src/features/resume/stylesheet/store.ts#L525-L538)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unhandled rejection in `refreshIntelligence` when compile worker errors**

   The `compile()` call in `refreshIntelligence` has no `.catch()` handler. Before this PR, stale compiles were rejected by the client, but the stale-rejection was swallowed by the existing unhandled path. Now that the new `onError` handler rejects all pending requests when the worker fails, a worker load failure during intelligence refresh will surface as an unhandled Promise rejection, which can produce console noise or crash in some environments. Adding `.catch(() => {})` (or propagating the error) would make it fail closed silently.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/features/resume/stylesheet/store.ts
   Line: 525-538

   Comment:
   **Unhandled rejection in `refreshIntelligence` when compile worker errors**

   The `compile()` call in `refreshIntelligence` has no `.catch()` handler. Before this PR, stale compiles were rejected by the client, but the stale-rejection was swallowed by the existing unhandled path. Now that the new `onError` handler rejects all pending requests when the worker fails, a worker load failure during intelligence refresh will surface as an unhandled Promise rejection, which can produce console noise or crash in some environments. Adding `.catch(() => {})` (or propagating the error) would make it fail closed silently.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fstore.ts%0ALine%3A%20525-538%0A%0AComment%3A%0A**Unhandled%20rejection%20in%20%60refreshIntelligence%60%20when%20compile%20worker%20errors**%0A%0AThe%20%60compile%28%29%60%20call%20in%20%60refreshIntelligence%60%20has%20no%20%60.catch%28%29%60%20handler.%20Before%20this%20PR%2C%20stale%20compiles%20were%20rejected%20by%20the%20client%2C%20but%20the%20stale-rejection%20was%20swallowed%20by%20the%20existing%20unhandled%20path.%20Now%20that%20the%20new%20%60onError%60%20handler%20rejects%20all%20pending%20requests%20when%20the%20worker%20fails%2C%20a%20worker%20load%20failure%20during%20intelligence%20refresh%20will%20surface%20as%20an%20unhandled%20Promise%20rejection%2C%20which%20can%20produce%20console%20noise%20or%20crash%20in%20some%20environments.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20%28or%20propagating%20the%20error%29%20would%20make%20it%20fail%20closed%20silently.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fstore.ts%0ALine%3A%20525-538%0A%0AComment%3A%0A**Unhandled%20rejection%20in%20%60refreshIntelligence%60%20when%20compile%20worker%20errors**%0A%0AThe%20%60compile%28%29%60%20call%20in%20%60refreshIntelligence%60%20has%20no%20%60.catch%28%29%60%20handler.%20Before%20this%20PR%2C%20stale%20compiles%20were%20rejected%20by%20the%20client%2C%20but%20the%20stale-rejection%20was%20swallowed%20by%20the%20existing%20unhandled%20path.%20Now%20that%20the%20new%20%60onError%60%20handler%20rejects%20all%20pending%20requests%20when%20the%20worker%20fails%2C%20a%20worker%20load%20failure%20during%20intelligence%20refresh%20will%20surface%20as%20an%20unhandled%20Promise%20rejection%2C%20which%20can%20produce%20console%20noise%20or%20crash%20in%20some%20environments.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20%28or%20propagating%20the%20error%29%20would%20make%20it%20fail%20closed%20silently.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amruthpillai%2Freactive-resume%22%20on%20the%20existing%20branch%20%22feat%2Ffix-stylesheet-checking-stuck-87f8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffix-stylesheet-checking-stuck-87f8%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fstore.ts%0ALine%3A%20525-538%0A%0AComment%3A%0A**Unhandled%20rejection%20in%20%60refreshIntelligence%60%20when%20compile%20worker%20errors**%0A%0AThe%20%60compile%28%29%60%20call%20in%20%60refreshIntelligence%60%20has%20no%20%60.catch%28%29%60%20handler.%20Before%20this%20PR%2C%20stale%20compiles%20were%20rejected%20by%20the%20client%2C%20but%20the%20stale-rejection%20was%20swallowed%20by%20the%20existing%20unhandled%20path.%20Now%20that%20the%20new%20%60onError%60%20handler%20rejects%20all%20pending%20requests%20when%20the%20worker%20fails%2C%20a%20worker%20load%20failure%20during%20intelligence%20refresh%20will%20surface%20as%20an%20unhandled%20Promise%20rejection%2C%20which%20can%20produce%20console%20noise%20or%20crash%20in%20some%20environments.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20%28or%20propagating%20the%20error%29%20would%20make%20it%20fail%20closed%20silently.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fstore.ts%3A525-538%0A**Unhandled%20rejection%20in%20%60refreshIntelligence%60%20when%20compile%20worker%20errors**%0A%0AThe%20%60compile%28%29%60%20call%20in%20%60refreshIntelligence%60%20has%20no%20%60.catch%28%29%60%20handler.%20Before%20this%20PR%2C%20stale%20compiles%20were%20rejected%20by%20the%20client%2C%20but%20the%20stale-rejection%20was%20swallowed%20by%20the%20existing%20unhandled%20path.%20Now%20that%20the%20new%20%60onError%60%20handler%20rejects%20all%20pending%20requests%20when%20the%20worker%20fails%2C%20a%20worker%20load%20failure%20during%20intelligence%20refresh%20will%20surface%20as%20an%20unhandled%20Promise%20rejection%2C%20which%20can%20produce%20console%20noise%20or%20crash%20in%20some%20environments.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20%28or%20propagating%20the%20error%29%20would%20make%20it%20fail%20closed%20silently.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fworker-client.ts%3A131-133%0A**Preflight%20worker%20error%20doesn't%20drain%20in-flight%20pending%20requests**%0A%0AWhen%20the%20preflight%20worker%20emits%20an%20%60error%60%20event%20after%20it%20has%20already%20become%20%60ready%60%2C%20%60terminate%28%29%60%20only%20clears%20the%20%60readiness%60%20promise%20%28which%20is%20%60undefined%60%20at%20that%20point%29%20and%20sets%20%60worker%20%3D%20undefined%60.%20Any%20requests%20already%20in%20%60pending%60%20with%20running%20timers%20are%20left%20hanging%20until%20the%205-second%20%60timeoutMs%60%20fires%2C%20at%20which%20point%20they%20resolve%20with%20%60timeoutResult%60%20and%20the%20store%20transitions%20to%20%60error%60.%20By%20contrast%2C%20the%20compile%20client's%20%60onError%60%20immediately%20rejects%20all%20pending%20requests.%20The%20timeout%20path%20is%20safe%20%28no%20permanent%20hang%29%2C%20but%20a%205-second%20delay%20before%20the%20UI%20shows%20an%20error%20is%20user-visible.%20Consider%20draining%20%60pending%60%20in%20this%20handler%20similarly%20to%20the%20compile%20client's%20%60onError%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fstore.ts%3A525-538%0A**Unhandled%20rejection%20in%20%60refreshIntelligence%60%20when%20compile%20worker%20errors**%0A%0AThe%20%60compile%28%29%60%20call%20in%20%60refreshIntelligence%60%20has%20no%20%60.catch%28%29%60%20handler.%20Before%20this%20PR%2C%20stale%20compiles%20were%20rejected%20by%20the%20client%2C%20but%20the%20stale-rejection%20was%20swallowed%20by%20the%20existing%20unhandled%20path.%20Now%20that%20the%20new%20%60onError%60%20handler%20rejects%20all%20pending%20requests%20when%20the%20worker%20fails%2C%20a%20worker%20load%20failure%20during%20intelligence%20refresh%20will%20surface%20as%20an%20unhandled%20Promise%20rejection%2C%20which%20can%20produce%20console%20noise%20or%20crash%20in%20some%20environments.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20%28or%20propagating%20the%20error%29%20would%20make%20it%20fail%20closed%20silently.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fworker-client.ts%3A131-133%0A**Preflight%20worker%20error%20doesn't%20drain%20in-flight%20pending%20requests**%0A%0AWhen%20the%20preflight%20worker%20emits%20an%20%60error%60%20event%20after%20it%20has%20already%20become%20%60ready%60%2C%20%60terminate%28%29%60%20only%20clears%20the%20%60readiness%60%20promise%20%28which%20is%20%60undefined%60%20at%20that%20point%29%20and%20sets%20%60worker%20%3D%20undefined%60.%20Any%20requests%20already%20in%20%60pending%60%20with%20running%20timers%20are%20left%20hanging%20until%20the%205-second%20%60timeoutMs%60%20fires%2C%20at%20which%20point%20they%20resolve%20with%20%60timeoutResult%60%20and%20the%20store%20transitions%20to%20%60error%60.%20By%20contrast%2C%20the%20compile%20client's%20%60onError%60%20immediately%20rejects%20all%20pending%20requests.%20The%20timeout%20path%20is%20safe%20%28no%20permanent%20hang%29%2C%20but%20a%205-second%20delay%20before%20the%20UI%20shows%20an%20error%20is%20user-visible.%20Consider%20draining%20%60pending%60%20in%20this%20handler%20similarly%20to%20the%20compile%20client's%20%60onError%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amruthpillai%2Freactive-resume%22%20on%20the%20existing%20branch%20%22feat%2Ffix-stylesheet-checking-stuck-87f8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffix-stylesheet-checking-stuck-87f8%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fstore.ts%3A525-538%0A**Unhandled%20rejection%20in%20%60refreshIntelligence%60%20when%20compile%20worker%20errors**%0A%0AThe%20%60compile%28%29%60%20call%20in%20%60refreshIntelligence%60%20has%20no%20%60.catch%28%29%60%20handler.%20Before%20this%20PR%2C%20stale%20compiles%20were%20rejected%20by%20the%20client%2C%20but%20the%20stale-rejection%20was%20swallowed%20by%20the%20existing%20unhandled%20path.%20Now%20that%20the%20new%20%60onError%60%20handler%20rejects%20all%20pending%20requests%20when%20the%20worker%20fails%2C%20a%20worker%20load%20failure%20during%20intelligence%20refresh%20will%20surface%20as%20an%20unhandled%20Promise%20rejection%2C%20which%20can%20produce%20console%20noise%20or%20crash%20in%20some%20environments.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20%28or%20propagating%20the%20error%29%20would%20make%20it%20fail%20closed%20silently.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fworker-client.ts%3A131-133%0A**Preflight%20worker%20error%20doesn't%20drain%20in-flight%20pending%20requests**%0A%0AWhen%20the%20preflight%20worker%20emits%20an%20%60error%60%20event%20after%20it%20has%20already%20become%20%60ready%60%2C%20%60terminate%28%29%60%20only%20clears%20the%20%60readiness%60%20promise%20%28which%20is%20%60undefined%60%20at%20that%20point%29%20and%20sets%20%60worker%20%3D%20undefined%60.%20Any%20requests%20already%20in%20%60pending%60%20with%20running%20timers%20are%20left%20hanging%20until%20the%205-second%20%60timeoutMs%60%20fires%2C%20at%20which%20point%20they%20resolve%20with%20%60timeoutResult%60%20and%20the%20store%20transitions%20to%20%60error%60.%20By%20contrast%2C%20the%20compile%20client's%20%60onError%60%20immediately%20rejects%20all%20pending%20requests.%20The%20timeout%20path%20is%20safe%20%28no%20permanent%20hang%29%2C%20but%20a%205-second%20delay%20before%20the%20UI%20shows%20an%20error%20is%20user-visible.%20Consider%20draining%20%60pending%60%20in%20this%20handler%20similarly%20to%20the%20compile%20client's%20%60onError%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/features/resume/stylesheet/store.ts:525-538
**Unhandled rejection in `refreshIntelligence` when compile worker errors**

The `compile()` call in `refreshIntelligence` has no `.catch()` handler. Before this PR, stale compiles were rejected by the client, but the stale-rejection was swallowed by the existing unhandled path. Now that the new `onError` handler rejects all pending requests when the worker fails, a worker load failure during intelligence refresh will surface as an unhandled Promise rejection, which can produce console noise or crash in some environments. Adding `.catch(() => {})` (or propagating the error) would make it fail closed silently.

### Issue 2
apps/web/src/features/resume/stylesheet/worker-client.ts:131-133
**Preflight worker error doesn't drain in-flight pending requests**

When the preflight worker emits an `error` event after it has already become `ready`, `terminate()` only clears the `readiness` promise (which is `undefined` at that point) and sets `worker = undefined`. Any requests already in `pending` with running timers are left hanging until the 5-second `timeoutMs` fires, at which point they resolve with `timeoutResult` and the store transitions to `error`. By contrast, the compile client's `onError` immediately rejects all pending requests. The timeout path is safe (no permanent hang), but a 5-second delay before the UI shows an error is user-visible. Consider draining `pending` in this handler similarly to the compile client's `onError`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): stop custom styles from sticki..."](https://github.com/amruthpillai/reactive-resume/commit/5449603530ea6e8a15894c745002455c2136e033) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48871943)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->