### PR TITLE
fix(stylesheet): harden PDF preflight and surface worker failures

### DIFF
--- a/apps/server/src/services/stylesheet-preflight.test.ts
+++ b/apps/server/src/services/stylesheet-preflight.test.ts
@@ -187,7 +187,7 @@ describe("stylesheet PDF preflight worker", () => {
 		expect(runner.activeWorkerCount).toBe(0);
 	}, 15_000);
 
-	it("does not expose internal errors from a failed worker", async () => {
+	it("does not expose internal errors from a failed worker bootstrap", async () => {
 		const runner = createStylesheetPreflightRunner({}, failedWorker);
 
 		const result = await runner.run(input);
@@ -200,6 +200,31 @@ describe("stylesheet PDF preflight worker", () => {
 		});
 		expect(runner.activeWorkerCount).toBe(0);
 		expect(runner.queuedPreflightCount).toBe(0);
+	});
+
+	it("surfaces sanitized render failures from inside the worker catch path", async () => {
+		const throwingWorker = new URL(
+			`data:text/javascript,${encodeURIComponent(`
+				import { parentPort } from "node:worker_threads";
+				parentPort.postMessage({ type: "ready" });
+				parentPort.postMessage({
+					ok: false,
+					code: "STYLESHEET_PREFLIGHT_WORKER_FAILED",
+					message: "The PDF preflight worker failed. (Error: Canvas is already closed)",
+					diagnostics: [],
+				});
+			`)}`,
+		);
+		const runner = createStylesheetPreflightRunner({ timeoutMs: 5_000 }, throwingWorker);
+
+		const result = await runner.run(input);
+
+		expect(result).toEqual({
+			ok: false,
+			code: "STYLESHEET_PREFLIGHT_WORKER_FAILED",
+			message: "The PDF preflight worker failed. (Error: Canvas is already closed)",
+			diagnostics: [],
+		});
 	});
 
 	it("bounds concurrent workers and queued requests without charging queue time to the worker deadline", async () => {

--- a/apps/server/src/services/stylesheet-preflight.ts
+++ b/apps/server/src/services/stylesheet-preflight.ts
@@ -75,9 +75,10 @@ const workerLocation = () => {
 		url: source
 			? new URL("../workers/stylesheet-preflight.ts", import.meta.url)
 			: new URL("./stylesheet-preflight-worker.mjs", import.meta.url),
+		// Production must not inherit parent execArgv (e.g. --import/--input-type); source workers need tsx.
+		execArgv: source ? sourceWorkerExecArgv() : [],
 		...(source
 			? {
-					execArgv: sourceWorkerExecArgv(),
 					env: {
 						...process.env,
 						TSX_TSCONFIG_PATH: fileURLToPath(new URL("../../tsconfig.json", import.meta.url)),
@@ -106,7 +107,7 @@ export function createStylesheetPreflightRunner(
 		reject: (cause: unknown) => void,
 	): boolean => {
 		// The URL seam is internal to the server package and keeps worker failure tests independent from the PDF renderer.
-		const location = testWorkerUrl ? { source: false, url: testWorkerUrl } : workerLocation();
+		const location = testWorkerUrl ? { source: false, url: testWorkerUrl, execArgv: [] as string[] } : workerLocation();
 		let worker: Worker;
 		try {
 			worker = new Worker(location.url, {
@@ -116,7 +117,7 @@ export function createStylesheetPreflightRunner(
 					// The source-only tsx compiler heap is outside the production render budget.
 					maxOldGenerationSizeMb: limits.maxOldGenerationMb + (location.source ? SOURCE_WORKER_LOADER_HEAP_MB : 0),
 				},
-				...("execArgv" in location ? { execArgv: location.execArgv } : {}),
+				execArgv: location.execArgv,
 				...("env" in location ? { env: location.env } : {}),
 			});
 		} catch (error) {

--- a/apps/server/src/workers/stylesheet-preflight-inspection.ts
+++ b/apps/server/src/workers/stylesheet-preflight-inspection.ts
@@ -1,4 +1,8 @@
-import type { PdfPreflightPageLimits, PdfPreflightResult, RenderPreflightPdfResult } from "@reactive-resume/pdf/server";
+import type {
+	PdfPreflightPageLimits,
+	PdfPreflightResult,
+	RenderPreflightPdfResult,
+} from "@reactive-resume/pdf/preflight";
 import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
 
 type StylesheetPreflightInspectionLimits = PdfPreflightPageLimits & {

--- a/apps/server/src/workers/stylesheet-preflight.ts
+++ b/apps/server/src/workers/stylesheet-preflight.ts
@@ -1,7 +1,10 @@
-import type { PdfPreflightPageLimits, PdfPreflightResult, StylesheetPreflightInput } from "@reactive-resume/pdf/server";
+import type {
+	PdfPreflightPageLimits,
+	PdfPreflightResult,
+	StylesheetPreflightInput,
+} from "@reactive-resume/pdf/preflight";
 import { parentPort, workerData } from "node:worker_threads";
 import * as React from "react";
-import { renderPreflightPdf } from "@reactive-resume/pdf/server";
 import { inspectPreflightPdf } from "./stylesheet-preflight-inspection";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
@@ -26,6 +29,13 @@ const send = (result: PdfPreflightResult) => {
 	parentPort?.postMessage(result);
 };
 
+const sanitizeWorkerCause = (cause: unknown): string => {
+	if (!(cause instanceof Error)) return "The PDF preflight worker failed.";
+	const detail = cause.message.replace(/\s+/g, " ").trim().slice(0, 200);
+	if (!detail) return "The PDF preflight worker failed.";
+	return `The PDF preflight worker failed. (${cause.name}: ${detail})`;
+};
+
 const serializeZodCause = (cause: unknown): SerializedPreflightCause | undefined => {
 	if (!(cause instanceof Error) || cause.name !== "ZodError" || !("issues" in cause) || !Array.isArray(cause.issues)) {
 		return;
@@ -33,9 +43,11 @@ const serializeZodCause = (cause: unknown): SerializedPreflightCause | undefined
 	return { name: cause.name, message: cause.message, issues: cause.issues };
 };
 
-parentPort?.postMessage({ type: "ready" });
+const initialization = import("@reactive-resume/pdf/preflight");
+void initialization.then(() => parentPort?.postMessage({ type: "ready" }));
 
 async function run(): Promise<PdfPreflightResult> {
+	const { renderPreflightPdf } = await initialization;
 	const { input, limits } = workerData as StylesheetPreflightWorkerData;
 	const rendered = await renderPreflightPdf(input, limits);
 	return rendered.ok ? inspectPreflightPdf(rendered, limits) : rendered;
@@ -50,10 +62,11 @@ if (parentPort) {
 				parentPort?.postMessage({ type: "preflight_error", cause: serializedCause });
 				return;
 			}
+			console.error("[stylesheet-preflight]", cause);
 			send({
 				ok: false,
 				code: "STYLESHEET_PREFLIGHT_WORKER_FAILED",
-				message: "The PDF preflight worker failed.",
+				message: sanitizeWorkerCause(cause),
 				diagnostics: [],
 			});
 		});

--- a/apps/web/src/features/resume/stylesheet/preflight.worker.test.ts
+++ b/apps/web/src/features/resume/stylesheet/preflight.worker.test.ts
@@ -55,4 +55,42 @@ describe("stylesheet preflight worker", () => {
 			cause: { name: "ZodError", message: "Invalid resume data", issues },
 		});
 	});
+
+	it("includes a sanitized cause when PDF preflight throws an unexpected error", async () => {
+		let handler: ((event: MessageEvent<PreflightWorkerRequest>) => Promise<void>) | undefined;
+		const postMessage = vi.fn();
+		vi.stubGlobal("self", {
+			postMessage,
+			addEventListener: vi.fn((_type, listener) => {
+				handler = listener as typeof handler;
+			}),
+		});
+		mocks.renderPreflightPdf.mockRejectedValueOnce(new Error("Canvas is already closed"));
+		vi.resetModules();
+		await import("./preflight.worker");
+
+		await handler?.({
+			data: {
+				type: "preflight",
+				requestId: 8,
+				editGeneration: 4,
+				input: {} as never,
+				limits: {} as never,
+			},
+		} as unknown as MessageEvent<PreflightWorkerRequest>);
+
+		expect(postMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "preflight_result",
+				requestId: 8,
+				editGeneration: 4,
+				result: expect.objectContaining({
+					ok: false,
+					code: "STYLESHEET_PREFLIGHT_WORKER_FAILED",
+					message: expect.stringContaining("Canvas is already closed"),
+					diagnostics: [],
+				}),
+			}),
+		);
+	});
 });

--- a/apps/web/src/features/resume/stylesheet/preflight.worker.ts
+++ b/apps/web/src/features/resume/stylesheet/preflight.worker.ts
@@ -20,6 +20,13 @@ const failure = (code: PdfPreflightFailure["code"], message: string): PdfPreflig
 	diagnostics: [],
 });
 
+const sanitizeWorkerCause = (cause: unknown): string => {
+	if (!(cause instanceof Error)) return "The PDF preflight worker failed.";
+	const detail = cause.message.replace(/\s+/g, " ").trim().slice(0, 200);
+	if (!detail) return "The PDF preflight worker failed.";
+	return `The PDF preflight worker failed. (${cause.name}: ${detail})`;
+};
+
 const serializeZodCause = (cause: unknown): SerializedPreflightCause | undefined => {
 	if (!(cause instanceof Error) || cause.name !== "ZodError" || !("issues" in cause) || !Array.isArray(cause.issues)) {
 		return;
@@ -49,7 +56,7 @@ self.addEventListener("message", async ({ data }: MessageEvent<PreflightWorkerRe
 			self.postMessage(response);
 			return;
 		}
-		const result = failure("STYLESHEET_PREFLIGHT_WORKER_FAILED", "The PDF preflight worker failed.");
+		const result = failure("STYLESHEET_PREFLIGHT_WORKER_FAILED", sanitizeWorkerCause(cause));
 		const response: PreflightWorkerResponse = {
 			type: "preflight_result",
 			requestId: data.requestId,

--- a/apps/web/src/features/resume/stylesheet/store.test.ts
+++ b/apps/web/src/features/resume/stylesheet/store.test.ts
@@ -759,6 +759,66 @@ describe("stylesheet store runtime", () => {
 		expect(runtime.store.getState().status).toBe("error");
 	});
 
+	it("surfaces browser preflight failures as diagnostics when the worker returns an empty list", async () => {
+		let resolveMutate!: (value: MutationResult & { diagnostics: never[] }) => void;
+		const mutate = vi.fn(
+			() =>
+				new Promise<MutationResult & { diagnostics: never[] }>((resolve) => {
+					resolveMutate = resolve;
+				}),
+		);
+		const runtime = createStylesheetStoreRuntime({
+			resumeId: "resume-1",
+			initial,
+			resumeData: defaultResumeData,
+			debounceMs: 0,
+			compile: async ({ editGeneration }) => ({
+				type: "compile_result",
+				requestId: editGeneration,
+				editGeneration,
+				program: { languageVersion: 1, rules: [] },
+				diagnostics: [],
+			}),
+			preflight: async ({ editGeneration }) => ({
+				type: "preflight_result",
+				requestId: editGeneration,
+				editGeneration,
+				result: {
+					ok: false,
+					code: "STYLESHEET_PREFLIGHT_WORKER_FAILED",
+					message: "The PDF preflight worker failed.",
+					diagnostics: [],
+				},
+			}),
+			mutate,
+		});
+
+		runtime.store.getState().setSourceText("@version 1;\nsection { color: teal; }");
+		await vi.runAllTimersAsync();
+
+		expect(runtime.store.getState().diagnostics).toEqual([
+			expect.objectContaining({
+				code: "STYLESHEET_PREFLIGHT_WORKER_FAILED",
+				severity: "error",
+				message: "The PDF preflight worker failed.",
+				range: {
+					start: { line: 1, column: 1, offset: 0 },
+					end: { line: 1, column: 1, offset: 0 },
+				},
+			}),
+		]);
+		expect(runtime.store.getState().diagnostics.some(({ severity }) => severity === "error")).toBe(true);
+		expect(mutate).toHaveBeenCalled();
+		resolveMutate({
+			stylesheet: stylesheet("@version 1;\n"),
+			revision: 4,
+			renderDataVersion: 7,
+			editGeneration: 1,
+			diagnostics: [],
+		});
+		await Promise.resolve();
+	});
+
 	it("finishes an edit when refreshIntelligence interleaves through the shared compile client", async () => {
 		const { createCompileWorkerClient } = await import("./worker-client");
 		const listeners = new Map<string, Set<EventListener>>();

--- a/apps/web/src/features/resume/stylesheet/store.ts
+++ b/apps/web/src/features/resume/stylesheet/store.ts
@@ -113,6 +113,18 @@ const emptySemanticTree = (): SemanticNode => ({
 const HISTORY_COALESCE_MS = 500;
 const MAX_HISTORY_ENTRIES = 50;
 
+const preflightFailureDiagnostic = (
+	result: Extract<PreflightWorkerResponse["result"], { ok: false }>,
+): SemanticCssDiagnostic => ({
+	code: result.code,
+	severity: "error",
+	message: result.message,
+	range: {
+		start: { line: 1, column: 1, offset: 0 },
+		end: { line: 1, column: 1, offset: 0 },
+	},
+});
+
 const inactiveState = (): Omit<
 	StylesheetStoreState,
 	"setSourceText" | "setFocused" | "activate" | "deactivate" | "undo" | "redo" | "refreshIntelligence"
@@ -389,7 +401,14 @@ export function createStylesheetStoreRuntime(options: CreateStylesheetStoreRunti
 			if (candidateValidationEpoch !== validationEpoch) return;
 			if (destroyed || preflight.editGeneration !== store.getState().editGeneration) return;
 			if (!preflight.result.ok) {
-				patch({ diagnostics: [...compiled.diagnostics, ...preflight.result.diagnostics], status: "error" });
+				patch({
+					diagnostics: [
+						...compiled.diagnostics,
+						...preflight.result.diagnostics,
+						preflightFailureDiagnostic(preflight.result),
+					],
+					status: "error",
+				});
 				if (candidate.transition !== "edit_source") return;
 			}
 		}

--- a/apps/web/src/features/resume/stylesheet/worker-client.test.ts
+++ b/apps/web/src/features/resume/stylesheet/worker-client.test.ts
@@ -115,6 +115,20 @@ describe("stylesheet worker clients", () => {
 		vi.useRealTimers();
 	});
 
+	it("rejects pending preflight work when the worker emits an error event", async () => {
+		const fake = worker();
+		const client = createPreflightWorkerClient(() => fake, 5_000);
+		const pending = client.preflight({ editGeneration: 1 } as never);
+		const outcome = pending.catch((error: unknown) => error);
+
+		fake.emit({ type: "preflight_ready" });
+		await Promise.resolve();
+		fake.emitError({ message: "Worker crashed" } as ErrorEvent);
+
+		expect(await outcome).toMatchObject({ message: "Worker crashed" });
+		expect(fake.terminate).toHaveBeenCalled();
+	});
+
 	it("rejects structured resume-data failures without waiting for the timeout", async () => {
 		vi.useFakeTimers();
 		const fake = worker();

--- a/apps/web/src/features/resume/stylesheet/worker-client.ts
+++ b/apps/web/src/features/resume/stylesheet/worker-client.ts
@@ -128,8 +128,18 @@ export function createPreflightWorkerClient(
 		pending.delete(response.requestId);
 		request.resolve(response);
 	};
-	const onError: WorkerErrorListener = () => {
+	const failPending = (error: Error) => {
+		for (const request of pending.values()) {
+			if (request.timer) clearTimeout(request.timer);
+			request.reject(error);
+		}
+		pending.clear();
+	};
+
+	const onError: WorkerErrorListener = (event) => {
+		const error = new Error(event.message || "Stylesheet preflight worker failed.");
 		terminate();
+		failPending(error);
 	};
 
 	const terminate = () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #3283. After the Checking-stuck fix shipped, Custom Styles can still fail with **Error** and:

> The PDF preflight worker failed. (Line 1, column 1)

That diagnostic comes from server PDF preflight returning `STYLESHEET_PREFLIGHT_WORKER_FAILED`, which blocked promoting `applied` — so styles never show.

## Root cause / hardening

The previous fix unblocked the pipeline; this addresses the preflight failure path:

1. **Server worker bootstrap** – imported `@reactive-resume/pdf/server` (heavy side graph) before `globalThis.React` was set. Now mirrors the browser worker: set React, then dynamically import `@reactive-resume/pdf/preflight`.
2. **Inherited Node flags** – production workers now use `execArgv: []` so parent flags like `--input-type` cannot break worker startup.
3. **Opaque failures** – worker catch paths swallowed the real exception behind a generic message. They now append a sanitized cause and log server-side.
4. **Client diagnostics** – browser preflight `ok: false` with empty `diagnostics` left the Error badge with no useful text until/unless the server responded. The store now maps failure codes/messages into diagnostics (same L1C1 shape as the server).
5. **Preflight `error` events** – the client now rejects in-flight requests instead of only terminating (which could hang until timeout).

## Test plan

- [x] `pnpm --filter web exec vitest run src/features/resume/stylesheet/store.test.ts src/features/resume/stylesheet/worker-client.test.ts src/features/resume/stylesheet/preflight.worker.test.ts`
- [x] `pnpm --filter server exec vitest run src/services/stylesheet-preflight.test.ts src/workers/stylesheet-preflight.test.ts`
- [x] Dist worker smoke: `@version 1;` + experience heading CSS on default resume → `ok`
- [ ] Manually on mobile: Design → Custom Styles, edit CSS, confirm Applied (or a *specific* failure message if it still fails)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9ea8d30-1b1e-4a5c-815d-512e16ee87f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9ea8d30-1b1e-4a5c-815d-512e16ee87f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stylesheet preflight error handling with clearer, sanitized failure messages.
  * Preflight failures now appear as error diagnostics while preserving existing diagnostics and saved edits.
  * Pending preflight requests are properly rejected and cleaned up when the worker encounters an error.
  * Worker initialization and failure reporting are now more reliable across environments.

* **Tests**
  * Added coverage for worker bootstrap failures, unexpected rendering errors, request rejection, and surfaced preflight diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the CSS stylesheet preflight pipeline on both client and server by fixing worker initialization order, propagating sanitized error messages from catch paths, and ensuring in-flight browser requests are rejected immediately on worker error events.

- **Server worker**: Dynamic-imports `@reactive-resume/pdf/preflight` after setting `globalThis.React`, mirrors the browser worker's lazy-load pattern, and sends `{ type: "ready" }` only once the module resolves. Production workers now use `execArgv: []` to strip inherited parent flags.
- **Browser store**: A new `preflightFailureDiagnostic` helper always injects a structured diagnostic entry (line 1, column 1) from the failure code/message so the Error badge shows actionable text even when `preflight.result.diagnostics` is empty.
- **Browser preflight worker client**: `onError` now calls `failPending` to reject all in-flight requests immediately instead of only terminating the worker, preventing hangs until the request timeout fires.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The core fixes (worker init order, execArgv isolation, error propagation, immediate error rejection) are all correct and well-tested.

All five hardening changes are logically sound and covered by dedicated unit tests. The only issues are: a derived promise from `void initialization.then(…)` in the server worker that lacks a `.catch`, which could cause a spurious unhandled-rejection warning if the dynamic import itself fails at startup; and identical `sanitizeWorkerCause` implementations in two separate files. Neither affects the correctness of the happy path or the described failure modes.

**Files Needing Attention:** apps/server/src/workers/stylesheet-preflight.ts — the `void initialization.then(…)` pattern should get a `.catch(() => {})` guard. The browser counterpart in `preflight.worker.ts` has the same pattern.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/server/src/workers/stylesheet-preflight.ts | Switches to dynamic import of @pdf/preflight (after React is set), defers ready signal until module resolves, and sanitizes catch-path error messages. Minor unhandled-rejection edge case in void initialization.then(...). |
| apps/server/src/services/stylesheet-preflight.ts | Moves execArgv out of the source-only conditional so production workers always receive execArgv: [], preventing parent --input-type / --import flags from leaking in. Test URL path gains explicit execArgv: [] too. |
| apps/server/src/workers/stylesheet-preflight-inspection.ts | Type imports migrated from @pdf/server to @pdf/preflight to match the new module split. No logic changes. |
| apps/web/src/features/resume/stylesheet/store.ts | Adds preflightFailureDiagnostic helper that synthesises a line-1-col-1 error diagnostic from any ok:false preflight result, ensuring the Error badge always shows actionable text instead of blank diagnostics. |
| apps/web/src/features/resume/stylesheet/worker-client.ts | Adds failPending helper and calls it from onError, immediately rejecting in-flight preflight promises on worker error instead of leaving them hanging until timeout. |
| apps/web/src/features/resume/stylesheet/preflight.worker.ts | Adds sanitizeWorkerCause to surface the real exception text in WORKER_FAILED messages; implementation is identical to the server worker's copy (code duplication). |
| apps/server/src/services/stylesheet-preflight.test.ts | Adds a test verifying sanitized catch-path error messages are forwarded to the parent without modification. |
| apps/web/src/features/resume/stylesheet/store.test.ts | Adds a test verifying that a WORKER_FAILED preflight result with empty diagnostics generates a synthetic failure diagnostic in the store. Does not cover the case where preflight.result.diagnostics is non-empty. |
| apps/web/src/features/resume/stylesheet/worker-client.test.ts | New test validates that pending preflight work is rejected immediately when the worker emits an error event, not left to timeout. |
| apps/web/src/features/resume/stylesheet/preflight.worker.test.ts | Adds a test that confirms the sanitized error message from a renderPreflightPdf throw appears in the WORKER_FAILED result sent back to the client. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as Parent Service
    participant W as Server Worker Thread
    participant M as @pdf/preflight module

    P->>W: "new Worker(url, { execArgv: [], workerData: {input, limits} })"
    Note over W: Set globalThis.React
    W->>M: "import("@reactive-resume/pdf/preflight") [dynamic]"
    W->>P: (startup timer ticking)
    M-->>W: module resolved
    W->>P: "postMessage({ type: "ready" })"
    Note over P: clearTimeout(startupTimer) / startTimeout(renderTimer)
    W->>M: renderPreflightPdf(input, limits)
    alt render ok
        M-->>W: "RenderPreflightPdfResult { ok: true }"
        W->>W: inspectPreflightPdf(rendered, limits)
        W->>P: postMessage(PdfPreflightResult)
    else render throws
        M-->>W: Error (e.g. Canvas is already closed)
        W->>W: sanitizeWorkerCause(cause)
        W->>P: "postMessage({ ok: false, code: WORKER_FAILED, message: sanitized })"
    end
    P->>P: finish(result) → resolve
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fserver%2Fsrc%2Fworkers%2Fstylesheet-preflight.ts%3A46-47%0A**Derived%20promise%20from%20%60void%20initialization.then%28%E2%80%A6%29%60%20can%20go%20unhandled%20on%20import%20failure**%0A%0A%60initialization.then%28callback%29%60%20creates%20a%20new%20derived%20promise%20whose%20rejection%20is%20not%20caught%20%E2%80%94%20%60void%60%20silences%20it%20at%20the%20call%20site%20but%20does%20not%20suppress%20Node.js's%20unhandled-rejection%20tracking%20for%20that%20derived%20object.%20If%20%60import%28%22%40reactive-resume%2Fpdf%2Fpreflight%22%29%60%20rejects%20%28e.g.%20a%20missing%20native%20dependency%20on%20first%20deploy%29%2C%20Node%20%E2%89%A5%2015%20may%20emit%20an%20%60unhandledRejection%60%20event%20for%20the%20derived%20promise%20and%20terminate%20the%20worker%20process%20before%20%60run%28%29%60%20can%20send%20back%20the%20%60WORKER_FAILED%60%20message%2C%20leaving%20the%20parent%20to%20rely%20solely%20on%20the%20%60onExit%60%20fallback.%20The%20%60await%20initialization%60%20inside%20%60run%28%29%60%20only%20attaches%20a%20handler%20to%20the%20*original*%20promise%2C%20not%20to%20the%20derived%20one.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20to%20the%20chained%20call%20eliminates%20the%20leak%20without%20changing%20the%20observable%20behavior.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fpreflight.worker.ts%3A23-28%0A**%60sanitizeWorkerCause%60%20duplicated%20verbatim%20between%20server%20and%20browser%20workers**%0A%0AThe%20function%20body%20%28lines%2023%E2%80%9328%20here%29%20is%20character-for-character%20identical%20to%20%60sanitizeWorkerCause%60%20in%20%60apps%2Fserver%2Fsrc%2Fworkers%2Fstylesheet-preflight.ts%60%20lines%2032%E2%80%9337.%20Since%20the%20two%20workers%20live%20in%20separate%20build%20targets%2C%20sharing%20requires%20a%20small%20shared%20utility%20%28e.g.%20in%20%60%40reactive-resume%2Fpdf%2Fpreflight%60%20or%20a%20%60workers%2Fshared%60%20module%29%2C%20but%20the%20duplication%20means%20a%20future%20change%20to%20truncation%20length%20or%20format%20must%20be%20applied%20in%20both%20places%20to%20stay%20consistent.%0A%0A%23%23%23%20Issue%203%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fstore.ts%3A403-413%0A**%60preflightFailureDiagnostic%60%20is%20always%20appended%2C%20even%20when%20%60preflight.result.diagnostics%60%20is%20non-empty**%0A%0AFor%20server-side%20failures%20like%20%60STYLESHEET_PREFLIGHT_BYTE_LIMIT%60%20and%20%60STYLESHEET_PREFLIGHT_PAGE_LIMIT%60%2C%20the%20server%20populates%20%60result.diagnostics%60%20with%20CSS-level%20render%20diagnostics%20%28warnings%20about%20specific%20properties%29.%20The%20new%20code%20unconditionally%20appends%20a%20second%20diagnostic%20at%20%60%7B%20line%3A%201%2C%20column%3A%201%20%7D%60%20with%20the%20failure%20message.%20This%20results%20in%20the%20editor%20showing%20both%20the%20CSS-level%20warnings%20*and*%20an%20additional%20%22The%20rendered%20PDF%20exceeds%20the%20preflight%20byte%20limit.%22%20entry%20pointing%20at%20the%20document%20root.%20While%20not%20incorrect%20%28the%20failure%20reason%20IS%20useful%20context%29%2C%20the%20test%20suite%20only%20covers%20the%20%60diagnostics%3A%20%5B%5D%60%20case%3B%20it%20may%20be%20worth%20adding%20a%20test%20that%20verifies%20the%20combined%20shape%20when%20%60result.diagnostics%60%20is%20non-empty%20to%20document%20the%20intended%20behaviour.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3284&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fserver%2Fsrc%2Fworkers%2Fstylesheet-preflight.ts%3A46-47%0A**Derived%20promise%20from%20%60void%20initialization.then%28%E2%80%A6%29%60%20can%20go%20unhandled%20on%20import%20failure**%0A%0A%60initialization.then%28callback%29%60%20creates%20a%20new%20derived%20promise%20whose%20rejection%20is%20not%20caught%20%E2%80%94%20%60void%60%20silences%20it%20at%20the%20call%20site%20but%20does%20not%20suppress%20Node.js's%20unhandled-rejection%20tracking%20for%20that%20derived%20object.%20If%20%60import%28%22%40reactive-resume%2Fpdf%2Fpreflight%22%29%60%20rejects%20%28e.g.%20a%20missing%20native%20dependency%20on%20first%20deploy%29%2C%20Node%20%E2%89%A5%2015%20may%20emit%20an%20%60unhandledRejection%60%20event%20for%20the%20derived%20promise%20and%20terminate%20the%20worker%20process%20before%20%60run%28%29%60%20can%20send%20back%20the%20%60WORKER_FAILED%60%20message%2C%20leaving%20the%20parent%20to%20rely%20solely%20on%20the%20%60onExit%60%20fallback.%20The%20%60await%20initialization%60%20inside%20%60run%28%29%60%20only%20attaches%20a%20handler%20to%20the%20*original*%20promise%2C%20not%20to%20the%20derived%20one.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20to%20the%20chained%20call%20eliminates%20the%20leak%20without%20changing%20the%20observable%20behavior.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fpreflight.worker.ts%3A23-28%0A**%60sanitizeWorkerCause%60%20duplicated%20verbatim%20between%20server%20and%20browser%20workers**%0A%0AThe%20function%20body%20%28lines%2023%E2%80%9328%20here%29%20is%20character-for-character%20identical%20to%20%60sanitizeWorkerCause%60%20in%20%60apps%2Fserver%2Fsrc%2Fworkers%2Fstylesheet-preflight.ts%60%20lines%2032%E2%80%9337.%20Since%20the%20two%20workers%20live%20in%20separate%20build%20targets%2C%20sharing%20requires%20a%20small%20shared%20utility%20%28e.g.%20in%20%60%40reactive-resume%2Fpdf%2Fpreflight%60%20or%20a%20%60workers%2Fshared%60%20module%29%2C%20but%20the%20duplication%20means%20a%20future%20change%20to%20truncation%20length%20or%20format%20must%20be%20applied%20in%20both%20places%20to%20stay%20consistent.%0A%0A%23%23%23%20Issue%203%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fstore.ts%3A403-413%0A**%60preflightFailureDiagnostic%60%20is%20always%20appended%2C%20even%20when%20%60preflight.result.diagnostics%60%20is%20non-empty**%0A%0AFor%20server-side%20failures%20like%20%60STYLESHEET_PREFLIGHT_BYTE_LIMIT%60%20and%20%60STYLESHEET_PREFLIGHT_PAGE_LIMIT%60%2C%20the%20server%20populates%20%60result.diagnostics%60%20with%20CSS-level%20render%20diagnostics%20%28warnings%20about%20specific%20properties%29.%20The%20new%20code%20unconditionally%20appends%20a%20second%20diagnostic%20at%20%60%7B%20line%3A%201%2C%20column%3A%201%20%7D%60%20with%20the%20failure%20message.%20This%20results%20in%20the%20editor%20showing%20both%20the%20CSS-level%20warnings%20*and*%20an%20additional%20%22The%20rendered%20PDF%20exceeds%20the%20preflight%20byte%20limit.%22%20entry%20pointing%20at%20the%20document%20root.%20While%20not%20incorrect%20%28the%20failure%20reason%20IS%20useful%20context%29%2C%20the%20test%20suite%20only%20covers%20the%20%60diagnostics%3A%20%5B%5D%60%20case%3B%20it%20may%20be%20worth%20adding%20a%20test%20that%20verifies%20the%20combined%20shape%20when%20%60result.diagnostics%60%20is%20non-empty%20to%20document%20the%20intended%20behaviour.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3284&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amruthpillai%2Freactive-resume%22%20on%20the%20existing%20branch%20%22feat%2Ffix-preflight-worker-failure-87f8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffix-preflight-worker-failure-87f8%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fserver%2Fsrc%2Fworkers%2Fstylesheet-preflight.ts%3A46-47%0A**Derived%20promise%20from%20%60void%20initialization.then%28%E2%80%A6%29%60%20can%20go%20unhandled%20on%20import%20failure**%0A%0A%60initialization.then%28callback%29%60%20creates%20a%20new%20derived%20promise%20whose%20rejection%20is%20not%20caught%20%E2%80%94%20%60void%60%20silences%20it%20at%20the%20call%20site%20but%20does%20not%20suppress%20Node.js's%20unhandled-rejection%20tracking%20for%20that%20derived%20object.%20If%20%60import%28%22%40reactive-resume%2Fpdf%2Fpreflight%22%29%60%20rejects%20%28e.g.%20a%20missing%20native%20dependency%20on%20first%20deploy%29%2C%20Node%20%E2%89%A5%2015%20may%20emit%20an%20%60unhandledRejection%60%20event%20for%20the%20derived%20promise%20and%20terminate%20the%20worker%20process%20before%20%60run%28%29%60%20can%20send%20back%20the%20%60WORKER_FAILED%60%20message%2C%20leaving%20the%20parent%20to%20rely%20solely%20on%20the%20%60onExit%60%20fallback.%20The%20%60await%20initialization%60%20inside%20%60run%28%29%60%20only%20attaches%20a%20handler%20to%20the%20*original*%20promise%2C%20not%20to%20the%20derived%20one.%20Adding%20%60.catch%28%28%29%20%3D%3E%20%7B%7D%29%60%20to%20the%20chained%20call%20eliminates%20the%20leak%20without%20changing%20the%20observable%20behavior.%0A%0A%23%23%23%20Issue%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fpreflight.worker.ts%3A23-28%0A**%60sanitizeWorkerCause%60%20duplicated%20verbatim%20between%20server%20and%20browser%20workers**%0A%0AThe%20function%20body%20%28lines%2023%E2%80%9328%20here%29%20is%20character-for-character%20identical%20to%20%60sanitizeWorkerCause%60%20in%20%60apps%2Fserver%2Fsrc%2Fworkers%2Fstylesheet-preflight.ts%60%20lines%2032%E2%80%9337.%20Since%20the%20two%20workers%20live%20in%20separate%20build%20targets%2C%20sharing%20requires%20a%20small%20shared%20utility%20%28e.g.%20in%20%60%40reactive-resume%2Fpdf%2Fpreflight%60%20or%20a%20%60workers%2Fshared%60%20module%29%2C%20but%20the%20duplication%20means%20a%20future%20change%20to%20truncation%20length%20or%20format%20must%20be%20applied%20in%20both%20places%20to%20stay%20consistent.%0A%0A%23%23%23%20Issue%203%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fresume%2Fstylesheet%2Fstore.ts%3A403-413%0A**%60preflightFailureDiagnostic%60%20is%20always%20appended%2C%20even%20when%20%60preflight.result.diagnostics%60%20is%20non-empty**%0A%0AFor%20server-side%20failures%20like%20%60STYLESHEET_PREFLIGHT_BYTE_LIMIT%60%20and%20%60STYLESHEET_PREFLIGHT_PAGE_LIMIT%60%2C%20the%20server%20populates%20%60result.diagnostics%60%20with%20CSS-level%20render%20diagnostics%20%28warnings%20about%20specific%20properties%29.%20The%20new%20code%20unconditionally%20appends%20a%20second%20diagnostic%20at%20%60%7B%20line%3A%201%2C%20column%3A%201%20%7D%60%20with%20the%20failure%20message.%20This%20results%20in%20the%20editor%20showing%20both%20the%20CSS-level%20warnings%20*and*%20an%20additional%20%22The%20rendered%20PDF%20exceeds%20the%20preflight%20byte%20limit.%22%20entry%20pointing%20at%20the%20document%20root.%20While%20not%20incorrect%20%28the%20failure%20reason%20IS%20useful%20context%29%2C%20the%20test%20suite%20only%20covers%20the%20%60diagnostics%3A%20%5B%5D%60%20case%3B%20it%20may%20be%20worth%20adding%20a%20test%20that%20verifies%20the%20combined%20shape%20when%20%60result.diagnostics%60%20is%20non-empty%20to%20document%20the%20intended%20behaviour.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3284&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/server/src/workers/stylesheet-preflight.ts:46-47
**Derived promise from `void initialization.then(…)` can go unhandled on import failure**

`initialization.then(callback)` creates a new derived promise whose rejection is not caught — `void` silences it at the call site but does not suppress Node.js's unhandled-rejection tracking for that derived object. If `import("@reactive-resume/pdf/preflight")` rejects (e.g. a missing native dependency on first deploy), Node ≥ 15 may emit an `unhandledRejection` event for the derived promise and terminate the worker process before `run()` can send back the `WORKER_FAILED` message, leaving the parent to rely solely on the `onExit` fallback. The `await initialization` inside `run()` only attaches a handler to the *original* promise, not to the derived one. Adding `.catch(() => {})` to the chained call eliminates the leak without changing the observable behavior.

### Issue 2
apps/web/src/features/resume/stylesheet/preflight.worker.ts:23-28
**`sanitizeWorkerCause` duplicated verbatim between server and browser workers**

The function body (lines 23–28 here) is character-for-character identical to `sanitizeWorkerCause` in `apps/server/src/workers/stylesheet-preflight.ts` lines 32–37. Since the two workers live in separate build targets, sharing requires a small shared utility (e.g. in `@reactive-resume/pdf/preflight` or a `workers/shared` module), but the duplication means a future change to truncation length or format must be applied in both places to stay consistent.

### Issue 3
apps/web/src/features/resume/stylesheet/store.ts:403-413
**`preflightFailureDiagnostic` is always appended, even when `preflight.result.diagnostics` is non-empty**

For server-side failures like `STYLESHEET_PREFLIGHT_BYTE_LIMIT` and `STYLESHEET_PREFLIGHT_PAGE_LIMIT`, the server populates `result.diagnostics` with CSS-level render diagnostics (warnings about specific properties). The new code unconditionally appends a second diagnostic at `{ line: 1, column: 1 }` with the failure message. This results in the editor showing both the CSS-level warnings *and* an additional "The rendered PDF exceeds the preflight byte limit." entry pointing at the document root. While not incorrect (the failure reason IS useful context), the test suite only covers the `diagnostics: []` case; it may be worth adding a test that verifies the combined shape when `result.diagnostics` is non-empty to document the intended behaviour.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(stylesheet): harden PDF preflight an..."](https://github.com/amruthpillai/reactive-resume/commit/587256820691a4f76865ca282a79d6e43f1a4bbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48953632)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->