### PR TITLE
feat: auto-detect browser locale on first visit and overhaul i18n translation quality

### DIFF
--- a/apps/web/locales/af-ZA.po
+++ b/apps/web/locales/af-ZA.po
@@ -401,7 +401,7 @@ msgstr "En baie meer..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropiese Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Middelbelyn"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Serebras"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Maak KI-assistent toe"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Samehang"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Verminder zoom"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "DiepSeek"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Fins"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Vuurwerke"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2797,7 +2797,7 @@ msgstr "Werkende CV ontbreek"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Mistral KI"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Ollama-wolk"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Periode"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Verwarring"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Om jou rekening uit te vee, moet jy die bevestigingstekst invoer en die 
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Saam.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "Geldige URL's moet met http:// of https:// begin."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Vercel KI-toegangspoort"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/af-ZA.po
+++ b/apps/web/locales/af-ZA.po
@@ -266,7 +266,7 @@ msgstr "Voeg 'n verskaffer by en toets dit voordat jy 'n agentdraad begin."
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Voeg toepassing by"
+msgstr "Voeg aansoek by"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -364,7 +364,7 @@ msgstr "KI-verskaffers vereis dat REDIS_URL en ENCRYPTION_SECRET gekonfigureer w
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanees"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Het jy reeds 'n rekening? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharies"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,15 +447,15 @@ msgstr "Toep"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Toepassingsaksies"
+msgstr "Aansoekakies"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Toepassing is by jou pyplyn gevoeg."
+msgstr "Aansoek is by jou pyplyn gevoeg."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Toepassing Copilot"
+msgstr "Aansoek-Copilot"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -464,18 +464,18 @@ msgstr "Aansoek verwyder."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Toepassingstatistiek"
+msgstr "Aansoekstatistiek"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Toepassing opgedateer."
+msgstr "Aansoek opgedateer."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Toepassings"
+msgstr "Aansoeke"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Toegepas met waarskuwings"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabies"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Toekennings"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbeidjans"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Pragtige sjablone om van te kies, met meer op pad."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengaals"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Die beste vir toepassings, deel en drukwerk."
+msgstr "Die beste vir aansoeke, deel en drukwerk."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Bouergereedskappalet"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgaars"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Kan nie herstel nie; die CV het verander sedert hierdie wysiging toegepa
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalaans"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Kontroleer konsep"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chinees (Vereenvoudig)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chinees (Tradisioneel)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Sirkel"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Klaar"
+msgstr "Maak skoon"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Kon nie die verbinding verifieer nie. Kontroleer die API-sleutel, model 
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Kon nie die toepassing byvoeg nie. Probeer asseblief weer."
+msgstr "Kon nie die aansoek byvoeg nie. Probeer asseblief weer."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Kon nie die toepassing verwyder nie."
+msgstr "Kon nie die aansoek verwyder nie."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Kon nie die tydlyninskrywing verwyder nie."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Kon nie die toepassing skuif nie. Probeer asseblief weer."
+msgstr "Kon nie die aansoek skuif nie. Probeer asseblief weer."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Geskep"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Het \"{0}\" geskep en dit aan hierdie toepassing gekoppel."
+msgstr "Het \"{0}\" geskep en dit aan hierdie aansoek gekoppel."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Pasgemaakte style"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Tsjeggies"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Gevaarsones"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Deens"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "Vee tydlyninskrywing uit"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Het {0} toepassing(e) uitgevee."
+msgstr "Het {0} aansoek(e) uitgevee."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1568,7 +1568,7 @@ msgstr "Wysig {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Wysig toepassing"
+msgstr "Wysig aansoek"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Aktiveer tweefaktor-verifikasie…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Engels"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Engels (Verenigde Koninkryk)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Vind swak kolpunte en herskryf hulle met sterker uitkomste, getalle, omv
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Fins"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Pas om te sien"
+msgstr "Pas aan vir weergawe"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Vrye vorm"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Frans"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Genereer 'n ewekansige naam"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Duits"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,13 +2116,13 @@ msgstr "Gaan terug"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Gaan huis toe"
+msgstr "Gaan na die tuisblad"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Gaan na beheerpaneel"
+msgstr "Gaan na die Dashboard"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "Punt"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Grieks"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Opskriflyn"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebreeus"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Kleurmerk"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Hongaars"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Voer in vanaf CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Ingevoerde {0} toepassing(e)."
+msgstr "Ingevoerde {0} aansoek(e)."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Verhoog zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesies"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Uitreiker"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italiaans"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Skuinsdruk"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japanees"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Uitvulbelyn"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Bly bymekaar"
+msgstr "Hou bymekaar"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Sleutelwoorde"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Koreaans"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Laas bekyk op {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Letties"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Lys"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litaus"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Laai tans KI-verskaffers. Probeer asseblief weer oor 'n oomblik."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Laai toepassings…"
+msgstr "Laai aansoeke…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Maak die ervaringsafdeling meer resultaatgerig en verwyder vae verantwoo
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Maleis"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malabaars"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Skuif afdeling na 'n ander kolom of bladsy"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Beweeg die verhoog"
+msgstr "Skuif die fase"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Naam"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalees"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Netwerk"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Nuwe Toepassing"
+msgstr "Nuwe Aansoek"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,7 +2902,7 @@ msgstr "Geen advertensies, geen dop nie"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Geen toepassings stem ooreen met jou filters nie."
+msgstr "Geen aansoeke stem ooreen met jou filters nie."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
@@ -2960,7 +2960,7 @@ msgstr "Geen drade nog nie."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Noors"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Notas"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Maak oop"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Oop KI-agent"
+msgstr "Maak die KI-agent oop"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-versoenbaar"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persies"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Pyplynvloei"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Pyplyngesondheid oor alle toepassings"
+msgstr "Pyplyngesondheid oor alle aansoeke"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Wag asseblief terwyl jou PDF gegenereer word…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Pools"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portret"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugees (Brasilië)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugees (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Gaan na tuisblad"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktiewe CV (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktiewe CV v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktiewe CV v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Rol-progressie"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Roemeens"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Voer jou eerste ontleding uit om 'n puntkaart, sterkpunte en geprioritis
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russies"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Soek"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Soek toepassings…"
+msgstr "Soek aansoeke…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Skeier"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serwies"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4057,7 +4057,7 @@ msgstr "Tans besig om te registreer..."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a magenta left border accent; compact and efficient for entry-level or internship applications."
-msgstr "Enkelkolom met 'n magenta linkerrandaksent; kompak en doeltreffend vir intreevlak- of internskap-aansoeke."
+msgstr "Enkelkolom met 'n magenta linkerrandaksent; kompak en doeltreffend vir intreevlak- of internskap-aansoeke."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a minimal top header and lots of whitespace; clean and modern for designers or content creators."
@@ -4098,11 +4098,11 @@ msgstr "Slaan oor na hoofinhoud"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slowaaks"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Sloweens"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Spasiëring (vertikaal)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spaans"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Ondersteun die toepassing deur te doen wat jy kan!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Sweeds"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Kleremaakwerk het misluk."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Tekskleur"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "Probeer weer"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turks"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipografie"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Oekraïens"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Gebruikers"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Oezbeeks"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Weergawegeskiedenis"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Viëtnamees"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Zoem uit"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zoeloe"
+msgstr "isiZulu"
 

--- a/apps/web/locales/af-ZA.po
+++ b/apps/web/locales/af-ZA.po
@@ -2377,7 +2377,7 @@ msgstr "Verhoog zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/am-ET.po
+++ b/apps/web/locales/am-ET.po
@@ -2377,7 +2377,7 @@ msgstr "ማጉላትን ጨምር"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/am-ET.po
+++ b/apps/web/locales/am-ET.po
@@ -266,7 +266,7 @@ msgstr "የወኪል ክር ከመጀመርዎ በፊት አቅራቢ ያክሉ 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "መተግበሪያ ያክሉ"
+msgstr "ማመልከቻ ያክሉ"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "የላቀ"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "አፍሪካንስ"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "የAI አቅራቢዎች REDIS_URL እና ENCRYPTION_SECRET እንዲዋ
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "አልባኒኛ"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -451,31 +451,31 @@ msgstr "የማመልከቻ እርምጃዎች"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "መተግበሪያ ወደ ቧንቧ መስመርዎ ታክሏል።"
+msgstr "ማመልከቻ ወደ ቧንቧ መስመርዎ ታክሏል።"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "የመተግበሪያ ኮፓይለት"
+msgstr "የማመልከቻ ኮፓይለት"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "መተግበሪያ ተሰርዟል።"
+msgstr "ማመልከቻ ተሰርዟል።"
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "የመተግበሪያ ስታቲስቲክስ"
+msgstr "የማመልከቻ ስታቲስቲክስ"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "መተግበሪያ ተዘምኗል።"
+msgstr "ማመልከቻ ተዘምኗል።"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "አፕሊኬሽኖች"
+msgstr "ማመልከቻዎች"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "ከማስጠንቀቂያዎች ጋር ተተግብሯል"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "ዓረብኛ"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "ሽልማቶች"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "አዘርባይጃንኛ"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "ውብ ቴምፕሌቶችን ይመርጡ፣ ተጨማሪዎችም በ�
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "ቤንጋሊኛ"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "ለመተግበሪያዎች፣ ለማጋራት እና ለማተም ምርጥ።"
+msgstr "ለማመልከቻዎች፣ ለማጋራት እና ለማተም ምርጥ።"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "የመገንቢያ ኮማንድ ፓሌት"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "ቡልጋሪኛ"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "ወደነበረበት መመለስ አይቻልም፤ ይህ ማስተ�
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "ካታላንኛ"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "ረቂቅን በመፈተሽ ላይ"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "ቻይንኛ (ቀለል ያለ)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "ቻይንኛ (ባለባለት)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1044,12 +1044,12 @@ msgstr "ግንኙነቱን ማረጋገጥ አልተቻለም። የኤፒአይ
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "መተግበሪያውን ማከል አልተቻለም። እባክዎ እንደገና ይሞክሩ።"
+msgstr "ማመልከቻውን ማከል አልተቻለም። እባክዎ እንደገና ይሞክሩ።"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "መተግበሪያውን መሰረዝ አልተቻለም።"
+msgstr "ማመልከቻውን መሰረዝ አልተቻለም።"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "የጊዜ መስመር ግቤቱን መሰረዝ አልተቻለም።"
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "መተግበሪያውን ማንቀሳቀስ አልተቻለም። እባክዎ እንደገና ይሞክሩ።"
+msgstr "ማመልከቻውን ማንቀሳቀስ አልተቻለም። እባክዎ እንደገና ይሞክሩ።"
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "የተፈጠረበት ቀን።"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "\"{0}\" ፈጥሮ ከዚህ መተግበሪያ ጋር አገናኘው።"
+msgstr "\"{0}\" ፈጥሮ ከዚህ ማመልከቻ ጋር አገናኘው።"
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "ብጁ ቅጦች"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "ቼክኛ"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "አደገኛ ክልል"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "ዴኒሽ"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "የጊዜ መስመር ግቤትን ሰርዝ"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "{0} መተግበሪያ(ዎች) ተሰርዘዋል።"
+msgstr "{0} ማመልከቻ(ዎች) ተሰርዘዋል።"
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "የየታሪክዎን ቅጂ በመፍጠር ላይ…"
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "ደች"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "{chip} አርትዕ"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "መተግበሪያን ያርትዑ"
+msgstr "ማመልከቻውን ያርትዑ"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "ባለ ሁለት ደረጃ ማረጋገጫን ማንቃት…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "እንግሊዝኛ"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "እንግሊዝኛ (ዩናይትድ ኪንግደም)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "ደካማ ነጥቦችን ፈልግ እና ጠንካራ ውጤቶችን�
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "ፊኒሽ"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "ለእይታ ተስማሚ"
+msgstr "ለእይታ አስማማ"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "ነፃ-ፎርም"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "ፈረንሳይኛ"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "የተዘፈነ ስም ይፍጠሩ"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "ጀርመንኛ"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "ተመለስ"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "ወደ ቤት ሂድ"
+msgstr "ወደ መነሻ ገጽ ሂድ"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "ውጤት"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "ግሪክኛ"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "ርዕሰ ነጥብ"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "ዕብራስጥ"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "የድምቀት ቀለም"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "ሒንዱኛ"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "ሀንጋሪኛ"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "ከCSV አስመጣ"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "{0} መተግበሪያ(ዎች) ከውጭ ገብቷል።"
+msgstr "{0} ማመልከቻ(ዎች) ከውጭ ገብቷል።"
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "ማጉላትን ጨምር"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "ኢንዶኔዥኛ"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "አውጪ"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "ጣሊያንኛ"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "ግዕዝ"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "ጃፓንኛ"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "ሙሉ ማሰለፊያ"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "ካናዳኛ"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "አንድ ላይ ቆይ"
+msgstr "አንድ ላይ ያዙ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "ቁልፍ ቃላት"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "ክህመርኛ"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "ኮሪያኛ"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "መጨረሻ በ{0} ታይቷል"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "ላትቪያንኛ"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "ዝርዝር"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "ሊቱዌንያንኛ"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "የAI አቅራቢዎችን በመጫን ላይ። እባክዎ ከአ�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "መተግበሪያዎችን በመጫን ላይ…"
+msgstr "ማመልከቻዎችን በመጫን ላይ…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "የተሞክሮ ክፍሉን የበለጠ ውጤት ተኮር ያድር�
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "ማላይኛ"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "ማላያላምኛ"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "ማራቲኛ"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "ስም"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "ኔፓሊኛ"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "ኔትዎርክ"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "አዲስ መተግበሪያ"
+msgstr "አዲስ ማመልከቻ"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,11 +2902,11 @@ msgstr "ምንም ማስታወቂያ የለም፣ ምንም መከታተያ የ�
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "ከማጣሪያዎችዎ ጋር የሚዛመዱ ምንም መተግበሪያዎች የሉም።"
+msgstr "ከማጣሪያዎችዎ ጋር የሚዛመዱ ምንም ማመልከቻዎች የሉም።"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "እስካሁን ምንም መተግበሪያዎች የሉም - የፈንጣጣ እና የምላሽ መጠኖችዎን ለማየት ጥቂት ያክሉ።"
+msgstr "እስካሁን ምንም ማመልከቻዎች የሉም - የፈንጣጣ እና የምላሽ መጠኖችዎን ለማየት ጥቂት ያክሉ።"
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2960,7 +2960,7 @@ msgstr "እስካሁን ምንም ክሮች የሉም።"
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "ኖርዌጂያንኛ"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "ማስታወሻዎች"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "ኦዲያ"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "ክፈት"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "ክፍት የ AI ወኪል"
+msgstr "የ AI ወኪልን ይክፈቱ"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "ከ OpenAI ጋር ተኳሃኝ"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "ፐርሲያንኛ"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "የቧንቧ መስመር ፍሰት"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "የቧንቧ መስመር ጤና በሁሉም አፕሊኬሽኖች ላይ"
+msgstr "የቧንቧ መስመር ጤና በሁሉም ማመልከቻዎች ላይ"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "እባክዎ የእርስዎ ፒዲኤፍ እስኪፈጠር ድረስ �
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "ፖላንድኛ"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "ቀለም ፎቶ"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "ፖርቹጋልኛ (ብራዚል)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "ፖርቹጋልኛ (ፖርቱጋል)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3681,7 +3681,7 @@ msgstr "የሚና እድገት"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "ሮማኒያንኛ"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "የውጤት ካርድ፣ ጥንካሬዎች እና ቅድሚያ የተ�
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "ሩስኛ"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "ፈልግ"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "መተግበሪያዎችን ፈልግ…"
+msgstr "ማመልከቻዎችን ፈልግ…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "መለያ መለያ"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "ሰርቢኛ"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "ወደ ዋና ይዘት ዝለል"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "ስሎቫክኛ"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "ስሎቬንያኛ"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "ክፍተት (አቀባዊ)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "ስፓኒሽ"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "መተግበሪያውን በችሎታችሁ ደግፉት!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "ስዊድንኛ"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "የልብስ ስፌት አልተሳካም።"
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "ታሚልኛ"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "ተሉጉኛ"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "የጽሁፍ ቀለም"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "ታይኛ"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4560,7 +4560,7 @@ msgstr "ክር ተሰርዟል።"
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "ክር"
+msgstr "ክሮች"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4630,7 +4630,7 @@ msgstr "የሚያመለክቱበትን ሥራ ይከታተሉ እና የላኩ�
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "የመጀመሪያውን መተግበሪያዎን ይከታተሉ"
+msgstr "የመጀመሪያውን ማመልከቻዎን ይከታተሉ"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "እንደገና ሞክር"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "ቱርክኛ"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "ታይፖግራፊ"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "ዩክሬንኛ"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "ለዚህ የጊዜ መስመር ግቤት የቀን መቁጠሪያ ቀ
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "የዚህን መተግበሪያ ዝርዝሮች ያዘምኑ።"
+msgstr "የዚህን ማመልከቻ ዝርዝሮች ያዘምኑ።"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "ተጠቃሚዎች"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "ኡዝቤክኛ"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "የስሪት ታሪክ"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "ቪትናምኛ"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,11 +5039,11 @@ msgstr "ሲቆለፍ የየታሪክዎን ማቅረቢያ ማዘመን ወይ�
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "አፕሊኬሽኖች ከየት ይመጣሉ"
+msgstr "ማመልከቻዎች ከየት ይመጣሉ"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
-msgstr "የእርስዎ መተግበሪያዎች የት ሄዱ?"
+msgstr "የእርስዎ ማመልከቻዎች የት ሄዱ?"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Work OpenAI"
@@ -5177,7 +5177,7 @@ msgstr "ዙም"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom in"
-msgstr "አቅርብ"
+msgstr "አጉላ"
 
 #: src/routes/agent/-components/resume-pane.tsx
 #: src/routes/builder/$resumeId/-components/dock.tsx
@@ -5186,9 +5186,9 @@ msgstr "የማጉላት ደረጃ"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom out"
-msgstr "አጉር"
+msgstr "አሳንስ"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "ዙሉ"
+msgstr "isiZulu"
 

--- a/apps/web/locales/am-ET.po
+++ b/apps/web/locales/am-ET.po
@@ -768,7 +768,7 @@ msgstr "መሀከል ማሰለፊያ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "ሴሬብራስ"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "የ AI ረዳትን ዝጋ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "ኮሄሬ"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "ማጉላትን ቀንስ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "ዲፕሴክ"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "ፊኒሽ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "ርችቶች"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2162,7 +2162,7 @@ msgstr "ግሪድ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "ግሮክ"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "የስራ ማጠቃለያ ይጎድላል"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "ሚስራል ኤአይ"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "ኦዲያ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "የኦላማ ክላውድ"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "ወቅት"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "ግራ መጋባት"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -5063,7 +5063,7 @@ msgstr "ኤክስ (ትዊተር)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI ግሮክ"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/ar-SA.po
+++ b/apps/web/locales/ar-SA.po
@@ -260,13 +260,13 @@ msgstr "أضف وسمًا واضغط Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "أضف موفر الخدمة واختبره قبل بدء سلسلة عمليات الوكيل."
+msgstr "أضف موفر الخدمة واختبره قبل بدء محادثة الوكيل."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "إضافة تطبيق"
+msgstr "إضافة طلب"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "متقدم"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "الأفريقانس"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "يتطلب موفرو خدمات الذكاء الاصطناعي تهي�
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "الألبانية"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "لديك حساب بالفعل؟ <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "الأمهرية"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "التطبيق"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "إجراءات التطبيق"
+msgstr "إجراءات الطلب"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "تمت إضافة التطبيق إلى مسار العمل الخاص بك."
+msgstr "تمت إضافة الطلب إلى مسار العمل الخاص بك."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "مساعد التطبيق"
+msgstr "مساعد الطلبات"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "تم حذف التطبيق."
+msgstr "تم حذف الطلب."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "إحصاءات التطبيق"
+msgstr "إحصاءات الطلبات"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "تم تحديث التطبيق."
+msgstr "تم تحديث الطلب."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "التطبيقات"
+msgstr "الطلبات"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -628,7 +628,7 @@ msgstr "الجوائز"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "الأذرية"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "قوالب جميلة للاختيار من بينها، مع المزي
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "البنغالية"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "الأفضل للتطبيقات والمشاركة والطباعة."
+msgstr "الأفضل للطلبات والمشاركة والطباعة."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "لوحة أوامر أداة الإنشاء"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "البلغارية"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "لا يمكن الاستعادة؛ فقد تغيرت السيرة الذ
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "الكتالانية"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "مراجعة المسودة"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "الصينية (المبسطة)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "الصينية (التقليدية)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "اختر سيرة ذاتية"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "اختر محادثة موجودة من الشريط الجانبي، أو ابدأ سلسلة محادثات جديدة تركز على المسودة."
+msgstr "اختر محادثة موجودة من الشريط الجانبي، أو ابدأ محادثة جديدة تركز على المسودة."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "دائرة"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "واضح"
+msgstr "مسح"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "تعذر التحقق من الاتصال. يرجى التحقق من م
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "تعذر إضافة التطبيق. يرجى المحاولة مرة أخرى."
+msgstr "تعذر إضافة الطلب. يرجى المحاولة مرة أخرى."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "تعذر حذف التطبيق."
+msgstr "تعذر حذف الطلب."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "تعذر حذف إدخال الجدول الزمني."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "تعذر نقل التطبيق. يرجى المحاولة مرة أخرى."
+msgstr "تعذر نقل الطلب. يرجى المحاولة مرة أخرى."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "تم الإنشاء"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "تم إنشاء \"{0}\" وربطه بهذا التطبيق."
+msgstr "تم إنشاء \"{0}\" وربطه بهذا الطلب."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "أنماط مخصصة"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "التشيكية"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "منطقة الخطر"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "الدانماركية"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "حذف الموفر"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "هل تريد حذف هذا الموضوع الخاص بالوكيل؟"
+msgstr "هل تريد حذف محادثة الوكيل هذه؟"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1392,7 +1392,7 @@ msgstr "حذف إدخال الجدول الزمني"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "تم حذف {0} تطبيق(ات)."
+msgstr "تم حذف {0} طلب(ات)."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "جاري استنساخ سيرتك الذاتية..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "الهولندية"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "تفعيل المصادقة الثنائية…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "الإنجليزية"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "الإنجليزية (المملكة المتحدة)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "فشل في تحليل السيرة الذاتية."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "فشل أرشفة الموضوع."
+msgstr "فشل أرشفة المحادثة."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "فشل حذف مفتاح واجهة برمجة التطبيقات (API).
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "فشل حذف الموضوع."
+msgstr "فشل حذف المحادثة."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "فشل تسجيل الخروج. يرجى المحاولة مرة أخر�
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "فشل بدء تشغيل سلسلة الوكيل."
+msgstr "فشل بدء تشغيل محادثة الوكيل."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "ابحث عن النقاط الضعيفة وأعد صياغتها بنت
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "الفنلندية"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "مناسب للعرض"
+msgstr "ملاءمة العرض"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "حر الشكل"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "الفرنسية"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "إنشاء اسم عشوائي"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "الألمانية"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "عودة"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "اذهب إلى المنزل"
+msgstr "العودة إلى الصفحة الرئيسية"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2127,7 +2127,7 @@ msgstr "الذهاب إلى لوحة التحكم"
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "الانتقال إلى لوحة معلومات السير الذاتية"
+msgstr "الانتقال إلى لوحة التحكم للسير الذاتية"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "التقدير"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "اليونانية"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "العنوان"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "العبرية"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "لون مميز"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "الهندية"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "الهنغارية"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "الاستيراد من ملف CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "تم استيراد {0} تطبيق(ات)."
+msgstr "تم استيراد {0} طلب(ات)."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "تكبير الصورة"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "الإندونيسية"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "الجهة المُصدِّرة"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "الإيطالية"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "مائل"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "اليابانية"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "محاذاة بضبط العرض"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "الكانادا"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "ابقوا معاً"
+msgstr "إبقاء العناصر معًا"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "الكلمات المفتاحية"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "الخميرية"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "الكورية"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "آخر عرض في {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "اللاتفية"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "قائمة"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "اللتوانية"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "جارٍ تحميل مزودي خدمات الذكاء الاصطناع�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "جارٍ تحميل التطبيقات…"
+msgstr "جارٍ تحميل الطلبات…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "استئناف التحميل…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "جارٍ تحميل الخيوط…"
+msgstr "جارٍ تحميل المحادثات…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "اجعل قسم الخبرة أكثر تركيزاً على النتائ
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "الملايوية"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "المالايالام"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "الماراثي"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "الاسم"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "النيبالية"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2889,12 +2889,12 @@ msgstr "علامة جديدة…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "موضوع جديد"
+msgstr "محادثة جديدة"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "موضوع جديد"
+msgstr "محادثة جديدة"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2902,7 +2902,7 @@ msgstr "بدون إعلانات، بدون تتبّع"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "لا توجد تطبيقات مطابقة لمرشحاتك."
+msgstr "لا توجد طلبات مطابقة لمرشحاتك."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
@@ -2956,11 +2956,11 @@ msgstr "لم يتم اختبار أي مزود خدمة"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "لا توجد مواضيع حتى الآن."
+msgstr "لا توجد محادثات بعد."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "النرويجية"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "ملاحظات"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "الأودية"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "افتح"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "وكيل الذكاء الاصطناعي المفتوح"
+msgstr "فتح وكيل الذكاء الاصطناعي"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "متوافق مع OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "الفارسية"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "تدفق خط الأنابيب"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "سلامة خطوط الأنابيب عبر جميع التطبيقات"
+msgstr "سلامة خطوط الأنابيب عبر جميع الطلبات"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "يرجى الانتظار ريثما يتم إنشاء ملف PDF الخ
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "البولندية"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "طولي"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "البرتغالية (البرازيل)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "البرتغالية (البرتغال)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - الانتقال إلى الصفحة الرئيسية"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "استئناف تفاعلي (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "السيرة الذاتية التفاعلية v<0>{__APP_VERSION__}</0>
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "استئناف تفاعلي الإصدار 4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "التقدم الوظيفي"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "الرومانية"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "قم بإجراء تحليلك الأول للحصول على بطاقة
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "الروسية"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "يبحث"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "تطبيقات البحث…"
+msgstr "البحث عن الطلبات…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3846,7 +3846,7 @@ msgstr "اختر سيرة ذاتية"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "اختر موضوعًا"
+msgstr "اختر محادثة"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "فاصل"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "الصربية"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "إنشاء مزود للذكاء الاصطناعي"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "قم بإعداد موفر الذكاء الاصطناعي قبل بدء سلسلة المحادثات."
+msgstr "قم بإعداد موفر الذكاء الاصطناعي قبل بدء محادثة."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "تجاوز إلى المحتوى الرئيسي"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "السلوفاكية"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "السلوفينية"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "تباعد (عمودي)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "الإسبانية"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "امنحنا نجمة على GitHub، لدينا حاليًا {0} نجم
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "ابدأ موضوعًا جديدًا"
+msgstr "ابدأ محادثة جديدة"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "ابدأ موضوعًا"
+msgstr "ابدأ محادثة"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "ابدأ في إنشاء سيرتك الذاتية من الصفر"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "ابدأ موضوعًا جديدًا"
+msgstr "ابدأ محادثة جديدة"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "ابدأ في صفحة جديدة"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "موضوع البداية"
+msgstr "ابدأ محادثة"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "ادعم التطبيق بما تستطيع!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "السويدية"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "فشلت عملية الخياطة."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "التاميلية"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "التيلوغوية"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "لون النص"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "التايلاندية"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4464,11 +4464,11 @@ msgstr "لا يمكن التراجع عن هذا الإجراء. سيتم حذف
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
-msgstr "لا يمكن التراجع عن هذا الإجراء. سيتم حذف الرسائل ومرفقات الموضوع."
+msgstr "لا يمكن التراجع عن هذا الإجراء. سيتم حذف الرسائل ومرفقات المحادثة."
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "تعذر فتح هذا الموضوع الخاص بالوكيل."
+msgstr "تعذر فتح محادثة الوكيل هذه."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4524,11 +4524,11 @@ msgstr "هذه المحادثة مؤرشفة. لا يمكن إرسال رسائ�
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "هذه السلسلة للقراءة فقط"
+msgstr "هذه المحادثة للقراءة فقط"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "هذه السلسلة للقراءة فقط لأن السيرة الذاتية العاملة أو مزود الذكاء الاصطناعي غير متوفر."
+msgstr "هذه المحادثة للقراءة فقط لأن السيرة الذاتية العاملة أو مزود الذكاء الاصطناعي غير متوفر."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,22 +4545,22 @@ msgstr "سيؤدي ذلك إلى إزالة جميع العناصر من هذا 
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "إجراءات الخيوط"
+msgstr "إجراءات المحادثة"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "تمت أرشفة الموضوع."
+msgstr "تمت أرشفة المحادثة."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "تم حذف الموضوع."
+msgstr "تم حذف المحادثة."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "الخيوط"
+msgstr "المحادثات"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "تبديل الشريط الجانبي الأيمن"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "تبديل الخيوط"
+msgstr "تبديل المحادثات"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4647,7 +4647,7 @@ msgstr "حاول ثانية"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "التركية"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "الطباعة"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "الأوكرانية"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "حدّث تاريخ التقويم لإدخال الجدول الزمن�
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "قم بتحديث تفاصيل هذا التطبيق."
+msgstr "قم بتحديث تفاصيل هذا الطلب."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "المستخدمون"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "الأوزبكية"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "سجل الإصدارات"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "الفيتنامية"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "تصغير"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "الزولو"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ar-SA.po
+++ b/apps/web/locales/ar-SA.po
@@ -401,7 +401,7 @@ msgstr "والمزيد..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "أنثروبك كلود"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "محاذاة في الوسط"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "الأدمغة"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "مساعد الذكاء الاصطناعي للإغلاق"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "التحم"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "تقليل التكبير"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "البحث العميق"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "الفنلندية"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "ألعاب نارية"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "جوجل"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "جوجل الجوزاء"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "الشبكة"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "جروك"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "سيرة ذاتية مفقودة"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "ميسترال للذكاء الاصطناعي"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "الأودية"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "سحابة أولاما"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3046,7 +3046,7 @@ msgstr "متوافق مع OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "الموجه المفتوح (OpenRouter)"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "الفترة"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "حيرة"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "يجب أن تبدأ عناوين URL الصالحة بـ http:// أو h
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "بوابة فيركل للذكاء الاصطناعي"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/ar-SA.po
+++ b/apps/web/locales/ar-SA.po
@@ -2377,7 +2377,7 @@ msgstr "تكبير الصورة"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/az-AZ.po
+++ b/apps/web/locales/az-AZ.po
@@ -401,7 +401,7 @@ msgstr "Və daha çox..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropik Klod"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Mərkəzləndir"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Beyinciklər"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Süni intellekt köməkçisini bağlayın"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Birgə"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Zumu azaldın"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Dərin Axtarış"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Fin"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Atəşfəşanlıq"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2162,7 +2162,7 @@ msgstr "Şəbəkə"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "Qroq"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "İşçi CV-si yoxdur"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Mistral süni intellekt"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odiya"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Ollama Buludu"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "Açıq Mənbə"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "Açıq AI"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "OpenAI ilə uyğun"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "AçıqRouter"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "Müddət"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Çaşqınlıq"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "Etibarlı URL‑lər http:// və ya https:// ilə başlamalıdır."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Vercel AI Qapısı"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/az-AZ.po
+++ b/apps/web/locales/az-AZ.po
@@ -2377,7 +2377,7 @@ msgstr "Zumu artırın"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/az-AZ.po
+++ b/apps/web/locales/az-AZ.po
@@ -266,7 +266,7 @@ msgstr "Agent mövzusuna başlamazdan əvvəl provayder əlavə edin və sınaqd
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Tətbiq əlavə edin"
+msgstr "Müraciət əlavə edin"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -332,7 +332,7 @@ msgstr "Agentlər"
 
 #: src/dialogs/resume/import.tsx
 msgid "AI"
-msgstr "Süni İntellekt"
+msgstr "AI"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "AI agent setup is unavailable right now. Please try again in a moment."
@@ -364,7 +364,7 @@ msgstr "Süni intellekt provayderləri REDIS_URL və ENCRYPTION_SECRET-in konfiq
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanca"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Artıq hesabınız var? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharca"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Tətbiq"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Tətbiq əməliyyatları"
+msgstr "Müraciət əməliyyatları"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Tətbiq kanalınıza əlavə edildi."
+msgstr "Müraciət kanalınıza əlavə edildi."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Tətbiq Kopilotu"
+msgstr "Müraciət Kopilotu"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Tətbiq silindi."
+msgstr "Müraciət silindi."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Tətbiq Statistikası"
+msgstr "Müraciət Statistikası"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Tətbiq yeniləndi."
+msgstr "Müraciət yeniləndi."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Tətbiqlər"
+msgstr "Müraciətlər"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Xəbərdarlıqlarla tətbiq olunur"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Ərəb"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Mükafatlar"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azərbaycan"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Seçmək üçün gözəl şablonlar, yolda olan yeniləri ilə."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Benqal"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Tətbiqlər, paylaşma və çap üçün ən yaxşısı."
+msgstr "Müraciətlər, paylaşma və çap üçün ən yaxşısı."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Qurucu Komanda Palitrası"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bolqar"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Bərpa etmək mümkün deyil; bu düzəliş tətbiq edildikdən bəri CV
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalan"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Qaralama yoxlanılır"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Çin (Sadələşdirilmiş)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Çin (Ənənəvi)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Dairə"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Açıq"
+msgstr "Təmizlə"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Bağlantı yoxlana bilmədi. API açarını, modelini və əsas URL-ni y
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Tətbiq əlavə edilə bilmədi. Yenidən cəhd edin."
+msgstr "Müraciət əlavə edilə bilmədi. Yenidən cəhd edin."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Tətbiqi silmək mümkün olmadı."
+msgstr "Müraciəti silmək mümkün olmadı."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Xronologiya qeydi silinə bilmədi."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Tətbiqi köçürmək mümkün olmadı. Yenidən cəhd edin."
+msgstr "Müraciəti köçürmək mümkün olmadı. Yenidən cəhd edin."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Yaradılıb"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "\"{0}\" yaratdı və onu bu tətbiqə əlaqələndirdi."
+msgstr "\"{0}\" yaratdı və onu bu müraciətə əlaqələndirdi."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Xüsusi Stillər"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Çex"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Təhlükəli Zona"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danimarka"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "Xronologiya qeydini sil"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Silinmiş {0} tətbiq(lər)."
+msgstr "Silinmiş {0} müraciət(lər)."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Özgeçmişiniz dublikat edilir..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Niderland"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Düzəliş et {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Tətbiqi redaktə edin"
+msgstr "Müraciəti redaktə edin"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "İki faktorlu identifikasiyanın aktivləşdirilməsi…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "İngilis"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "İngilis (Böyük Britaniya)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1861,7 +1861,7 @@ msgstr "Şifrənizi sıfırlamaq alınmadı. Zəhmət olmasa yenidən cəhd edin
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "Süni intellekt provayderini yadda saxlamaq alınmadı."
+msgstr "AI provayderini yadda saxlamaq alınmadı."
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -1963,7 +1963,7 @@ msgstr "Zəif ifadələri tapın və onları daha güclü nəticələr, rəqəml
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Fin"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Sərbəst forma"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Fransız"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Təsadüfi ad yarat"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Alman"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,13 +2116,13 @@ msgstr "Geri qayıt"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Evə get"
+msgstr "Ana səhifəyə keç"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "İdarə panelinə keç"
+msgstr "İdarəetmə panelinə keç"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "Qiymət"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Yunan"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Sloganınız"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "İvrit"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Vurğulama Rəngi"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hind"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Macar"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,11 +2349,11 @@ msgstr "CSV-dən idxal edin"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "{0} tətbiq(lər)i idxal etdi."
+msgstr "{0} müraciət(lər)i idxal etdi."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "PDF və ya Word-dən idxal etmək üçün qoşulmuş süni intellekt provayderi tələb olunur."
+msgstr "PDF və ya Word-dən idxal etmək üçün qoşulmuş AI provayderi tələb olunur."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Zumu artırın"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "İndoneziya"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Vərəq verən"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "İtalyan"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kursiv"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Yapon"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "Tam Kənarlaşdır"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "Açar sözlər"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Kxmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Koreya"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Sonuncu dəfə {0} tarixində baxılıb"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Latış"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Siyahı"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litva"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Süni intellekt provayderləri yüklənir. Zəhmət olmasa, bir az sonra
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Tətbiqlər yüklənir…"
+msgstr "Müraciətlər yüklənir…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Təcrübə bölməsini daha nəticəyönümlü edin və qeyri-müəyyən
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malay"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Bölməni başqa bir sütuna və ya səhifəyə köçürün"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Səhnəni hərəkət etdirin"
+msgstr "Mərhələni köçürün"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Ad"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepal"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Şəbəkə"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Yeni Tətbiq"
+msgstr "Yeni Müraciət"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,7 +2902,7 @@ msgstr "Reklam yoxdur, İzləmə yoxdur"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Filtrlərinizə uyğun heç bir tətbiq yoxdur."
+msgstr "Filtrlərinizə uyğun heç bir müraciət yoxdur."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
@@ -2960,7 +2960,7 @@ msgstr "Hələ mövzu yoxdur."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norveç"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Qeydlər"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odiya"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Aç"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Açıq süni intellekt agenti"
+msgstr "Süni intellekt agentini açın"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI ilə uyğun"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Fars"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Boru kəməri axını"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Bütün tətbiqlərdə boru kəmərinin sağlamlığı"
+msgstr "Bütün müraciətlərdə boru kəmərinin sağlamlığı"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "PDF faylınız yaradılana qədər gözləyin…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polyak"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portret"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portuqal (Braziliya)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portuqal (Portuqaliya)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Ana səhifəyə keç"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktiv Rezume (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktiv CV v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktiv Rezume v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Rol inkişafı"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumın"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "İlk təhlilinizi işə salın, skor kartı, güclü tərəflər və pri
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Rus"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Axtarış"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Tətbiqləri axtarın…"
+msgstr "Müraciətləri axtarın…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Ayırıcı"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serb"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Əsas məzmuna keç"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovak"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Sloven"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Aralıq (Şaquli)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "İspan"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Tətbiqi bacardığınız şəkildə dəstəkləyin!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "İsveç"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Dərzilik uğursuz oldu."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Teluqu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Mətn Rəngi"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Tay"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "Yenidən cəhd edin"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Türk"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipoqrafiya"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrayn"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Bu xronologiya qeydi üçün təqvim tarixini yeniləyin."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Bu tətbiqin məlumatlarını yeniləyin."
+msgstr "Bu müraciətin məlumatlarını yeniləyin."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "İstifadəçilər"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Özbək"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Versiya tarixçəsi"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vyetnam"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,11 +5039,11 @@ msgstr "Kilidləndikdə, özgeçmiş yenilənə və ya silinə bilməz."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "Tətbiqlər haradan gəlir"
+msgstr "Müraciətlər haradan gəlir"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
-msgstr "Tətbiqləriniz hara getdi"
+msgstr "Müraciətləriniz hara getdi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Work OpenAI"
@@ -5190,5 +5190,5 @@ msgstr "Uzaqlaşdır"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/bg-BG.po
+++ b/apps/web/locales/bg-BG.po
@@ -401,7 +401,7 @@ msgstr "И още много..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Антропният Клод"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Подравняване в центъра"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Церебрас"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Затвори асистента с изкуствен интелект
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Кохерентност"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Намаляване на мащаба"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Дълбоко търсене"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Фински"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Фойерверки"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "Google"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "Google Близнаци"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "Мрежа"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "Грок"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "Липсва работна автобиография"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Мистрал ИИ"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Одия"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Облак Олама"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Период"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Озадаченост"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "За да изтриете профила си, трябва да във
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Заедно.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -5063,7 +5063,7 @@ msgstr "X (Туитър)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI Грок"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/bg-BG.po
+++ b/apps/web/locales/bg-BG.po
@@ -266,7 +266,7 @@ msgstr "Добавете и тествайте доставчик, преди д
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Добавяне на приложение"
+msgstr "Добавяне на кандидатура"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "Разширено"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Африканс"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -344,7 +344,7 @@ msgstr "Настройката на AI агент не е налична, док
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "Асистент с изкуствен интелект"
+msgstr "Асистент с ИИ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "Доставчиците на изкуствен интелект изи
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Албански"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Вече имате акаунт? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Амхарски"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Приложение"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Действия на приложението"
+msgstr "Действия на кандидатурата"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Приложението е добавено към вашия конвейер."
+msgstr "Кандидатурата е добавена към вашия конвейер."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Приложение Copilot"
+msgstr "Копилот за кандидатури"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Приложението е изтрито."
+msgstr "Кандидатурата е изтрита."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Статистика на приложението"
+msgstr "Статистика на кандидатурите"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Приложението е актуализирано."
+msgstr "Кандидатурата е актуализирана."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Приложения"
+msgstr "Кандидатури"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Прилага се с предупреждения"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Арабски"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Награди"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Азербайджански"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Красиви шаблони, от които да избирате, с
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Бенгалски"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Най-подходящ за приложения, споделяне и печат."
+msgstr "Най-подходящ за кандидатури, споделяне и печат."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -760,7 +760,7 @@ msgstr "Не може да се възстанови; автобиография
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Каталонски"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Проверка на черновата"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Китайски (опростен)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Китайски (традиционен)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Изберете автобиография"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Изберете съществуващ разговор от страничната лента или започнете нова тема, фокусирана върху чернова."
+msgstr "Изберете съществуващ разговор от страничната лента или започнете нова нишка, фокусирана върху чернова."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "Кръг"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Clear"
+msgstr "Изчисти"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Не можа да се провери връзката. Провере�
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Приложението не можа да се добави. Моля, опитайте отново."
+msgstr "Кандидатурата не можа да се добави. Моля, опитайте отново."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Не можах да изтрия приложението."
+msgstr "Не можах да изтрия кандидатурата."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Записът в хронологията не можа да бъде �
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Не можах да преместя приложението. Моля, опитайте отново."
+msgstr "Не можах да преместя кандидатурата. Моля, опитайте отново."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Създадено"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Създадох „{0}“ и го свързах с това приложение."
+msgstr "Създадох „{0}“ и го свързах с тази кандидатура."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Персонализирани стилове"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Чешки"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Опасна зона"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Датски"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Изтриване на доставчик"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Да се изтрие ли тази тема от агент?"
+msgstr "Да се изтрие ли тази нишка от агент?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1392,7 +1392,7 @@ msgstr "Изтриване на запис в хронологията"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Изтрити {0} приложения."
+msgstr "Изтрити {0} кандидатури."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Вашата автобиография се дублира..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Нидерландски"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Редактиране на {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Редактиране на приложението"
+msgstr "Редактиране на кандидатурата"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Активиране на двуфакторно удостоверяв�
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Английски"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Английски (Обединено кралство)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Не успя да анализира резюме."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Архивирането на темата не бе успешно."
+msgstr "Архивирането на нишката не бе успешно."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Не успяхте да изтриете API ключа. Моля, оп
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Изтриването на темата не бе успешно."
+msgstr "Изтриването на нишката не бе успешно."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1963,7 +1963,7 @@ msgstr "Намерете слаби точки и ги пренапишете с
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Фински"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Свободна форма"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Френски"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Генериране на случайно име"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Немски"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Получете преглед на автобиографията си
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Получете задълбочен преглед на автобиографията си, задвижван от изкуствен интелект, с обща оценка, основни силни страни и практически предложения. За да активирате тази функция, актуализирайте настройките на AI."
+msgstr "Получете задълбочен преглед на автобиографията си, задвижван от ИИ, с обща оценка, основни силни страни и практически предложения. За да активирате тази функция, актуализирайте настройките на ИИ."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,7 +2116,7 @@ msgstr "Назад"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Върви си вкъщи"
+msgstr "Към началната страница"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Оценка"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Гръцки"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Подзаглавие"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Иврит"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Цвят на акцента"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Хинди"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Унгарски"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,11 +2349,11 @@ msgstr "Импортиране от CSV файл"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Импортирани са {0} приложения."
+msgstr "Импортирани са {0} кандидатури."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "Импортирането от PDF или Word изисква свързан доставчик на изкуствен интелект."
+msgstr "Импортирането от PDF или Word изисква свързан доставчик на ИИ."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Увеличаване на мащаба"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Индонезийски"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Издател"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Италиански"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Курсив"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Японски"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "Двустранно подравняване"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Каннада"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "Ключови думи"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Кхмерски"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Корейски"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Последно прегледано на {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Латвийски"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Списък"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Литовски"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Зареждане на доставчици на ИИ. Моля, опи
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Зареждане на приложения…"
+msgstr "Зареждане на кандидатури…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Зареждане на автобиографии…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Зареждане на теми…"
+msgstr "Зареждане на нишки…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Направете секцията за опит по-ориентир�
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Малайски"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Малаялам"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Марати"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Преместване на секция в друга колона ил
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Преместване на сцената"
+msgstr "Преместване на етап"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Име"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Непалски"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Мрежа"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Ново приложение"
+msgstr "Нова кандидатура"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "Нов етикет…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Нова тема"
+msgstr "Нова нишка"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Нова тема"
+msgstr "Нова нишка"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2902,11 +2902,11 @@ msgstr "Без реклами, без проследяване"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Няма приложения, които да отговарят на вашите филтри."
+msgstr "Няма кандидатури, които да отговарят на вашите филтри."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Все още няма заявления — добавете няколко, за да видите вашата фуния и процента на отговорите."
+msgstr "Все още няма кандидатури — добавете няколко, за да видите вашата фуния и процента на отговорите."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2960,7 +2960,7 @@ msgstr "Все още няма теми."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Норвежки"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Бележки"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Одия"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Отвори"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Отворен AI агент"
+msgstr "Отворете AI агента"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Съвместим с OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Персийски"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Поток в тръбопровода"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Състояние на тръбопровода във всички приложения"
+msgstr "Състояние на тръбопровода във всички кандидатури"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Моля, изчакайте, докато вашият PDF файл с�
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Полски"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Портрет"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Португалски (Бразилия)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Португалски (Португалия)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Отиване към началната страни�
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Реактивно резюме (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3681,7 +3681,7 @@ msgstr "Кариерно развитие"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Румънски"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Извършете първия си анализ, за да получ�
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Руски"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Търсене"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Търсене на приложения…"
+msgstr "Търсене на кандидатури…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Разделител"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Сръбски"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Създаване на доставчик на изкуствен ин�
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Настройте доставчик на изкуствен интелект, преди да започнете тема."
+msgstr "Настройте доставчик на изкуствен интелект, преди да започнете нишка."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Прескачане към основното съдържание"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Словашки"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Словенски"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Разстояние (вертикално)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Испански"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,7 +4189,7 @@ msgstr "Отбележете ни в GitHub, в момента {0} звезди 
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Започнете нова тема"
+msgstr "Започнете нова нишка"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
@@ -4206,7 +4206,7 @@ msgstr "Започнете да изграждате автобиография�
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Започни нова тема"
+msgstr "Започни нова нишка"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Започнете на нова страница"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Започни темата"
+msgstr "Започни нишка"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Подкрепете приложението, като направит
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Шведски"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Шивачеството се провали."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Тамилски"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Телугу"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Цвят на текста"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Тайландски"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "Въведеният от вас URL адрес не е валиден."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Работното резюме беше изтрито. Тази тема е само за четене."
+msgstr "Работното резюме беше изтрито. Тази нишка е само за четене."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4460,7 +4460,7 @@ msgstr "Това действие е необратимо. Всичките ви
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "Това действие не може да бъде отменено. Съобщенията от разговора и качените прикачени файлове ще бъдат премахнати. Работното резюме остава във вашето табло за управление и може да бъде изтрито отделно."
+msgstr "Това действие не може да бъде отменено. Съобщенията от разговора и качените прикачени файлове ще бъдат премахнати. Работното резюме остава във вашето табло и може да бъде изтрито отделно."
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
@@ -4520,15 +4520,15 @@ msgstr "Тази стъпка не е задължителна, но е преп
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Тази тема е архивирана. Не могат да се изпращат нови съобщения."
+msgstr "Тази нишка е архивирана. Не могат да се изпращат нови съобщения."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Тази тема е само за четене"
+msgstr "Тази нишка е само за четене"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Тази тема е само за четене, защото работещото резюме или доставчикът на изкуствен интелект не е наличен."
+msgstr "Тази нишка е само за четене, защото работещото резюме или доставчикът на изкуствен интелект не е наличен."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4549,11 +4549,11 @@ msgstr "Действия с нишките"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Темата е архивирана."
+msgstr "Нишката е архивирана."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Темата е изтрита."
+msgstr "Нишката е изтрита."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -4647,7 +4647,7 @@ msgstr "Опитай отново"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Турски"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Типография"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Украински"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Актуализирайте календарната дата за то
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Актуализирайте данните на това приложение."
+msgstr "Актуализирайте данните на тази кандидатура."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Потребители"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Узбекски"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "История на версиите"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Виетнамски"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,11 +5039,11 @@ msgstr "Когато е заключена, автобиографията не 
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "Откъде идват заявленията"
+msgstr "Откъде идват кандидатурите"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
-msgstr "Къде отидоха вашите приложения"
+msgstr "Къде отидоха вашите кандидатури"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Work OpenAI"
@@ -5190,5 +5190,5 @@ msgstr "Намаляване"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Зулуски"
+msgstr "isiZulu"
 

--- a/apps/web/locales/bg-BG.po
+++ b/apps/web/locales/bg-BG.po
@@ -2377,7 +2377,7 @@ msgstr "Увеличаване на мащаба"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -4215,7 +4215,7 @@ msgstr "Започнете на нова страница"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Започни нишка"
+msgstr "Започнете нишка"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"

--- a/apps/web/locales/bn-BD.po
+++ b/apps/web/locales/bn-BD.po
@@ -401,7 +401,7 @@ msgstr "এবং আরো অনেক..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "অ্যান্থ্রপিক ক্লাড"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "মধ্যের দিকে অ্যালাইন"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "সেরেব্রাস"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "এআই সহকারী বন্ধ করুন"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "কোহেয়ার"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "জুম কমান"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "ডিপসিক"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "ফিনিশ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "আতশবাজি"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "গুগল"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "গুগল জেমিনি"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "গ্রিড"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "গ্রোক"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "কাজের জীবনবৃত্তান্ত অনুপস�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "মিস্ট্রাল এআই"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "ওড়িয়া"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ওলামা ক্লাউড"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "মুক্ত উৎস"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "ওপেনএআই"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "ওপেনএআই-সামঞ্জস্যপূর্ণ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "ওপেনরাউটার"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "সময়কাল"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "বিভ্রান্তি"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "বৈধ URL অবশ্যই http:// বা https:// দিয়ে
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "ভার্সেল এআই গেটওয়ে"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "এক্স (টুইটার)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI গ্রোক"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/bn-BD.po
+++ b/apps/web/locales/bn-BD.po
@@ -266,7 +266,7 @@ msgstr "এজেন্ট থ্রেড শুরু করার আগে �
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "অ্যাপ্লিকেশন যোগ করুন"
+msgstr "আবেদন যোগ করুন"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "উন্নত"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "আফ্রিকান্স"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "এআই প্রোভাইডারদের REDIS_URL এবং EN
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "আলবেনিয়ান"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "ইতিমধ্যে একটি অ্যাকাউন্ট আ
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "আমহারিক"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "অ্যাপ"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "অ্যাপ্লিকেশন কার্যক্রম"
+msgstr "আবেদন কার্যক্রম"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "আপনার পাইপলাইনে অ্যাপ্লিকেশন যোগ করা হয়েছে।"
+msgstr "আপনার পাইপলাইনে আবেদন যোগ করা হয়েছে।"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "অ্যাপ্লিকেশন কোপাইলট"
+msgstr "আবেদন কোপাইলট"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "অ্যাপ্লিকেশনটি মুছে ফেলা হয়েছে।"
+msgstr "আবেদনটি মুছে ফেলা হয়েছে।"
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "অ্যাপ্লিকেশন পরিসংখ্যান"
+msgstr "আবেদন পরিসংখ্যান"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "অ্যাপ্লিকেশন আপডেট করা হয়েছে।"
+msgstr "আবেদন আপডেট করা হয়েছে।"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "অ্যাপ্লিকেশন"
+msgstr "আবেদন"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "সতর্কতাসহ প্রয়োগ করা হয়ে
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "আরবি"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "পুরস্কার"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "আজারবাইজানি"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -665,7 +665,7 @@ msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "অ্যাপ্লিকেশন, শেয়ার এবং প্রিন্ট করার জন্য সেরা।"
+msgstr "আবেদন, শেয়ার এবং প্রিন্ট করার জন্য সেরা।"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "বিল্ডার কমান্ড প্যালেট"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "বুলগেরিয়ান"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "পুনরুদ্ধার করা সম্ভব নয়; এ�
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "কাতালান"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "খসড়া পরীক্ষা করা হচ্ছে"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "চীনা (সরলীকৃত)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "চীনা (প্রচলিত)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "বৃত্ত"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "স্বচ্ছ"
+msgstr "সাফ করুন"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "সংযোগটি যাচাই করা যায়নি। �
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "অ্যাপ্লিকেশনটি যোগ করা যায়নি। অনুগ্রহ করে আবার চেষ্টা করুন।"
+msgstr "আবেদনটি যোগ করা যায়নি। অনুগ্রহ করে আবার চেষ্টা করুন।"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "অ্যাপ্লিকেশনটি মুছে ফেলা যায়নি।"
+msgstr "আবেদনটি মুছে ফেলা যায়নি।"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "সময়রেখার এন্ট্রি মুছে ফেল
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "অ্যাপ্লিকেশনটি সরানো যায়নি। অনুগ্রহ করে আবার চেষ্টা করুন।"
+msgstr "আবেদনটি সরানো যায়নি। অনুগ্রহ করে আবার চেষ্টা করুন।"
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "তৈরি হয়েছে"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "\"{0}\" তৈরি করা হয়েছে এবং এটিকে এই অ্যাপ্লিকেশনের সাথে লিঙ্ক করা হয়েছে।"
+msgstr "\"{0}\" তৈরি করা হয়েছে এবং এটিকে এই আবেদনের সাথে লিঙ্ক করা হয়েছে।"
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "কাস্টম স্টাইল"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "চেক"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "ঝুঁকিপূর্ণ এলাকা"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "ডেনিশ"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "সময়রেখার এন্ট্রি মুছুন"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "{0} টি অ্যাপ্লিকেশন মুছে ফেলা হয়েছে।"
+msgstr "{0} টি আবেদন মুছে ফেলা হয়েছে।"
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "আপনার জীবনবৃত্তান্ত ডুপ্ল�
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "ডাচ"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "সম্পাদনা {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "অ্যাপ্লিকেশন সম্পাদনা করুন"
+msgstr "আবেদন সম্পাদনা করুন"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "দ্বি-স্তর প্রমাণীকরণ সক্রি
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "ইংরেজি"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "ইংরেজি (যুক্তরাজ্য)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "দুর্বল বুলেট পয়েন্টগুলো খ
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "ফিনিশ"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "দেখার জন্য উপযুক্ত"
+msgstr "দেখার জন্য মানানসই করুন"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "মুক্ত-ফর্ম"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "ফরাসি"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "একটি এলোমেলো নাম জেনারেট ক�
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "জার্মান"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "ফিরে যান"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "বাড়ি যান"
+msgstr "হোম পেজে যান"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "গ্রেড"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "গ্রিক"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "শিরোনাম"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "হিব্রু"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "হাইলাইট রঙ"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "হিন্দি"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "হাঙ্গেরিয়ান"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "CSV থেকে আমদানি করুন"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "আমদানি করা {0} অ্যাপ্লিকেশন(গুলি)।"
+msgstr "আমদানি করা {0} আবেদন(গুলি)।"
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "জুম বাড়ান"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "ইন্দোনেশিয়ান"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "ইস্যুকারী"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "ইতালীয়"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "ইটালিক"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "জাপানি"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "জাস্টিফাই অ্যালাইন"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "কন্নড়"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "একসাথে থাকুন"
+msgstr "একসাথে রাখুন"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "কীওয়ার্ডসমূহ"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "খেমার"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "কোরিয়ান"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "সর্বশেষ দেখা হয়েছে {0} তারি�
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "লাতভীয়"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "তালিকা"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "লিথুয়ানিয়ান"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "এআই প্রোভাইডার লোড করা হচ্�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "অ্যাপ্লিকেশন লোড হচ্ছে…"
+msgstr "আবেদন লোড হচ্ছে…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "অভিজ্ঞতা বিভাগটিকে আরও ফলা
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "মালয়"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "মালয়ালম"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "মারাঠি"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "বিভাগটিকে অন্য কলাম বা পৃষ�
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "মঞ্চ পরিবর্তন করুন"
+msgstr "পর্যায় পরিবর্তন করুন"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "নাম"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "নেপালি"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2902,7 +2902,7 @@ msgstr "কোনো বিজ্ঞাপন নয়, কোনো ট্র�
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "আপনার ফিল্টারগুলোর সাথে কোনো অ্যাপ্লিকেশন মেলে না।"
+msgstr "আপনার ফিল্টারগুলোর সাথে কোনো আবেদন মেলে না।"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
@@ -2960,7 +2960,7 @@ msgstr "এখনো কোনো থ্রেড নেই।"
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "নরওয়েজিয়ান"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "নোটস"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "ওড়িয়া"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "খুলুন"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "ওপেন এআই এজেন্ট"
+msgstr "এআই এজেন্ট খুলুন"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "ওপেনএআই-সামঞ্জস্যপূর্ণ"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "ফার্সি"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "পাইপলাইন প্রবাহ"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "সমস্ত অ্যাপ্লিকেশন জুড়ে পাইপলাইনের স্বাস্থ্য"
+msgstr "সমস্ত আবেদন জুড়ে পাইপলাইনের স্বাস্থ্য"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "আপনার পিডিএফ তৈরি হওয়া পর�
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "পোলিশ"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "পোর্ট্রেট"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "পর্তুগিজ (ব্রাজিল)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "পর্তুগিজ (পর্তুগাল)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - হোমপেইজে যান"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "প্রতিক্রিয়াশীল জীবনবৃত্তান্ত (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "প্রতিক্রিয়াশীল জীবনবৃত্�
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "প্রতিক্রিয়াশীল রিজ্যুম v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "ভূমিকা অগ্রগতি"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "রোমানিয়ান"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "আপনার প্রথম বিশ্লেষণ চালান
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "রুশ"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "অনুসন্ধান"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "অ্যাপ্লিকেশন অনুসন্ধান করুন…"
+msgstr "আবেদন অনুসন্ধান করুন…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "সেপারেটর"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "সার্বিয়ান"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "মূল কনটেন্টে যান"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "স্লোভাক"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "স্লোভেনীয়"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "স্পেসিং (উল্লম্ব)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "স্প্যানিশ"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "যা পারেন তা করে অ্যাপটিকে স�
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "সুইডিশ"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "দর্জিকাজের কাজ ব্যর্থ হয়ে
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "তামিল"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "তেলেগু"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "টেক্সটের রঙ"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "থাই"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "আবার চেষ্টা করুন"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "তুর্কি"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "টাইপোগ্রাফি"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "ইউক্রেনীয়"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "এই সময়রেখার এন্ট্রির ক্যা
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "এই অ্যাপ্লিকেশনটির বিবরণ আপডেট করুন।"
+msgstr "এই আবেদনটির বিবরণ আপডেট করুন।"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "ব্যবহারকারী"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "উজবেক"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "সংস্করণ ইতিহাস"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "ভিয়েতনামি"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "জুম আউট"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "জুলু"
+msgstr "isiZulu"
 

--- a/apps/web/locales/bn-BD.po
+++ b/apps/web/locales/bn-BD.po
@@ -2377,7 +2377,7 @@ msgstr "জুম বাড়ান"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/ca-ES.po
+++ b/apps/web/locales/ca-ES.po
@@ -2377,7 +2377,7 @@ msgstr "Augmenta el zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/ca-ES.po
+++ b/apps/web/locales/ca-ES.po
@@ -266,7 +266,7 @@ msgstr "Afegiu i proveu un proveïdor abans d'iniciar un fil d'agent."
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Afegeix una aplicació"
+msgstr "Afegeix una sol·licitud"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -364,7 +364,7 @@ msgstr "Els proveïdors d'IA requereixen que REDIS_URL i ENCRYPTION_SECRET estig
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanès"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Ja teniu un compte? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amhàric"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Aplicació"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Accions de l'aplicació"
+msgstr "Accions de la sol·licitud"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Aplicació afegida al teu pipeline."
+msgstr "Sol·licitud afegida al teu pipeline."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Copilot d'aplicacions"
+msgstr "Copilot de sol·licituds"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Aplicació suprimida."
+msgstr "Sol·licitud suprimida."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Estadístiques de l’aplicació"
+msgstr "Estadístiques de sol·licituds"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Aplicació actualitzada."
+msgstr "Sol·licitud actualitzada."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Aplicacions"
+msgstr "Sol·licituds"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Aplicat amb avisos"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Àrab"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Premis"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Àzeri"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Plantilles boniques per triar, amb més en camí."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengalí"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Ideal per a aplicacions, compartició i impressió."
+msgstr "Ideal per a sol·licituds, compartició i impressió."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Paleta de comandes del creador"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Búlgar"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -819,11 +819,11 @@ msgstr "S'està revisant l'esborrany"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Xinès (simplificat)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Xinès (tradicional)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Cercle"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Clar"
+msgstr "Esborra"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "No s'ha pogut verificar la connexió. Comproveu la clau de l'API, el mod
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "No s'ha pogut afegir l'aplicació. Torna-ho a provar."
+msgstr "No s'ha pogut afegir la sol·licitud. Torna-ho a provar."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "No s'ha pogut suprimir l'aplicació."
+msgstr "No s'ha pogut suprimir la sol·licitud."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "No s'ha pogut suprimir l'entrada de la cronologia."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "No s'ha pogut moure l'aplicació. Torna-ho a provar."
+msgstr "No s'ha pogut moure la sol·licitud. Torna-ho a provar."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Creat"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "He creat \"{0}\" i l'he enllaçat a aquesta aplicació."
+msgstr "He creat \"{0}\" i l'he enllaçat a aquesta sol·licitud."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Estils personalitzats"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Txec"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Zona de perill"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danès"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "Suprimeix l'entrada de la cronologia"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "S'han suprimit {0} aplicacions."
+msgstr "S'han suprimit {0} sol·licituds."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "S’està duplicant el currículum..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Neerlandès"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Edita {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Edita l'aplicació"
+msgstr "Edita la sol·licitud"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Habilitació de l'autenticació de dos factors…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Anglès"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Anglès (Regne Unit)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Troba els punts febles i reescriu-los amb resultats, números, abast i v
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finès"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Forma lliure"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Francès"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Genera un nom aleatori"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Alemany"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,13 +2116,13 @@ msgstr "Torna enrere"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Torna a casa"
+msgstr "Torna a la pàgina d'inici"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Ves al tauler"
+msgstr "Ves al tauler de control"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "Nota"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Grec"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Titular"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebreu"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Color de ressaltat"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Hongarès"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Importa des de CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "S'han importat {0} aplicacions."
+msgstr "S'han importat {0} sol·licituds."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Augmenta el zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesi"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Emissor"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italià"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Cursiva"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japonès"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "Justifica"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "Paraules clau"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Coreà"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Darrera visualització el {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Letó"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Llista"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lituà"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "S'estan carregant els proveïdors d'IA. Si us plau, torneu-ho a provar d
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "S'estan carregant les aplicacions…"
+msgstr "S'estan carregant les sol·licituds…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Feu que la secció d'experiència estigui més orientada a resultats i e
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malai"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malaiàlam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Moure la secció a una altra columna o pàgina"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Mou l'escenari"
+msgstr "Mou la fase"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Nom"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalès"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Xarxa"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Nova aplicació"
+msgstr "Nova sol·licitud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,7 +2902,7 @@ msgstr "Sense publicitat, sense seguiment"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "No hi ha cap aplicació que coincideixi amb els filtres."
+msgstr "No hi ha cap sol·licitud que coincideixi amb els filtres."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
@@ -2960,7 +2960,7 @@ msgstr "Encara no hi ha fils."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Noruec"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Notes"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Obre"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Agent d'IA oberta"
+msgstr "Obre l'agent d'IA"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Compatible amb OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persa"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Flux de canonades"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Estat de la canonada en totes les aplicacions"
+msgstr "Estat de la canonada en totes les sol·licituds"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Si us plau, espereu mentre es genera el vostre PDF…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polonès"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Vertical"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portuguès (Brasil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portuguès (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Ves a la pàgina inicial"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Currículum reactiu (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3681,7 +3681,7 @@ msgstr "Progressió del càrrec"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Romanès"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Executa la teva primera anàlisi per obtenir un quadre de comandament, e
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Rus"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Cerca"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Cerca aplicacions…"
+msgstr "Cerca sol·licituds…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Separador"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbi"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Vés al contingut principal"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Eslovac"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Eslovè"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Espaiat (vertical)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Espanyol"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Dóna suport a l’aplicació fent el que puguis!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Suec"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "La sastreria va fracassar."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Color del text"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Tai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "Torna-ho a intentar"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turc"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipografia"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ucraïnès"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Actualitza la data del calendari d'aquesta entrada de la cronologia."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Actualitza els detalls d'aquesta aplicació."
+msgstr "Actualitza els detalls d'aquesta sol·licitud."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Usuaris"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbek"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Historial de versions"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamita"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Allunya"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulú"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ca-ES.po
+++ b/apps/web/locales/ca-ES.po
@@ -768,7 +768,7 @@ msgstr "Alinea al centre"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Cerebres"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Tanca l'assistent d'IA"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Coherència"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finès"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Focs artificials"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2797,7 +2797,7 @@ msgstr "Falta un currículum laboral"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "IA Mistral"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Núvol d'Ollama"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3046,7 +3046,7 @@ msgstr "Compatible amb OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "Routador obert"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "Període"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Perplexitat"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Per suprimir el compte, has d’introduir el text de confirmació i fer 
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Junts.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/cs-CZ.po
+++ b/apps/web/locales/cs-CZ.po
@@ -401,7 +401,7 @@ msgstr "A mnoho dalších…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropický Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Zarovnat na střed"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Mozky"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Zavřít asistenta s umělou inteligencí"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Soudržný"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Zmenšit přiblížení"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Hluboké vyhledávání"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Finština"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Ohňostroj"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -3207,7 +3207,7 @@ msgstr "Období"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Zmatek"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "Platné URL adresy musí začínat http:// nebo https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Brána Vercel AI"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/cs-CZ.po
+++ b/apps/web/locales/cs-CZ.po
@@ -2377,7 +2377,7 @@ msgstr "Zvětšit přiblížení"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/cs-CZ.po
+++ b/apps/web/locales/cs-CZ.po
@@ -266,7 +266,7 @@ msgstr "Před spuštěním vlákna agenta přidejte a otestujte poskytovatele."
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Přidat aplikaci"
+msgstr "Přidat žádost"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -311,11 +311,11 @@ msgstr "Upravte životopis pro roli zaměřenou na práci na dálku, která si c
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "Moderní"
+msgstr "Pokročilé"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Afrikánština"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -344,7 +344,7 @@ msgstr "Nastavení agenta AI není k dispozici, dokud nejsou nakonfigurovány pa
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "Asistent s umělou inteligencí"
+msgstr "Asistent AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "Poskytovatelé umělé inteligence vyžadují konfiguraci parametrů RED
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albánština"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Máte již účet? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharština"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Aplikace"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Akce aplikace"
+msgstr "Akce žádosti"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Aplikace přidána do vašeho kanálu."
+msgstr "Žádost přidána do vašeho kanálu."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Aplikační kopilot"
+msgstr "Kopilot žádostí"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Aplikace smazána."
+msgstr "Žádost smazána."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Statistiky aplikace"
+msgstr "Statistiky žádostí"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Aplikace aktualizována."
+msgstr "Žádost aktualizována."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Aplikace"
+msgstr "Žádosti"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Použito s varováním"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabština"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Ocenění"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Ázerbájdžánština"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Krásné šablony, ze kterých můžete vybírat, a další jsou na cest
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengálština"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Nejlepší pro aplikace, sdílení a tisk."
+msgstr "Nejlepší pro žádosti, sdílení a tisk."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Příkazová paleta editoru"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulharština"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Nelze obnovit; životopis se od provedení této úpravy změnil."
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalánština"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Kontrola návrhu"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Čínština (zjednodušená)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Čínština (tradiční)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Kruh"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Přehledně"
+msgstr "Vyčistit"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Nepodařilo se ověřit připojení. Zkontrolujte klíč API, model a z�
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Aplikaci se nepodařilo přidat. Zkuste to prosím znovu."
+msgstr "Žádost se nepodařilo přidat. Zkuste to prosím znovu."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Aplikaci se nepodařilo smazat."
+msgstr "Žádost se nepodařilo smazat."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Záznam časové osy se nepodařilo odstranit."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Aplikaci se nepodařilo přesunout. Zkuste to prosím znovu."
+msgstr "Žádost se nepodařilo přesunout. Zkuste to prosím znovu."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Vytvořeno"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Vytvořil(a) jsem „{0}“ a propojil(a) ho s touto aplikací."
+msgstr "Vytvořil(a) jsem „{0}“ a propojil(a) ho s touto žádostí."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1288,7 +1288,7 @@ msgstr "Nebezpečná zóna"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Dánština"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "Odstranit záznam časové osy"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Smazáno {0} aplikací."
+msgstr "Smazáno {0} žádostí."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Duplikování životopisu…"
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Nizozemština"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Upravit {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Upravit aplikaci"
+msgstr "Upravit žádost"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Povolení dvoufaktorového ověřování…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Angličtina"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Angličtina (Spojené království)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1861,7 +1861,7 @@ msgstr "Nepodařilo se obnovit heslo. Zkuste to prosím znovu."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "Uložení poskytovatele umělé inteligence se nezdařilo."
+msgstr "Uložení poskytovatele AI se nezdařilo."
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -1963,7 +1963,7 @@ msgstr "Najděte slabé odrážky a přepište je se silnějšími výsledky, č
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finština"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Volný formát"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Francouzština"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Vygenerovat náhodný název"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Němčina"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Získejte přehled o svém životopisu s celkovým hodnocením, silnými
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Získejte hloubkovou recenzi svého životopisu s celkovým hodnocením, klíčovými přednostmi a praktickými návrhy. Chcete-li tuto funkci aktivovat, aktualizujte nastavení umělé inteligence."
+msgstr "Získejte hloubkovou recenzi svého životopisu s celkovým hodnocením, klíčovými přednostmi a praktickými návrhy. Chcete-li tuto funkci aktivovat, aktualizujte nastavení AI."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,18 +2116,18 @@ msgstr "Zpět"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Jít domů"
+msgstr "Přejít na úvodní stránku"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Přejít na nástěnku"
+msgstr "Přejít na Dashboard"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Přejít na palubní desku s životopisy"
+msgstr "Přejít na Dashboard životopisů"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Prospěch"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Řečtina"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Titulek"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebrejština"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Barva zvýraznění"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindština"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Maďarština"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,11 +2349,11 @@ msgstr "Importovat z CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Importováno {0} aplikací."
+msgstr "Importováno {0} žádostí."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "Import z PDF nebo Wordu vyžaduje připojeného poskytovatele umělé inteligence."
+msgstr "Import z PDF nebo Wordu vyžaduje připojeného poskytovatele AI."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Zvětšit přiblížení"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonéština"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Vydavatel"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italština"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kurzíva"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japonština"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Zarovnání do bloku"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannadština"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Držte pohromadě"
+msgstr "Ponechat pohromadě"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Klíčová slova"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmerština"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Korejština"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Naposledy zobrazeno {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Lotyština"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Seznam"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litevština"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Načítání poskytovatelů umělé inteligence. Zkuste to prosím znovu
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Načítání aplikací…"
+msgstr "Načítání žádostí…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Zaměřte sekci věnovanou zkušenostem více na výsledky a odstraňte 
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malajština"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malajálamština"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Maráthština"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Přesunout sekci do jiného sloupce nebo na jinou stránku"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Přesunout scénu"
+msgstr "Přesunout fázi"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Název"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepálština"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Síť"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Nová aplikace"
+msgstr "Nová žádost"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,7 +2902,7 @@ msgstr "Bez reklam, bez sledování"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Žádné aplikace neodpovídají vašim filtrům."
+msgstr "Žádné žádosti neodpovídají vašim filtrům."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
@@ -2960,7 +2960,7 @@ msgstr "Zatím žádná vlákna."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norština"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Poznámky"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Udijština"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Otevřít"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Otevřený agent AI"
+msgstr "Otevřít agenta AI"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Kompatibilní s OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Perština"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Průtok potrubím"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Stav potrubí napříč všemi aplikacemi"
+msgstr "Stav potrubí napříč všemi žádostmi"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Počkejte prosím, než se váš PDF vygeneruje…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polština"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portrét"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugalština (Brazílie)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugalština (Portugalsko)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume – přejít na domovskou stránku"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktivní životopis (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktivní životopis v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktivní životopis v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Kariérní postup"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumunština"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Proveďte první analýzu a získejte hodnotící tabulku, silné strán
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Ruština"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Vyhledávání"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Vyhledávání aplikací…"
+msgstr "Vyhledávání žádostí…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Oddělovač"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Srbština"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Přeskočit na hlavní obsah"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovenština"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovinština"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Rozestupy (svislé)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Španělština"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Podpořte aplikaci tím, co můžete!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Švédština"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Krejčovství selhalo."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamilština"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugština"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Barva textu"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thajština"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4460,7 +4460,7 @@ msgstr "Tuto akci nelze vrátit zpět. Všechna vaše data budou trvale smazána
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "Tuto akci nelze vrátit zpět. Zprávy z konverzace a nahrané přílohy budou odstraněny. Pracovní životopis zůstane ve vašem řídicím panelu a lze jej smazat samostatně."
+msgstr "Tuto akci nelze vrátit zpět. Zprávy z konverzace a nahrané přílohy budou odstraněny. Pracovní životopis zůstane ve vašem Dashboardu a lze jej smazat samostatně."
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
@@ -4647,7 +4647,7 @@ msgstr "Zkuste to znovu"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turečtina"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typografie"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrajinština"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Aktualizujte kalendářní datum pro tento záznam časové osy."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Aktualizujte podrobnosti této aplikace."
+msgstr "Aktualizujte podrobnosti této žádosti."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Uživatelé"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbečtina"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Historie verzí"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamština"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Oddálit"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/da-DK.po
+++ b/apps/web/locales/da-DK.po
@@ -401,7 +401,7 @@ msgstr "Og mange flere..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropiske Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -876,7 +876,7 @@ msgstr "Luk AI-assistent"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Sammenhæng"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Fyrværkeri"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Ollama-skyen"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Periode"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Forvirring"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "For at slette din konto skal du indtaste bekræftelsesteksten og klikke 
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Sammen.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/da-DK.po
+++ b/apps/web/locales/da-DK.po
@@ -2377,7 +2377,7 @@ msgstr "Øg zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/da-DK.po
+++ b/apps/web/locales/da-DK.po
@@ -266,7 +266,7 @@ msgstr "Tilføj og test en udbyder, før du starter en agenttråd."
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Tilføj applikation"
+msgstr "Tilføj ansøgning"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -311,7 +311,7 @@ msgstr "Tilpas CV'et til en fjernstyret rolle, der værdsætter asynkron kommuni
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "Fremskreden"
+msgstr "Avanceret"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
@@ -364,7 +364,7 @@ msgstr "AI-udbydere kræver, at REDIS_URL og ENCRYPTION_SECRET konfigureres."
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albansk"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Har du allerede en konto? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharisk"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "App"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Applikationshandlinger"
+msgstr "Ansøgningshandlinger"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Applikation føjet til din pipeline."
+msgstr "Ansøgning føjet til din pipeline."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Applikations-Copilot"
+msgstr "Ansøgnings-Copilot"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Applikation slettet."
+msgstr "Ansøgning slettet."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Applikationsstatistik"
+msgstr "Ansøgningsstatistik"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Applikationen er opdateret."
+msgstr "Ansøgningen er opdateret."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Applikationer"
+msgstr "Ansøgninger"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Anvendt med advarsler"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabisk"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Priser"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Aserbajdsjansk"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Smukke skabeloner at vælge imellem, med flere på vej."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Bedst til applikationer, deling og udskrivning."
+msgstr "Bedst til ansøgninger, deling og udskrivning."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Builder-kommandopalet"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgarsk"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Kan ikke gendannes; CV'et er ændret, siden denne redigering blev anvend
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalansk"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Tjekker udkast"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Kinesisk (forenklet)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Kinesisk (traditionelt)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Cirkel"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Klar"
+msgstr "Ryd"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Forbindelsen kunne ikke bekræftes. Kontroller API-nøglen, modellen og 
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Kunne ikke tilføje applikationen. Prøv igen."
+msgstr "Kunne ikke tilføje ansøgningen. Prøv igen."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Kunne ikke slette applikationen."
+msgstr "Kunne ikke slette ansøgningen."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Tidslinjeposten kunne ikke slettes."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Kunne ikke flytte applikationen. Prøv igen."
+msgstr "Kunne ikke flytte ansøgningen. Prøv igen."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Oprettet"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Oprettede \"{0}\" og linkede det til denne applikation."
+msgstr "Oprettede \"{0}\" og linkede det til denne ansøgning."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Brugerdefinerede stilarter"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Tjekkisk"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1392,7 +1392,7 @@ msgstr "Slet tidslinjepost"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Slettede {0} applikation(er)."
+msgstr "Slettede {0} ansøgning(er)."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Duplikerer dit CV..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Hollandsk"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Rediger {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Rediger applikation"
+msgstr "Rediger ansøgning"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Aktivering af tofaktorgodkendelse…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Engelsk"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Engelsk (Storbritannien)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Find svage punktopstillinger og omskriv dem med stærkere udfald, tal, o
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finsk"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Frit format"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Fransk"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Generér et tilfældigt navn"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Tysk"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Gå tilbage"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Gå hjem"
+msgstr "Til forsiden"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Karakter"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Græsk"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2199,11 +2199,11 @@ msgstr "Overskrift 6"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
 msgid "Headline"
-msgstr "Overskrift"
+msgstr "Underoverskrift"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebraisk"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Fremhævelsesfarve"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Ungarsk"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Importer fra CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Importerede {0} applikation(er)."
+msgstr "Importerede {0} ansøgning(er)."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Øg zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesisk"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Udsteder"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italiensk"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kursiv"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japansk"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "Lige margener"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "Nøgleord"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Koreansk"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Sidst vist den {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Lettisk"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Liste"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litauisk"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Indlæser AI-udbydere. Prøv igen om et øjeblik."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Indlæser applikationer…"
+msgstr "Indlæser ansøgninger…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Gør erfaringssektionen mere resultatorienteret og fjern vage ansvarsomr
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malajisk"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Flyt sektion til en anden kolonne eller side"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Flyt scene"
+msgstr "Flyt fase"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Navn"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalesisk"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Netværk"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Ny applikation"
+msgstr "Ny ansøgning"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,7 +2902,7 @@ msgstr "Ingen reklamer, ingen sporing"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Ingen applikationer matcher dine filtre."
+msgstr "Ingen ansøgninger matcher dine filtre."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
@@ -2977,7 +2977,7 @@ msgstr "Noter"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Åbn"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Åben AI-agent"
+msgstr "Åbn AI-agenten"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-kompatibel"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persisk"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Rørledningsstrømning"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Pipeline-tilstand på tværs af alle applikationer"
+msgstr "Pipeline-tilstand på tværs af alle ansøgninger"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Vent venligst mens din PDF genereres…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polsk"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Stående"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugisisk (Brasilien)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugisisk (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Gå til startside"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktivt CV (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktivt CV v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktivt CV v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Rolleudvikling"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumænsk"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Kør din første analyse for at få et scorekort, styrker og prioritered
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russisk"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Søge"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Søg i applikationer…"
+msgstr "Søg i ansøgninger…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Skillelinje"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbisk"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Spring til hovedindhold"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovakisk"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovensk"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Mellemrum (lodret)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spansk"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Støt appen ved at gøre, hvad du kan!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Svensk"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Skrædderi mislykkedes."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Tekstfarve"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "Prøv igen"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Tyrkisk"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typografi"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrainsk"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Opdater kalenderdatoen for denne tidslinjepost."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Opdater oplysningerne om denne applikation."
+msgstr "Opdater oplysningerne om denne ansøgning."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Brugere"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Usbekisk"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Versionshistorik"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamesisk"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Zoom ud"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/de-DE.po
+++ b/apps/web/locales/de-DE.po
@@ -401,7 +401,7 @@ msgstr "Und viele weitere ..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Anthropischer Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Zentriert"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Großhirn"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Schließen Sie den KI-Assistenten"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Zusammenhängen"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finnisch"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Feuerwerk"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "Google"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "Google Zwillinge"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2797,7 +2797,7 @@ msgstr "Fehlender Arbeitslebenslauf"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Mistral KI"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Ollama-Wolke"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Zeitraum"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Verwirrung"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"

--- a/apps/web/locales/de-DE.po
+++ b/apps/web/locales/de-DE.po
@@ -311,7 +311,7 @@ msgstr "Passen Sie Ihren Lebenslauf an eine Remote-First-Position an, die asynch
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "Fortschrittlich"
+msgstr "Erweitert"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
@@ -364,7 +364,7 @@ msgstr "KI-Anbieter benötigen die Konfiguration von REDIS_URL und ENCRYPTION_SE
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanisch"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Sie haben bereits ein Konto? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharisch"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Bewerbung gelöscht."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Anwendungsstatistiken"
+msgstr "Bewerbungsstatistiken"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Mit Warnungen angewendet"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabisch"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Auszeichnungen"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Aserbaidschanisch"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Schöne Vorlagen zur Auswahl – und es kommen laufend weitere hinzu."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengalisch"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Ideal für Anwendungen, zum Teilen und Drucken."
+msgstr "Ideal für Bewerbungen, zum Teilen und Drucken."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Befehlspalette des Builders"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgarisch"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Wiederherstellung nicht möglich; der Lebenslauf hat sich seit der letzt
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalanisch"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Entwurf prüfen"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chinesisch (vereinfacht)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chinesisch (traditionell)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Kreis"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Klar"
+msgstr "Zurücksetzen"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Benutzerdefinierte Stile"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Tschechisch"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Gefahrenbereich"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Dänisch"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1302,7 +1302,7 @@ msgstr "Dunkles Design"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Dashboard"
-msgstr "Armaturenbrett"
+msgstr "Dashboard"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Data Security"
@@ -1548,7 +1548,7 @@ msgstr "Ihr Lebenslauf wird dupliziert..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Niederländisch"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Zwei-Faktor-Authentifizierung aktivieren…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Englisch"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Englisch (Vereinigtes Königreich)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Finden Sie schwache Stichpunkte und formulieren Sie sie mit aussagekräf
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finnisch"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Passend zur Ansicht"
+msgstr "An Ansicht anpassen"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Freiform"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Französisch"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2116,7 +2116,7 @@ msgstr "Zurück"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Nach Hause gehen"
+msgstr "Zur Startseite"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Note"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Griechisch"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Berufsbezeichnung"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebräisch"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Hervorhebungsfarbe"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Ungarisch"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "Zoom vergrößern"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesisch"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Aussteller"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italienisch"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kursiv"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japanisch"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Blocksatz"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Zusammenbleiben"
+msgstr "Zusammenhalten"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Stichwörter"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Koreanisch"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Zuletzt angesehen am {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Lettisch"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Listenansicht"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litauisch"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "KI-Anbieter werden geladen. Bitte versuchen Sie es in einem Moment erneu
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Anwendungen werden geladen…"
+msgstr "Bewerbungen werden geladen…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Gestalten Sie den Abschnitt „Erfahrung“ ergebnisorientierter und ent
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malaiisch"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Name"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalesisch"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Netzwerk"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Neue Anwendung"
+msgstr "Neue Bewerbung"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2960,7 +2960,7 @@ msgstr "Bisher keine Threads."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norwegisch"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Notizen"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Öffnen"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Offener KI-Agent"
+msgstr "KI-Agent öffnen"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-kompatibel"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persisch"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Bitte warten Sie, während Ihre PDF-Datei generiert wird…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polnisch"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Hochformat"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugiesisch (Brasilien)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugiesisch (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume – Zur Startseite gehen"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktiver Lebenslauf (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktiver Lebenslauf v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktiver Lebenslauf v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Karriereverlauf"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumänisch"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Führen Sie Ihre erste Analyse durch, um eine Scorecard, Stärken und pr
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russisch"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "Trennzeichen"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbisch"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Zum Hauptinhalt springen"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slowakisch"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slowenisch"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Abstand (vertikal)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spanisch"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4193,7 +4193,7 @@ msgstr "Eröffne einen neuen Thread"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Eröffne einen Thread"
+msgstr "Eröffnen Sie einen Thread"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4215,7 +4215,7 @@ msgstr "Auf neuer Seite beginnen"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Thema starten"
+msgstr "Thread starten"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Unterstützen Sie die App, wo Sie können!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Schwedisch"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Anpassung fehlgeschlagen."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Textfarbe"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thailändisch"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4553,7 +4553,7 @@ msgstr "Thread archiviert."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Thema gelöscht."
+msgstr "Thread gelöscht."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -4647,7 +4647,7 @@ msgstr "Versuchen Sie es erneut"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Türkisch"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typografie"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrainisch"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Nutzende"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Usbekisch"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Versionsverlauf"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamesisch"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Herauszoomen"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/de-DE.po
+++ b/apps/web/locales/de-DE.po
@@ -2377,7 +2377,7 @@ msgstr "Zoom vergrößern"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/el-GR.po
+++ b/apps/web/locales/el-GR.po
@@ -315,12 +315,12 @@ msgstr "Προχωρημένος"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Αφρικάανς"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Agent"
-msgstr "Μέσο"
+msgstr "Πράκτορας"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Agent ready"
@@ -344,7 +344,7 @@ msgstr "Η ρύθμιση του παράγοντα AI δεν είναι δια�
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "Βοηθός Τεχνητής Νοημοσύνης"
+msgstr "Βοηθός ΤΝ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "Οι πάροχοι τεχνητής νοημοσύνης απαιτού
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Αλβανικά"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Έχετε ήδη λογαριασμό; <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Αμχαρικά"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Η αίτηση διαγράφηκε."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Στατιστικά εφαρμογής"
+msgstr "Στατιστικά αιτήσεων"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Εφαρμόζεται με προειδοποιήσεις"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Αραβικά"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -591,7 +591,7 @@ msgstr "Επισύναψη αρχείων"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment"
-msgstr "Προσάρτημα"
+msgstr "Συνημμένο"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment uploaded."
@@ -628,7 +628,7 @@ msgstr "Βραβεία"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Αζερικά"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Όμορφα πρότυπα για να επιλέξετε, με ακό�
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Μπενγκάλι"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Ιδανικό για εφαρμογές, κοινή χρήση και εκτύπωση."
+msgstr "Ιδανικό για αιτήσεις, κοινή χρήση και εκτύπωση."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Παλέτα εντολών δημιουργού"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Βουλγαρικά"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Δεν είναι δυνατή η επαναφορά. Το βιογρα�
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Καταλανικά"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Έλεγχος προσχεδίου"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Κινέζικα (Απλοποιημένα)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Κινέζικα (Παραδοσιακά)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Κύκλος"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Σαφής"
+msgstr "Εκκαθάριση"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Προσαρμοσμένα στυλ"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Τσεχικά"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Ζώνη κινδύνου"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Δανικά"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "Δημιουργία αντιγράφου του βιογραφικού 
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Ολλανδικά"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Ενεργοποίηση ελέγχου ταυτότητας δύο πα
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Αγγλικά"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Αγγλικά (Ηνωμένο Βασίλειο)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1861,7 +1861,7 @@ msgstr "Απέτυχε η επαναφορά του κωδικού πρόσβα�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "Αποτυχία αποθήκευσης παρόχου τεχνητής νοημοσύνης."
+msgstr "Αποτυχία αποθήκευσης παρόχου ΤΝ."
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -1963,7 +1963,7 @@ msgstr "Βρείτε αδύναμες κουκκίδες και ξαναγράψ
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Φινλανδικά"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Κατάλληλο για προβολή"
+msgstr "Προσαρμογή στην προβολή"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Ελεύθερη μορφή"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Γαλλικά"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Δημιουργία τυχαίου ονόματος"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Γερμανικά"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Λάβετε μια επισκόπηση του βιογραφικού �
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Λάβετε μια εμπεριστατωμένη επισκόπηση του βιογραφικού σας με τεχνητή νοημοσύνη με συνολική βαθμολογία, βασικά πλεονεκτήματα και πρακτικές προτάσεις. Για να ενεργοποιήσετε αυτή τη λειτουργία, ενημερώστε τις ρυθμίσεις τεχνητής νοημοσύνης."
+msgstr "Λάβετε μια εμπεριστατωμένη επισκόπηση του βιογραφικού σας με ΤΝ με συνολική βαθμολογία, βασικά πλεονεκτήματα και πρακτικές προτάσεις. Για να ενεργοποιήσετε αυτή τη λειτουργία, ενημερώστε τις ρυθμίσεις ΤΝ."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,13 +2116,13 @@ msgstr "Επιστροφή"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Πήγαινε σπίτι"
+msgstr "Πίσω στην αρχική"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Μετάβαση στον πίνακα εργαλείων"
+msgstr "Μετάβαση στο ταμπλό"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2203,7 +2203,7 @@ msgstr "Επικεφαλίδα θέσης"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Εβραϊκά"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Χρώμα επισήμανσης"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Χίντι"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Ουγγρικά"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2353,7 +2353,7 @@ msgstr "Εισήχθησαν {0} αίτηση/αιτήσεις."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "Η εισαγωγή από PDF ή Word απαιτεί έναν συνδεδεμένο πάροχο τεχνητής νοημοσύνης."
+msgstr "Η εισαγωγή από PDF ή Word απαιτεί έναν συνδεδεμένο πάροχο ΤΝ."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Αύξηση ζουμ"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Ινδονησιακά"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Φορέας πιστοποίησης"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Ιταλικά"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Πλάγια"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Ιαπωνικά"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Πλήρης στοίχιση"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Κανάντα"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Μείνετε μαζί"
+msgstr "Κράτηση μαζί"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Λέξεις-κλειδιά"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Χμερ"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Κορεατικά"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Τελευταία προβολή στις {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Λετονικά"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Λίστα"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Λιθουανικά"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Φόρτωση παρόχων τεχνητής νοημοσύνης. Δ�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Φόρτωση εφαρμογών…"
+msgstr "Φόρτωση αιτήσεων…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Κάντε το τμήμα εμπειρίας πιο προσανατο�
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Μαλάι"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Μαλαγιαλάμ"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Μαραθικά"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Όνομα"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Νεπάλι"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Δίκτυο"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Νέα εφαρμογή"
+msgstr "Νέα αίτηση"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2960,7 +2960,7 @@ msgstr "Δεν υπάρχουν ακόμη θέματα."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Νορβηγικά"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Σημειώσεις"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Οντιά"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Άνοιγμα"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Ανοιχτός πράκτορας τεχνητής νοημοσύνης"
+msgstr "Ανοίξτε τον πράκτορα τεχνητής νοημοσύνης"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Συμβατό με OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Περσικά"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Παρακαλώ περιμένετε όσο δημιουργείται 
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Πολωνικά"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Κάθετος προσανατολισμός"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Πορτογαλικά (Βραζιλίας)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Πορτογαλικά (Πορτογαλίας)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Μετάβαση στην αρχική σελίδα"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Αντιδραστικό βιογραφικό σημείωμα (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Αντιδραστικό βιογραφικό v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Αντιδραστικό βιογραφικό σημείωμα v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Εξέλιξη ρόλου"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Ρουμανικά"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Εκτελέστε την πρώτη σας ανάλυση για να �
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Ρωσικά"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "Διαχωριστικό"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Σερβικά"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Μετάβαση στο κύριο περιεχόμενο"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Σλοβακικά"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Σλοβενικά"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Κενό (κάθετο)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Ισπανικά"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4223,7 +4223,7 @@ msgstr "Στατιστικά"
 
 #: src/hooks/use-form-blocker.tsx
 msgid "Stay"
-msgstr "Παραμονή"
+msgstr "Μείνε"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Stop generation"
@@ -4276,7 +4276,7 @@ msgstr "Υποστηρίξτε την εφαρμογή κάνοντας ό,τι 
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Σουηδικά"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Η προσαρμογή απέτυχε."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Ταμίλ"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Τελούγκου"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Χρώμα κειμένου"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Ταϊλανδικά"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4460,7 +4460,7 @@ msgstr "Αυτή η ενέργεια δεν μπορεί να αναιρεθεί
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "Αυτή η ενέργεια δεν μπορεί να αναιρεθεί. Τα μηνύματα συνομιλίας και τα μεταφορτωμένα συνημμένα θα καταργηθούν. Το βιογραφικό σημείωμα εργασίας παραμένει στον πίνακα ελέγχου σας και μπορεί να διαγραφεί ξεχωριστά."
+msgstr "Αυτή η ενέργεια δεν μπορεί να αναιρεθεί. Τα μηνύματα συνομιλίας και τα μεταφορτωμένα συνημμένα θα καταργηθούν. Το βιογραφικό σημείωμα εργασίας παραμένει στο ταμπλό σας και μπορεί να διαγραφεί ξεχωριστά."
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
@@ -4647,7 +4647,7 @@ msgstr "Δοκιμάστε ξανά"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Τουρκικά"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Τυπογραφία"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ουκρανικά"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Χρήστες"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Ουζμπεκικά"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Ιστορικό εκδόσεων"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Βιετναμέζικα"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5173,7 +5173,7 @@ msgstr "Η υποστήριξή σας διασφαλίζει ότι το έργ
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Zoom"
-msgstr "Ανίπταμαι διαγωνίως"
+msgstr "Ζουμ"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom in"
@@ -5190,5 +5190,5 @@ msgstr "Σμίκρυνση"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Ζουλού"
+msgstr "isiZulu"
 

--- a/apps/web/locales/el-GR.po
+++ b/apps/web/locales/el-GR.po
@@ -401,7 +401,7 @@ msgstr "Και πολλά άλλα..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Ανθρωπική Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Στοίχιση στο κέντρο"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Εγκεφαλίδες"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Κλείσιμο βοηθού τεχνητής νοημοσύνης"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Διατηρώ συνέπεια"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Μείωση ζουμ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Βαθιά Αναζήτηση"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Φινλανδικά"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Πυροτεχνήματα"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2162,7 +2162,7 @@ msgstr "Πλέγμα"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "Γκροκ"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2981,7 +2981,7 @@ msgstr "Οντιά"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Ολάμα Νέφος"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Περίοδος"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Αμηχανία"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Για να διαγράψετε τον λογαριασμό σας, π�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Μαζί.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "Τα έγκυρα URLs πρέπει να ξεκινούν με http:// �
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Πύλη Vercel AI Gateway"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/el-GR.po
+++ b/apps/web/locales/el-GR.po
@@ -1559,7 +1559,7 @@ msgstr "Οι παλαιότερες εκδόσεις διατηρούνται. �
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/routes/builder/$resumeId/-components/mobile-builder-shell.tsx
 msgid "Edit"
-msgstr "Εκδίδω"
+msgstr "Επεξεργασία"
 
 #. Screen reader label for button that edits a keyword chip. Variable is the current keyword text.
 #: src/components/input/chip-input.tsx
@@ -2377,7 +2377,7 @@ msgstr "Αύξηση ζουμ"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/en-GB.po
+++ b/apps/web/locales/en-GB.po
@@ -2377,7 +2377,7 @@ msgstr "Increase zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/en-GB.po
+++ b/apps/web/locales/en-GB.po
@@ -364,7 +364,7 @@ msgstr "AI providers require REDIS_URL and ENCRYPTION_SECRET to be configured."
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanian"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Already have an account? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharic"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -504,7 +504,7 @@ msgstr "Applied with warnings"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabic"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Awards"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaijani"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Beautiful templates to choose from, with more on the way."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Builder Command Palette"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgarian"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Cannot restore; the resume has changed since this edit was applied."
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalan"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Checking draft"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chinese (Simplified)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chinese (Traditional)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1278,7 +1278,7 @@ msgstr "Custom Styles"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Czech"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Danger Zone"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danish"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "Duplicating your resume..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Dutch"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1670,7 +1670,7 @@ msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "English (United Kingdom)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Find weak bullets and rewrite them with stronger outcomes, numbers, scop
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finnish"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Free-form"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "French"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Generate a random name"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "German"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2154,7 +2154,7 @@ msgstr "Grade"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Greek"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Headline"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebrew"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Highlight Color"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Hungarian"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "Increase zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesian"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Issuer"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italian"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Italic"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japanese"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "Justify Align"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "Keywords"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Korean"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Last viewed on {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Latvian"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "List"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lithuanian"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2754,15 +2754,15 @@ msgstr "Make the experience section more results-oriented and remove vague respo
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malay"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Name"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepali"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2960,7 +2960,7 @@ msgstr "No threads yet."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norwegian"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Notes"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persian"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Please wait while your PDF is being generated…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polish"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portrait"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portuguese (Brazil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portuguese (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3681,7 +3681,7 @@ msgstr "Role Progression"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Romanian"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Run your first analysis to get a scorecard, strengths, and prioritized s
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russian"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "Separator"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbian"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Skip to main content"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovak"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovene"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Spacing (Vertical)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spanish"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Support the app by doing what you can!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Swedish"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Tailoring failed."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Text Colour"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "Try again"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turkish"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typography"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrainian"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Users"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbek"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Version history"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamese"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Zoom out"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/en-US.po
+++ b/apps/web/locales/en-US.po
@@ -2372,7 +2372,7 @@ msgstr "Increase zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/en-US.po
+++ b/apps/web/locales/en-US.po
@@ -359,7 +359,7 @@ msgstr "AI providers require REDIS_URL and ENCRYPTION_SECRET to be configured."
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanian"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -371,7 +371,7 @@ msgstr "Already have an account? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharic"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -499,7 +499,7 @@ msgstr "Applied with warnings"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabic"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -623,7 +623,7 @@ msgstr "Awards"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaijani"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -656,7 +656,7 @@ msgstr "Beautiful templates to choose from, with more on the way."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -698,7 +698,7 @@ msgstr "Builder Command Palette"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgarian"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -755,7 +755,7 @@ msgstr "Cannot restore; the resume has changed since this edit was applied."
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalan"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -814,11 +814,11 @@ msgstr "Checking draft"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chinese (Simplified)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chinese (Traditional)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1273,7 +1273,7 @@ msgstr "Custom Styles"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Czech"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1283,7 +1283,7 @@ msgstr "Danger Zone"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danish"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1543,7 +1543,7 @@ msgstr "Duplicating your resume..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Dutch"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1665,7 +1665,7 @@ msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "English (United Kingdom)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1958,7 +1958,7 @@ msgstr "Find weak bullets and rewrite them with stronger outcomes, numbers, scop
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finnish"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2048,7 +2048,7 @@ msgstr "Free-form"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "French"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2082,7 +2082,7 @@ msgstr "Generate a random name"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "German"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2149,7 +2149,7 @@ msgstr "Grade"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Greek"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2198,7 +2198,7 @@ msgstr "Headline"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebrew"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2277,7 +2277,7 @@ msgstr "Highlight Color"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2301,7 +2301,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Hungarian"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2372,7 +2372,7 @@ msgstr "Increase zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesian"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2420,7 +2420,7 @@ msgstr "Issuer"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italian"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2428,7 +2428,7 @@ msgstr "Italic"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japanese"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2486,7 +2486,7 @@ msgstr "Justify Align"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2504,11 +2504,11 @@ msgstr "Keywords"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Korean"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2566,7 +2566,7 @@ msgstr "Last viewed on {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Latvian"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2669,7 +2669,7 @@ msgstr "List"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lithuanian"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2749,15 +2749,15 @@ msgstr "Make the experience section more results-oriented and remove vague respo
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malay"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2843,7 +2843,7 @@ msgstr "Name"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepali"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2955,7 +2955,7 @@ msgstr "No threads yet."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norwegian"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2972,7 +2972,7 @@ msgstr "Notes"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3206,7 +3206,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persian"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3267,7 +3267,7 @@ msgstr "Please wait while your PDF is being generated…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polish"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3276,11 +3276,11 @@ msgstr "Portrait"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portuguese (Brazil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portuguese (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3676,7 +3676,7 @@ msgstr "Role Progression"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Romanian"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3696,7 +3696,7 @@ msgstr "Run your first analysis to get a scorecard, strengths, and prioritized s
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russian"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3894,7 +3894,7 @@ msgstr "Separator"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbian"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4093,11 +4093,11 @@ msgstr "Skip to main content"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovak"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovenian"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4148,7 +4148,7 @@ msgstr "Spacing (Vertical)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spanish"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4271,7 +4271,7 @@ msgstr "Support the app by doing what you can!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Swedish"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4318,11 +4318,11 @@ msgstr "Tailoring failed."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4359,7 +4359,7 @@ msgstr "Text Color"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4642,7 +4642,7 @@ msgstr "Try again"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turkish"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4723,7 +4723,7 @@ msgstr "Typography"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrainian"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4924,7 +4924,7 @@ msgstr "Users"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbek"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4974,7 +4974,7 @@ msgstr "Version history"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamese"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5185,4 +5185,4 @@ msgstr "Zoom out"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"

--- a/apps/web/locales/es-ES.po
+++ b/apps/web/locales/es-ES.po
@@ -2377,7 +2377,7 @@ msgstr "Aumentar el zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/es-ES.po
+++ b/apps/web/locales/es-ES.po
@@ -315,7 +315,7 @@ msgstr "Avanzado"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Afrikáans"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "Los proveedores de IA requieren que se configuren REDIS_URL y ENCRYPTION
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanés"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "¿Ya tienes una cuenta? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amhárico"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Candidatura eliminada."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Estadísticas de la aplicación"
+msgstr "Estadísticas de candidatura"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Aplicado con advertencias"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Árabe"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Premios"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerí"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Hermosas plantillas entre las que puedes elegir, y pronto habrá más."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengalí"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Ideal para aplicaciones, compartir e imprimir."
+msgstr "Ideal para candidaturas, compartir e imprimir."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Paleta de comandos del editor"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Búlgaro"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "No se puede restaurar; el currículum ha cambiado desde que se aplicó e
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalán"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Borrador de comprobación"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chino (simplificado)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chino (tradicional)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Círculo"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Claro"
+msgstr "Borrar"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Estilos personalizados"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Checo"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Zona de peligro"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danés"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "Duplicando tu currículum..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Neerlandés"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Habilitar la autenticación de dos factores…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Inglés"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Inglés (Reino Unido)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Identifica los puntos débiles y reescríbelos con resultados, cifras, a
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finés"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Apto para visualización"
+msgstr "Ajustar a la vista"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Forma libre"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Francés"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Generar un nombre aleatorio"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Alemán"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Volver"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Ir a casa"
+msgstr "Ir a la página de inicio"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Calificación"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Griego"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Título"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebreo"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Color de resaltado"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Húngaro"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "Aumentar el zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesio"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2433,7 +2433,7 @@ msgstr "Cursiva"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japonés"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Justificar"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Canarés"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Manténganse unidos"
+msgstr "Mantener junto"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Palabras clave"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Jemer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Coreano"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Última visualización el {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Letón"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Lista"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lituano"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Cargando proveedores de IA. Inténtelo de nuevo en un momento."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Cargando aplicaciones…"
+msgstr "Cargando candidaturas…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Haga que la sección de experiencia esté más orientada a los resultado
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malayo"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Maratí"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Nombre"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalí"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Red"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Nueva solicitud"
+msgstr "Nueva candidatura"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2960,7 +2960,7 @@ msgstr "Aún no hay hilos de discusión."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Noruego"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Notas"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Abrir"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Agente de IA abierta"
+msgstr "Abrir el agente de IA"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Compatible con OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persa"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Por favor, espere mientras se genera su PDF…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polaco"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Vertical"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugués (Brasil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugués (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Ir a la página de inicio"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Hoja de vida reactiva (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reanudación reactiva v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Currículum reactivo v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Progresión de puestos"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumano"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Realice su primer análisis para obtener un cuadro de mando, los puntos 
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Ruso"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "Separador"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbio"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4057,7 +4057,7 @@ msgstr "Registrándose..."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a magenta left border accent; compact and efficient for entry-level or internship applications."
-msgstr "Una sola columna con un acento de borde izquierdo magenta; compacto y eficiente para solicitudes de nivel inicial o de prácticas."
+msgstr "Una sola columna con un acento de borde izquierdo magenta; compacto y eficiente para candidaturas de nivel inicial o de prácticas."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a minimal top header and lots of whitespace; clean and modern for designers or content creators."
@@ -4098,11 +4098,11 @@ msgstr "Saltar al contenido principal"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Eslovaco"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Esloveno"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4223,7 +4223,7 @@ msgstr "Estadísticas"
 
 #: src/hooks/use-form-blocker.tsx
 msgid "Stay"
-msgstr "Continuar"
+msgstr "Permanecer"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Stop generation"
@@ -4276,7 +4276,7 @@ msgstr "¡Apoya la aplicación haciendo lo que puedas!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Sueco"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "No se pudo adaptar."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Color del texto"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Tailandés"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4460,7 +4460,7 @@ msgstr "Esta acción no se puede deshacer. Todos tus datos se eliminarán perman
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "Esta acción es irreversible. Los mensajes de conversación y los archivos adjuntos se eliminarán. El currículum permanece en tu panel de control y se puede eliminar por separado."
+msgstr "Esta acción es irreversible. Los mensajes de conversación y los archivos adjuntos se eliminarán. El currículum permanece en tu panel y se puede eliminar por separado."
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
@@ -4560,7 +4560,7 @@ msgstr "Hilo eliminado."
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Trapos"
+msgstr "Hilos"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4647,7 +4647,7 @@ msgstr "Intentar otra vez"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turco"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4683,7 +4683,7 @@ msgstr "Dos columnas, limpio y profesional con sutiles divisores de sección; ad
 
 #: src/dialogs/resume/template/data.ts
 msgid "Two-column, minimal and text-dense with no decorative elements; perfect for traditional industries or ATS-heavy applications."
-msgstr "Dos columnas, minimalista y denso en texto sin elementos decorativos; perfecto para industrias tradicionales o solicitudes en las que el ATS tenga mucho peso."
+msgstr "Dos columnas, minimalista y denso en texto sin elementos decorativos; perfecto para industrias tradicionales o candidaturas en las que el ATS tenga mucho peso."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Two-column, minimal with light gray sidebar and subtle icons; professional and understated for legal, finance, or executive roles."
@@ -4728,7 +4728,7 @@ msgstr "Tipografía"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ucraniano"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Usuarios"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbeko"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Historial de versiones"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamita"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Alejar"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulú"
+msgstr "isiZulu"
 

--- a/apps/web/locales/es-ES.po
+++ b/apps/web/locales/es-ES.po
@@ -401,7 +401,7 @@ msgstr "Y mucho más..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Claude Antrópico"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Alinear al centro"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Cerebros"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Asistente de IA de cierre"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Adherirse"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Disminuir el zoom"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Búsqueda profunda"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Finés"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Fuegos artificiales"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "Google"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "Google Géminis"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Nube de Ollama"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Periodo"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Perplejidad"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Para eliminar tu cuenta, debes introducir el texto de confirmación y ha
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Juntos.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "Las URL válidas deben comenzar con http:// o https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Pasarela Vercel AI"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/fa-IR.po
+++ b/apps/web/locales/fa-IR.po
@@ -260,7 +260,7 @@ msgstr "یک برچسب اضافه کنید و Enter را بزنید…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "قبل از شروع یک نخ عامل، یک ارائه‌دهنده اضافه و آزمایش کنید."
+msgstr "قبل از شروع گفتگوی عامل، یک ارائه‌دهنده اضافه و آزمایش کنید."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -315,7 +315,7 @@ msgstr "پیشرفته"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "آفریکانس"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -324,11 +324,11 @@ msgstr "عامل"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Agent ready"
-msgstr "نماینده آماده است"
+msgstr "عامل آماده است"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Agents"
-msgstr "نمایندگان"
+msgstr "عامل‌ها"
 
 #: src/dialogs/resume/import.tsx
 msgid "AI"
@@ -364,7 +364,7 @@ msgstr "ارائه دهندگان هوش مصنوعی نیاز به پیکربن
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "آلبانیایی"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "قبلاً حساب دارید؟ <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "امهری"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "درخواست حذف شد."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "آمار اپلیکیشن"
+msgstr "آمار درخواست‌ها"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "با هشدارها اعمال می‌شود"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "عربی"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "جوایز"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "آذربایجانی"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "قالب‌های زیبایی برای انتخاب، با موارد �
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "بنگالی"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "پالت فرمان سازنده"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "بلغاری"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "بازیابی امکان‌پذیر نیست؛ رزومه از زمان
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "کاتالان"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "بررسی پیش‌نویس"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "چینی (ساده‌شده)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "چینی (سنتی)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "رزومه انتخاب کنید"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "یک مکالمه موجود را از نوار کناری انتخاب کنید، یا یک رشته مکالمه جدید با محوریت پیش‌نویس شروع کنید."
+msgstr "یک مکالمه موجود را از نوار کناری انتخاب کنید، یا یک گفتگوی جدید با محوریت پیش‌نویس شروع کنید."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "دایره"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "شفاف"
+msgstr "پاک کردن"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "سبک‌های سفارشی"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "چکی"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "منطقهٔ خطر"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "دانمارکی"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "حذف ارائه دهنده"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "این تاپیک مربوط به نماینده حذف بشه؟"
+msgstr "این گفتگوی عامل حذف شود؟"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1548,7 +1548,7 @@ msgstr "در حال تکثیر رزومه شما..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "هلندی"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "فعال کردن احراز هویت دو مرحله‌ای…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "انگلیسی"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "انگلیسی (بریتانیا)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "در تحلیل رزومه شکست خورد."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "آرشیو کردن تاپیک ناموفق بود."
+msgstr "آرشیو کردن گفتگو ناموفق بود."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "حذف کلید API ناموفق بود. لطفاً دوباره تلا�
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "حذف تاپیک ناموفق بود."
+msgstr "حذف گفتگو ناموفق بود."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "خروج ناموفق بود. لطفاً دوباره تلاش کنید.
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "شروع تاپیک مربوط به نماینده ناموفق بود."
+msgstr "شروع گفتگوی عامل ناموفق بود."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "نقاط ضعف را پیدا کنید و آنها را با نتایج�
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "فنلاندی"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "مناسب برای مشاهده"
+msgstr "برای مشاهده تنظیم کنید"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "فرم آزاد"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "فرانسوی"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "تولید یک نام تصادفی"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "آلمانی"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "بازگشت"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "برو به خانه"
+msgstr "بازگشت به صفحه اصلی"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "نمره"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "یونانی"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "تیتر"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "عبری"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "رنگ برجسته"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "هندی"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "مجاری"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "افزایش زوم"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "اندونزیایی"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "صادرکننده"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "ایتالیایی"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "ایتالیک"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "ژاپنی"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "تراز دوطرفه"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "کانادا"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "با هم باشید"
+msgstr "با هم نگه دارید"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "کلیدواژه‌ها"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "خمری"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "کره‌ای"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "آخرین‌بار در {0} مشاهده شد"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "لتونیایی"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "لیست"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "لیتوانیایی"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "در حال بارگذاری ارائه دهندگان هوش مصنوع
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "بارگیری برنامه‌ها…"
+msgstr "بارگیری درخواست‌ها…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "در حال بارگذاری رزومه‌ها…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "در حال بارگذاری موضوعات…"
+msgstr "در حال بارگذاری گفتگوها…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "بخش تجربه را نتیجه‌گراتر کنید و مسئولی�
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "مالایی"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "مالایالام"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "مراتی"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "نام"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "نپالی"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "شبکه"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "برنامه جدید"
+msgstr "درخواست جدید"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "برچسب جدید…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "تاپیک جدید"
+msgstr "گفتگوی جدید"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "موضوع جدید"
+msgstr "گفتگوی جدید"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2956,11 +2956,11 @@ msgstr "هیچ ارائه دهنده آزمایش شده ای وجود ندار�
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "هنوز هیچ تاپیکی وجود ندارد."
+msgstr "هنوز هیچ گفتگویی وجود ندارد."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "نروژی"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "یادداشت‌ها"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "اودیایی"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "باز کردن"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "عامل هوش مصنوعی باز"
+msgstr "باز کردن عامل هوش مصنوعی"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "سازگار با OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3272,7 +3272,7 @@ msgstr "لطفا منتظر بمانید تا PDF شما تولید شود…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "لهستانی"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "عمودی"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "پرتغالی (برزیل)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "پرتغالی (پرتغال)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - رفتن به صفحهٔ اصلی"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "رزومهٔ واکنشی (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "رزومه واکنشی نسخه<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "رزومهٔ واکنشی نسخهٔ ۴ (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "پیشرفت نقش"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "رومانیایی"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "اولین تحلیل خود را اجرا کنید تا کارت امت
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "روسی"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3846,7 +3846,7 @@ msgstr "انتخاب رزومه"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "یک رشته انتخاب کنید"
+msgstr "یک گفتگو انتخاب کنید"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "جداکننده"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "صربی"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "یک ارائه دهنده هوش مصنوعی راه اندازی کن�
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "قبل از شروع یک تاپیک، یک ارائه دهنده هوش مصنوعی تنظیم کنید."
+msgstr "قبل از شروع یک گفتگو، یک ارائه دهنده هوش مصنوعی تنظیم کنید."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "رفتن به محتوای اصلی"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "اسلواکی"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "اسلوونیایی"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "فاصله (عمودی)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "اسپانیایی"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "در GitHub برای ما ستاره بگذارید، در حال حاض
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "شروع یک تاپیک جدید"
+msgstr "شروع یک گفتگوی جدید"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "شروع یک تاپیک"
+msgstr "شروع یک گفتگو"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "ساخت رزومه خود را از صفر شروع کنید"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "شروع تاپیک جدید"
+msgstr "شروع گفتگوی جدید"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "شروع در صفحه جدید"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "شروع تاپیک"
+msgstr "شروع گفتگو"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4223,7 +4223,7 @@ msgstr "آمارها"
 
 #: src/hooks/use-form-blocker.tsx
 msgid "Stay"
-msgstr "ماندن"
+msgstr "بمان"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Stop generation"
@@ -4276,7 +4276,7 @@ msgstr "با هر کاری که می‌توانید از اپ حمایت کنی�
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "سوئدی"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "تنظیم ناموفق بود."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "تامیلی"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "تلوگویی"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "رنگ متن"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "تایلندی"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4372,7 +4372,7 @@ msgstr "با تشکر از حامیان مالی ما"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "The agent needs your input."
-msgstr "نماینده به نظرات شما نیاز دارد."
+msgstr "عامل به نظرات شما نیاز دارد."
 
 #. Error description when AI returns invalid resume analysis format
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
@@ -4419,7 +4419,7 @@ msgstr "URL وارد شده معتبر نیست."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "رزومه کاری حذف شد. این تاپیک فقط خواندنی است."
+msgstr "رزومه کاری حذف شد. این گفتگو فقط خواندنی است."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4464,11 +4464,11 @@ msgstr "این اقدام قابل بازگشت نیست. پیام‌های مک
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
-msgstr "این اقدام قابل بازگشت نیست. پیام‌ها و پیوست‌های تاپیک حذف خواهند شد."
+msgstr "این اقدام قابل بازگشت نیست. پیام‌ها و پیوست‌های گفتگو حذف خواهند شد."
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "این تاپیک مربوط به نماینده قابل باز شدن نیست."
+msgstr "این گفتگوی عامل قابل باز شدن نیست."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "این مرحله اختیاری است، اما توصیه می‌شو�
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "این تاپیک بایگانی شده است. پیام جدید قابل ارسال نیست."
+msgstr "این گفتگو بایگانی شده است. پیام جدید قابل ارسال نیست."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "این تاپیک فقط خواندنی است"
+msgstr "این گفتگو فقط خواندنی است"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "این تاپیک فقط خواندنی است زیرا رزومه کاری یا ارائه دهنده هوش مصنوعی در دسترس نیست."
+msgstr "این گفتگو فقط خواندنی است زیرا رزومه کاری یا ارائه دهنده هوش مصنوعی در دسترس نیست."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,22 +4545,22 @@ msgstr "این همه موارد را از این بخش حذف خواهد کر�
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "اقدامات نخ"
+msgstr "اقدامات گفتگو"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "تاپیک بایگانی شد."
+msgstr "گفتگو بایگانی شد."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "تاپیک حذف شد."
+msgstr "گفتگو حذف شد."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "موضوعات"
+msgstr "گفتگوها"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "گوشه‌ای کردن نوار کناری راست"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "تغییر وضعیت موضوعات"
+msgstr "تغییر وضعیت گفتگوها"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4647,7 +4647,7 @@ msgstr "دوباره امتحان کنید"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "ترکی"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "تایپوگرافی"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "اوکراینی"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "کاربران"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "ازبکی"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "تاریخچه نسخه"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "ویتنامی"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "کوچک‌نمایی"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "زولو"
+msgstr "isiZulu"
 

--- a/apps/web/locales/fa-IR.po
+++ b/apps/web/locales/fa-IR.po
@@ -401,7 +401,7 @@ msgstr "و بسیاری موارد دیگر..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "کلود آنتروپیک"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "تراز وسط"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "مغزها"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "دستیار هوش مصنوعی را ببندید"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "کوهر"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "کاهش زوم"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "جستجوی عمیق"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "فنلاندی"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "آتش بازی"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "گوگل"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "گوگل جمینای"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "جدول"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "گروک"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "رزومه کاری موجود نیست"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "هوش مصنوعی میسترال"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "اودیایی"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ابر اولاما"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "متن‌باز"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "اوپن‌ای‌آی"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "سازگار با OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "روتر آزاد"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "دوره"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "سرگشتگی"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "URLهای معتبر باید با http:// یا https:// شروع شون
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "دروازه ورچل ای‌آی"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "ایکس (توییتر)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI گروک"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/fa-IR.po
+++ b/apps/web/locales/fa-IR.po
@@ -2377,7 +2377,7 @@ msgstr "افزایش زوم"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/fi-FI.po
+++ b/apps/web/locales/fi-FI.po
@@ -315,7 +315,7 @@ msgstr "Edistynyt"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "afrikaans"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -344,7 +344,7 @@ msgstr "Tekoälyagentin asetukset eivät ole käytettävissä, ennen kuin REDIS_
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "Tekoälyavustaja"
+msgstr "AI-avustaja"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "Tekoälypalveluntarjoajat vaativat REDIS_URL- ja ENCRYPTION_SECRET-mää
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "albania"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Onko sinulla jo tili? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "amhara"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Hakemus poistettu."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Sovelluksen tilastot"
+msgstr "Hakemusten tilastot"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Käytetty varoituksilla"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "arabia"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Palkinnot"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "azeri"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Kauniita mallipohjia, joista valita – ja lisää tulossa."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Paras sovelluksiin, jakamiseen ja tulostamiseen."
+msgstr "Paras hakemuksiin, jakamiseen ja tulostamiseen."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Rakentajan komentopaletti"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "bulgaria"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Ei voida palauttaa; ansioluettelo on muuttunut tämän muokkauksen jälk
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "katalaani"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Luonnoksen tarkistaminen"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "kiina (yksinkertaistettu)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "kiina (perinteinen)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Ympyrä"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Kirkas"
+msgstr "Tyhjennä"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Mukautetut tyylit"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "tšekki"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Vaaravyöhyke"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "tanska"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "Monistetaan ansioluetteloasi..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "hollanti"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Kaksivaiheisen todennuksen käyttöönotto…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "englanti"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Englanti (Yhdistynyt kuningaskunta)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1861,7 +1861,7 @@ msgstr "Salasanan palauttaminen epäonnistui. Yritä uudelleen."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "Tekoälypalveluntarjoajan tallentaminen epäonnistui."
+msgstr "AI-palveluntarjoajan tallentaminen epäonnistui."
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -1963,7 +1963,7 @@ msgstr "Etsi heikkoja luettelokohtia ja kirjoita ne uudelleen vahvemmilla tuloks
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "suomi"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Vapaamuotoinen"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "ranska"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Luo satunnainen nimi"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "saksa"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Saat ansioluettelostasi katsauksen, joka sisältää kokonaispisteet, va
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Saat ansioluettelostasi perusteellisen tekoälypohjaisen katsauksen, joka sisältää kokonaisarvosanan, tärkeimmät vahvuudet ja käytännön ehdotuksia. Voit aktivoida tämän ominaisuuden päivittämällä tekoälyasetukset."
+msgstr "Saat ansioluettelostasi perusteellisen AI-pohjaisen katsauksen, joka sisältää kokonaisarvosanan, tärkeimmät vahvuudet ja käytännön ehdotuksia. Voit aktivoida tämän ominaisuuden päivittämällä AI-asetukset."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,13 +2116,13 @@ msgstr "Palaa takaisin"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Mene kotiin"
+msgstr "Siirry etusivulle"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Siirry hallintapaneeliin"
+msgstr "Siirry kojelautaan"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "Arvosana"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "kreikka"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Kuvausteksti"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "heprea"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Korostusväri"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://yhdyskäytävä.esimerkki.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "unkari"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2353,7 +2353,7 @@ msgstr "Tuotiin {0} hakemus(ta)."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "PDF- tai Word-tiedostoista tuominen edellyttää yhdistettyä tekoälypalveluntarjoajaa."
+msgstr "PDF- tai Word-tiedostoista tuominen edellyttää yhdistettyä AI-palveluntarjoajaa."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Lisää zoomausta"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "indonesia"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Myöntäjä"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "italia"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kursiivi"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "japani"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Tasaa molemmat reunat"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Pysykää yhdessä"
+msgstr "Pidä yhdessä"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Avainsanat"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "korea"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Viimeksi katsottu {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "latvia"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Lista"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "liettua"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Ladataan tekoälypalveluntarjoajia. Yritä uudelleen hetken kuluttua."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Sovellusten lataaminen…"
+msgstr "Hakemusten lataaminen…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Tee kokemusosiosta tuloskeskeisempi ja poista epämääräiset vastuualu
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "malaiji"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "malajalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Nimi"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "nepali"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2960,7 +2960,7 @@ msgstr "Ei vielä ketjuja."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "norja"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Muistiinpanot"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Avaa"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Avoin tekoälyagentti"
+msgstr "Avaa tekoälyagentti"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-yhteensopiva"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "persia"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Odota hetki, PDF-tiedostoasi luodaan…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "puola"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Pysty"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "portugali (Brasilia)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "portugali (Portugali)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume – Siirry etusivulle"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktiivinen ansioluettelo (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktiivinen ansioluettelo v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktiivinen ansioluettelo v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Roolin eteneminen"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "romania"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Suorita ensimmäinen analyysi, jotta saat tuloskortin, vahvuudet ja prio
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "venäjä"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "Erotin"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "serbia"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Siirry suoraan pääsisältöön"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "slovakki"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Sloveeni"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Väli (pysty)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "espanja"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Tue sovellusta parhaasi mukaan!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "ruotsi"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Mukauttaminen epäonnistui."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "tamili"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Tekstiväri"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4460,7 +4460,7 @@ msgstr "Tätä toimintoa ei voi perua. Kaikki tietosi poistetaan pysyvästi."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "Tätä toimintoa ei voi perua. Keskusteluviestit ja ladatut liitteet poistetaan. Työansioluettelo pysyy hallintapaneelissasi ja se voidaan poistaa erikseen."
+msgstr "Tätä toimintoa ei voi perua. Keskusteluviestit ja ladatut liitteet poistetaan. Työansioluettelo pysyy kojelautaasi ja se voidaan poistaa erikseen."
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
@@ -4647,7 +4647,7 @@ msgstr "Yritä uudelleen"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "turkki"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typografia"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "ukraina"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Käyttäjät"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "uzbekki"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Versiohistoria"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "vietnam"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Loitonna"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/fi-FI.po
+++ b/apps/web/locales/fi-FI.po
@@ -2377,7 +2377,7 @@ msgstr "Lisää zoomausta"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -4460,7 +4460,7 @@ msgstr "Tätä toimintoa ei voi perua. Kaikki tietosi poistetaan pysyvästi."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "Tätä toimintoa ei voi perua. Keskusteluviestit ja ladatut liitteet poistetaan. Työansioluettelo pysyy kojelautaasi ja se voidaan poistaa erikseen."
+msgstr "Tätä toimintoa ei voi perua. Keskusteluviestit ja ladatut liitteet poistetaan. Työansioluettelo pysyy kojelaudallasi ja se voidaan poistaa erikseen."
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."

--- a/apps/web/locales/fi-FI.po
+++ b/apps/web/locales/fi-FI.po
@@ -401,7 +401,7 @@ msgstr "Ja paljon muuta..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antrooppinen Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Keskitä"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Aivot"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Sulje tekoälyavustaja"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Koheroitua"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Ilotulitus"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2797,7 +2797,7 @@ msgstr "Puuttuva työansioluettelo"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Mistral-tekoäly"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -3207,7 +3207,7 @@ msgstr "Ajanjakso"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Hämmennys"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Poistaaksesi tilisi sinun täytyy syöttää vahvistusteksti ja napsautt
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Yhdessä.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/fr-FR.po
+++ b/apps/web/locales/fr-FR.po
@@ -768,7 +768,7 @@ msgstr "Alignement centré"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Cerveaux"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Assistant IA proche"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Adhérer"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finnois"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Feux d'artifice"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2797,7 +2797,7 @@ msgstr "CV professionnel manquant"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Mistral IA"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Nuage Ollama"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Période"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Perplexité"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Pour supprimer votre compte, vous devez saisir le texte de confirmation 
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Ensemble.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "Les URL valides doivent commencer par http:// ou https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Passerelle Vercel AI"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/fr-FR.po
+++ b/apps/web/locales/fr-FR.po
@@ -2377,7 +2377,7 @@ msgstr "Augmenter le zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/fr-FR.po
+++ b/apps/web/locales/fr-FR.po
@@ -260,7 +260,7 @@ msgstr "Ajoutez une étiquette et appuyez sur Entrée…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Ajoutez et testez un fournisseur avant de démarrer un thread d'agent."
+msgstr "Ajoutez et testez un fournisseur avant de démarrer une conversation d'agent."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -364,7 +364,7 @@ msgstr "Les fournisseurs d'IA exigent la configuration de REDIS_URL et ENCRYPTIO
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanais"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Vous avez déjà un compte ? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharique"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Candidature supprimée."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Statistiques d'application"
+msgstr "Statistiques des candidatures"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Appliqué avec avertissements"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabe"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Récompenses"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaïdjanais"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Vous avez le choix parmi de magnifiques modèles, et d'autres sont en co
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Idéal pour les applications, le partage et l'impression."
+msgstr "Idéal pour les candidatures, le partage et l'impression."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Palette de commandes du créateur"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgare"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Impossible de restaurer le CV ; il a été modifié depuis cette modifi
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalan"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Vérification du brouillon"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chinois (simplifié)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chinois (traditionnel)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Choisissez un CV"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Choisissez une conversation existante dans la barre latérale, ou créez une nouvelle discussion axée sur les brouillons."
+msgstr "Choisissez une conversation existante dans la barre latérale, ou créez une nouvelle conversation axée sur les brouillons."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "Cercle"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Clair"
+msgstr "Effacer"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Styles personnalisés"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Tchèque"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Zone dangereuse"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danois"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Supprimer le fournisseur"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Supprimer ce fil de discussion de l'agent ?"
+msgstr "Supprimer cette conversation de l'agent ?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1548,7 +1548,7 @@ msgstr "Duplication de votre CV..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Néerlandais"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Activation de l'authentification à deux facteurs…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Anglais"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Anglais (Royaume-Uni)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Échec de l'analyse du curriculum vitae."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Impossible d'archiver la discussion."
+msgstr "Impossible d'archiver la conversation."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Échec de la suppression de la clé API. Veuillez réessayer."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Impossible de supprimer la discussion."
+msgstr "Impossible de supprimer la conversation."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Échec de la déconnexion. Veuillez réessayer."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Échec du démarrage du thread de l'agent."
+msgstr "Échec du démarrage de la conversation de l'agent."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Repérez les points faibles et reformulez-les avec des résultats, des c
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finnois"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Ajuster à la vue"
+msgstr "Ajuster à l'affichage"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2087,7 +2087,7 @@ msgstr "Générer un nom aléatoire"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Allemand"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Obtenez un examen de votre CV avec une note globale, des points forts et
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Obtenez un examen approfondi de votre CV par l'IA, avec une note globale, des points forts et des suggestions pratiques. Pour activer cette fonctionnalité, veuillez mettre à jour vos paramètres d'intelligence artificielle."
+msgstr "Obtenez un examen approfondi de votre CV par l'IA, avec une note globale, des points forts et des suggestions pratiques. Pour activer cette fonctionnalité, veuillez mettre à jour vos paramètres d'IA."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,7 +2116,7 @@ msgstr "Revenir en arrière"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Rentrez chez vous"
+msgstr "Retour à l'accueil"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Note"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Grec"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Titre professionnel"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hébreu"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Couleur de surbrillance"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Hongrois"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "Augmenter le zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonésien"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Émetteur"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italien"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Italique"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japonais"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Alignement justifié"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Restez ensemble"
+msgstr "Garder sur la même page"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Mots-clés"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Cambodgien/Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Coréen"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Dernière consultation le {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Letton"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Liste"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lithuanien"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Chargement des fournisseurs d'IA. Veuillez réessayer dans un instant."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Chargement des applications…"
+msgstr "Chargement des candidatures…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Le chargement reprend…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Chargement des threads…"
+msgstr "Chargement des conversations…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Rendez la section relative à l'expérience plus axée sur les résultat
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malaisien"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Nom"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Népalais"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Réseau"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Nouvelle demande"
+msgstr "Nouvelle candidature"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "Nouvelle étiquette…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Nouveau sujet"
+msgstr "Nouvelle conversation"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Nouveau sujet"
+msgstr "Nouvelle conversation"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2956,11 +2956,11 @@ msgstr "Fournisseur non testé"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Aucun sujet de discussion pour l'instant."
+msgstr "Aucune conversation pour le moment."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norvégien"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Notes"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Ouvrir"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Agent Open AI"
+msgstr "Ouvrir l'agent IA"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Compatible avec OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persan"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Veuillez patienter pendant la génération de votre PDF…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polonais"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portrait"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugais (Brésil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugais (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3681,7 +3681,7 @@ msgstr "Progression de poste"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Roumain"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Effectuez votre première analyse pour obtenir un tableau de bord, des p
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russe"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3846,7 +3846,7 @@ msgstr "Sélectionnez un CV"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "Sélectionnez une discussion"
+msgstr "Sélectionnez une conversation"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "Séparateur"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbe"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Mettre en place un fournisseur d'IA"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Configurez un fournisseur d'IA avant de démarrer un thread."
+msgstr "Configurez un fournisseur d'IA avant de démarrer une conversation."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Passer au contenu principal"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovaque"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovène"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Espacement (vertical)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Espagnol"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "Ajoutez-nous en favori sur GitHub, actuellement {0} étoiles (s'ouvre da
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Créer une nouvelle discussion"
+msgstr "Créer une nouvelle conversation"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Créer une discussion"
+msgstr "Créer une conversation"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Commencez à rédiger votre CV en partant de zéro"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Créer une nouvelle discussion"
+msgstr "Créer une nouvelle conversation"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Commencer sur une nouvelle page"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Créer un sujet"
+msgstr "Créer une conversation"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Soutenez l'application en donnant ce que vous pouvez !"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Suédois"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "L'adaptation a échoué."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamoul"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Télugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Couleur du texte"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thaïlandais"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "L'URL que vous avez saisie n'est pas valide."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Le CV a été supprimé. Cette discussion est en lecture seule."
+msgstr "Le CV a été supprimé. Cette conversation est en lecture seule."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4468,7 +4468,7 @@ msgstr "Cette action est irréversible. Les messages et les pièces jointes sero
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Impossible d'ouvrir cette discussion avec cet agent."
+msgstr "Impossible d'ouvrir cette conversation avec cet agent."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "Cette étape est facultative, mais recommandée."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Cette discussion est archivée. Il n'est plus possible d'envoyer de nouveaux messages."
+msgstr "Cette conversation est archivée. Il n'est plus possible d'envoyer de nouveaux messages."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Ce fil de discussion est en lecture seule"
+msgstr "Cette conversation est en lecture seule"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Ce fil de discussion est en lecture seule car le fournisseur de CV ou d'IA est indisponible."
+msgstr "Cette conversation est en lecture seule car le fournisseur de CV ou d'IA est indisponible."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,22 +4545,22 @@ msgstr "Cette opération permet de supprimer tous les éléments de cette sectio
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "Actions du fil de discussion"
+msgstr "Actions de la conversation"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Discussion archivée."
+msgstr "Conversation archivée."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Sujet supprimé."
+msgstr "Conversation supprimée."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Fils"
+msgstr "Conversations"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "Barre latérale droite"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Basculer les fils"
+msgstr "Basculer les conversations"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4647,7 +4647,7 @@ msgstr "Essayer à nouveau"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turc"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typographie"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrainien"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Utilisateurs"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Ouzbékistanais"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Historique des versions"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamien"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Zoom arrière"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zoulou"
+msgstr "isiZulu"
 

--- a/apps/web/locales/he-IL.po
+++ b/apps/web/locales/he-IL.po
@@ -2377,7 +2377,7 @@ msgstr "הגדלת הזום"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/he-IL.po
+++ b/apps/web/locales/he-IL.po
@@ -315,7 +315,7 @@ msgstr "מִתקַדֵם"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "אפריקאנס"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "ספקי בינה מלאכותית דורשים הגדרה של REDIS_UR
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "אלבנית"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "כבר יש לך חשבון? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "אמהרית"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "המועמדות נמחקה."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "סטטיסטיקת היישום"
+msgstr "סטטיסטיקת מועמדויות"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "יושם עם אזהרות"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "ערבית"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -591,7 +591,7 @@ msgstr "צרף קבצים"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment"
-msgstr "הִתקַשְׁרוּת"
+msgstr "קובץ מצורף"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment uploaded."
@@ -628,7 +628,7 @@ msgstr "פרסים"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "אזרית"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "תבניות יפות לבחירה, ועוד תבניות בדרך."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "בנגלית"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "לוח פקודות הבונה"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "בולגרית"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "לא ניתן לשחזר; קורות החיים השתנו מאז שהע
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "קטלאנית"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "בודק טיוטה"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "סינית (מופשטת)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "סינית (מסורתית)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1278,7 +1278,7 @@ msgstr "סגנונות מותאמים אישית"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "צ׳כית"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "אזור מסוכן"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "דנית"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "משכפל את קורות החיים שלך..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "הולנדית"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "הפעלת אימות דו-שלבי…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "אנגלית"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "אנגלית (בריטניה)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "מצא נקודות תבליט חלשות וכתוב אותן מחדש �
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "פינית"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "התאמה לתצוגה"
+msgstr "התאם לתצוגה"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "צורה חופשית"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "צרפתית"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "יצירת שם אקראי"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "גרמנית"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,18 +2116,18 @@ msgstr "חזרה"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "לך הביתה"
+msgstr "חזרה לדף הבית"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "מעבר ללוח בקרה"
+msgstr "מעבר ללוח מחוונים"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "עבור למרכז השליטה בקורות החיים"
+msgstr "עבור ללוח המחוונים של קורות החיים"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "ציון"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "יוונית"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2282,7 +2282,7 @@ msgstr "צבע סימון"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "הינדי"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "הונגרית"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "הגדלת הזום"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "אינדונזית"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "מנפיק"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "איטלקית"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "נטוי"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "יפנית"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "יישור לשני הצדדים"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "קנאדה"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "להישאר יחד"
+msgstr "שמור יחד"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "מילות מפתח"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "חמרית"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "קוריאנית"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "נצפה לאחרונה בתאריך {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "לטבית"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "רשימה"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "ליטאית"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "טוען ספקי בינה מלאכותית. אנא נסה שוב בעו
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "טוען אפליקציות…"
+msgstr "טוען מועמדויות…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "הפוך את מדור הניסיון לממוקד יותר בתוצאו
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "מלאית"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "מליאלאם"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "מרטהית"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "שם"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "נפאלית"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "רשת"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "יישום חדש"
+msgstr "מועמדות חדשה"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2960,7 +2960,7 @@ msgstr "עדיין אין שרשורים."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "נורווגית"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "הערות"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "אודיה"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "פתיחה"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "סוכן בינה מלאכותית פתוח"
+msgstr "פתח סוכן בינה מלאכותית"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "תואם ל-OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "פרסית"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "אנא המתן בזמן יצירת קובץ ה-PDF שלך…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "פולנית"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "לאורך"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "פורטוגזית (ברזיל)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "פורטוגזית (פורטוגל)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - מעבר לדף הבית"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "קורות חיים תגובתיים (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "קורות חיים ריאקטיביים v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "קורות חיים תגובתיים גרסה 4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "התקדמות בתפקיד"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "רומנית"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "בצע את הניתוח הראשון שלך כדי לקבל דוח בי
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "רוסית"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "מפריד"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "סרבית"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "דלג לתוכן העיקרי"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "סלובקית"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "סלובנית"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "ריווח (אנכי)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "ספרדית"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "אפשר לתמוך ביישום על ידי עשייה בכל דרך ש
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "שוודית"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "ההתאמה נכשלה."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "טמילית"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "טלוגו"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "צבע כתב"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "תאית"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "נסה שוב"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "טורקית"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "טיפוגרפיה"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "אוקראינית"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "משתמשים"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "אוזבקית"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "היסטוריית גרסאות"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "וייטנאמית"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "התרחקות"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "זולו"
+msgstr "isiZulu"
 

--- a/apps/web/locales/he-IL.po
+++ b/apps/web/locales/he-IL.po
@@ -401,7 +401,7 @@ msgstr "ועוד שלל יכולות…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "קלוד האנתרופי"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "יישור למרכז"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "מוח"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "סגור את עוזר הבינה המלאכותית"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "לִדבּוֹק יָחָד"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "הקטנת הזום"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "דיפקייק"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "פינית"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "זיקוקים"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "גוגל"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "גוגל ג'מיני"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "רשת"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "גרוק"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "קורות חיים חסרים"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "מיסטרל בינה מלאכותית"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "אודיה"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "אולמה קלאוד"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "תקופה"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "מְבוּכָה"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "כדי למחוק את החשבון שלך, עליך להזין את ט�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "יחד.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -5063,7 +5063,7 @@ msgstr "איקס (טוויטר)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI גרוק"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/hi-IN.po
+++ b/apps/web/locales/hi-IN.po
@@ -2377,7 +2377,7 @@ msgstr "ज़ूम बढ़ाएँ"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/hi-IN.po
+++ b/apps/web/locales/hi-IN.po
@@ -311,16 +311,16 @@ msgstr "ऐसे रिमोट-फर्स्ट रोल के लिए 
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "विकसित"
+msgstr "उन्नत"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "अफ्रीकान्स"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Agent"
-msgstr "प्रतिनिधि"
+msgstr "एजेंट"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Agent ready"
@@ -364,7 +364,7 @@ msgstr "एआई प्रदाताओं को REDIS_URL और ENCRYPTION
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "अल्बानियाई"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "पहले से खाता है? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "अमहारी"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "आवेदन हटाया गया।"
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "ऐप आँकड़े"
+msgstr "आवेदन आँकड़े"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "चेतावनी सहित लागू"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "अरबी"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -591,7 +591,7 @@ msgstr "फ़ाइलों को संलग्न करें"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment"
-msgstr "लगाव"
+msgstr "संलग्नक"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment uploaded."
@@ -628,7 +628,7 @@ msgstr "पुरस्कार"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "अज़रबैजानी"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "सुंदर खाके जिनमें से चुन सक�
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "बंगाली"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "बिल्डर कमांड पैलेट"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "बुल्गारियाई"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "इसे पुनर्स्थापित नहीं किया
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "कातालान"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "मसौदे की जाँच"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "चीनी (सरलीकृत)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "चीनी (परंपरागत)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "गोला"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "स्पष्ट"
+msgstr "साफ़ करें"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "कस्टम शैलियाँ"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "चेक"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "खतरनाक क्षेत्र"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "डेनिश"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "आपका रेज़्यूमे डुप्लिकेट क
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "डच"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "दो-कारक प्रमाणीकरण सक्षम क�
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "अंग्रेज़ी"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "अंग्रेज़ी (यूनाइटेड किंगडम)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "कमजोर बिंदुओं को पहचानें औ�
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "फिनिश"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "देखने के लिए उपयुक्त"
+msgstr "दृश्य के लिए समायोजित करें"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "मुफ्त फॉर्म"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "फ़्रेंच"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "कोई रैंडम नाम बनाएँ"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "जर्मन"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "वापस जाएँ"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "घर जाओ"
+msgstr "होम पेज पर जाएँ"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "ग्रेड"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "ग्रीक"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "हेडलाइन"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "हीब्रू"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "हंगेरियन"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "ज़ूम बढ़ाएँ"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "इंडोनेशियाई"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "ज़ारीकर्ता"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "इतालवी"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "इटैलिक"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "जापानी"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "जस्टिफ़ाई अलाइन"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "कन्नड़"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "खोजशब्द"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "खमेर"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "कोरियाई"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "आखिरी बार {0} को देखा गया"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "लातवियाई"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "सूची"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "लिथुआनियाई"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "एआई प्रदाताओं को लोड किया ज�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "एप्लिकेशन लोड हो रहे हैं…"
+msgstr "आवेदन लोड हो रहे हैं…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,11 +2754,11 @@ msgstr "अनुभव अनुभाग को अधिक परिणा�
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "मलय"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "मलयालम"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
@@ -2857,7 +2857,7 @@ msgstr "नेटवर्क"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "नए आवेदन"
+msgstr "नया आवेदन"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2960,7 +2960,7 @@ msgstr "अभी तक कोई थ्रेड नहीं है।"
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "नॉर्वेजियन"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "टिप्पणियाँ"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "ओड़िया"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "खोलें"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "ओपन एआई एजेंट"
+msgstr "एआई एजेंट खोलें"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "ओपनएआई-संगत"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "फ़ारसी"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "कृपया प्रतीक्षा करें, आपकी �
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "पोलिश"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "व्यक्तिचित्र"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "पुर्तगाली (ब्राज़ील)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "पुर्तगाली (पुर्तगाल)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - होमपेज पर जाएँ"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "प्रतिक्रियाशील रिज़्यूमे (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "रिएक्टिव रिज्यूम v<0>{__APP_VERSION__}</0>
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "प्रतिक्रियाशील रिज़्यूमे v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "भूमिका प्रगति"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "रोमानियाई"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "अपना पहला विश्लेषण चलाएँ त�
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "रूसी"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "सेपरेटर"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "सर्बियाई"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4057,7 +4057,7 @@ msgstr "रजिस्ट्रेशन..."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a magenta left border accent; compact and efficient for entry-level or internship applications."
-msgstr "मैजेंटा बाएँ बॉर्डर एक्सेंट के साथ सिंगल‑कॉलम; एंट्री‑लेवल या इंटर्नशिप एप्लिकेशन के लिए कॉम्पैक्ट और प्रभावी।"
+msgstr "मैजेंटा बाएँ बॉर्डर एक्सेंट के साथ सिंगल‑कॉलम; एंट्री‑लेवल या इंटर्नशिप आवेदन के लिए कॉम्पैक्ट और प्रभावी।"
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a minimal top header and lots of whitespace; clean and modern for designers or content creators."
@@ -4098,11 +4098,11 @@ msgstr "मुख्य सामग्री पर जाएँ"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "स्लोवाक"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "स्लोवेनियाई"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "स्पेसिंग (ऊर्ध्वाधर)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "स्पेनिश"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4193,7 +4193,7 @@ msgstr "एक नया थ्रेड शुरू करें"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "एक चर्चा शुरू करें"
+msgstr "एक थ्रेड शुरू करें"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4276,7 +4276,7 @@ msgstr "जो आप कर सकते हैं वह करके ऐप �
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "स्वीडिश"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "अनुकूलन विफल रहा।"
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "तमिल"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "तेलुगु"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "अक्षरों का रंग"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "थाई"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4560,7 +4560,7 @@ msgstr "थ्रेड डिलीट कर दिया गया।"
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "धागे"
+msgstr "थ्रेड"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4647,7 +4647,7 @@ msgstr "पुनः प्रयास करें"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "तुर्की"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4683,7 +4683,7 @@ msgstr "सूक्ष्म सेक्शन डिवाइडर के �
 
 #: src/dialogs/resume/template/data.ts
 msgid "Two-column, minimal and text-dense with no decorative elements; perfect for traditional industries or ATS-heavy applications."
-msgstr "कोई सजावटी तत्व नहीं होने के साथ न्यूनतम और टेक्स्ट‑घना दो‑कॉलम; पारंपरिक उद्योगों या ATS‑केंद्रित एप्लिकेशन के लिए बिल्कुल उपयुक्त।"
+msgstr "कोई सजावटी तत्व नहीं होने के साथ न्यूनतम और टेक्स्ट‑घना दो‑कॉलम; पारंपरिक उद्योगों या ATS‑केंद्रित आवेदन के लिए बिल्कुल उपयुक्त।"
 
 #: src/dialogs/resume/template/data.ts
 msgid "Two-column, minimal with light gray sidebar and subtle icons; professional and understated for legal, finance, or executive roles."
@@ -4728,7 +4728,7 @@ msgstr "टाइपोग्राफी"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "यूक्रेनी"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "उपयोगकर्ता"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "उज़्बेक"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "संस्करण इतिहास"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "वियतनामी"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "ज़ूम आउट"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "ज़ुलु"
+msgstr "isiZulu"
 

--- a/apps/web/locales/hi-IN.po
+++ b/apps/web/locales/hi-IN.po
@@ -401,7 +401,7 @@ msgstr "और भी कई..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "एन्थ्रोपिक क्लॉड"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "मध्य में संरेखित करें"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "मस्तिष्क"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "एआई सहायक को बंद करें"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "जुटना"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "ज़ूम कम करें"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "डीपसीक"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "फिनिश"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "आतिशबाजी"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "गूगल"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "गूगल जेमिनी"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "ग्रिड"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "ग्रोक"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "कार्य संबंधी रिज्यूमे गुम �
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "मिस्ट्रल एआई"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "ओड़िया"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ओलामा क्लाउड"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "खुला स्त्रोत"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "ओपनएआई"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "ओपनएआई-संगत"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "ओपनराउटर"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "अवधि"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "विकलता"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "मान्य URL http:// या https:// से शुरू हो�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "वर्सेल एआई गेटवे"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "एक्स (ट्विटर)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI ग्रोक"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/hu-HU.po
+++ b/apps/web/locales/hu-HU.po
@@ -2377,7 +2377,7 @@ msgstr "Nagyítás növelése"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -3720,7 +3720,7 @@ msgstr "Mentés"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Save & Test Provider"
-msgstr "Mentés és tesztelés szolgáltatója"
+msgstr "Szolgáltató mentése és tesztelése"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Save & Upload"

--- a/apps/web/locales/hu-HU.po
+++ b/apps/web/locales/hu-HU.po
@@ -401,7 +401,7 @@ msgstr "– És még sok más..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropikus Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Középre igazítás"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Agy"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Bezárás AI asszisztens"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Összefügg"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "finn"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Tűzijáték"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2797,7 +2797,7 @@ msgstr "Hiányzó munkaköri önéletrajz"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Mistral mesterséges intelligencia"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -3207,7 +3207,7 @@ msgstr "Időszak"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Zavar"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "A fiókod törléséhez add meg a megerősítő szöveget, majd kattints
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Együtt.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/hu-HU.po
+++ b/apps/web/locales/hu-HU.po
@@ -260,7 +260,7 @@ msgstr "Adj hozzá egy címkét, majd nyomj Entert…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Adjon hozzá és teszteljen egy szolgáltatót egy ügynökszál indítása előtt."
+msgstr "Adjon hozzá és teszteljen egy szolgáltatót egy ügynökbeszélgetés indítása előtt."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -315,7 +315,7 @@ msgstr "Fejlett"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "afrikaans"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "A mesterséges intelligencia szolgáltatók megkövetelik a REDIS_URL é
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "albán"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Már van fiókja? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "amhara"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "A jelentkezés törölve."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Alkalmazásstatisztikák"
+msgstr "Jelentkezési statisztikák"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Figyelmeztetésekkel alkalmazva"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "arab"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Díjak"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "azerbajdzsáni"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Választható, gyönyörű sablonok, és még több érkezik."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "bangla"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Szerkesztő parancskereső"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "bolgár"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Nem lehet visszaállítani; az önéletrajz megváltozott a szerkesztés
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "katalán"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Vázlat ellenőrzése"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "kínai (egyszerűsített)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "kínai (hagyományos)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Kör"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Tiszta"
+msgstr "Törlés"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Egyéni stílusok"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "cseh"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Veszélyes terület"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "dán"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1302,7 +1302,7 @@ msgstr "Sötét téma"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Dashboard"
-msgstr "Műszerfal"
+msgstr "irányítópult"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Data Security"
@@ -1374,7 +1374,7 @@ msgstr "Szolgáltató törlése"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Törli ezt az ügynökszálat?"
+msgstr "Törli ezt az ügynökbeszélgetést?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1548,7 +1548,7 @@ msgstr "Önéletrajz duplikálása..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "holland"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Kétfaktoros hitelesítés engedélyezése…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Angol"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Angol (Egyesült Királyság)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Nem sikerült elemezni az önéletrajzot."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Nem sikerült archiválni a szálat."
+msgstr "Nem sikerült archiválni a beszélgetést."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Az API-kulcs törlése nem sikerült. Kérjük, próbálja újra."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Nem sikerült törölni a szálat."
+msgstr "Nem sikerült törölni a beszélgetést."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Nem sikerült kijelentkezni. Kérjük, próbálja meg újra."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Nem sikerült elindítani az ügynökszálat."
+msgstr "Nem sikerült elindítani az ügynökbeszélgetést."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Keress gyenge felsoroláspontokat, és írd át őket erősebb eredmény
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "finn"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Nézethez igazítva"
+msgstr "Nézetre igazítás"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Szabad formátumú"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "francia"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Véletlenszerű név generálása"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Német"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Vizsgálja meg önéletrajzát egy általános pontszámmal, erősségek
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Kap egy mélyreható, mesterséges intelligencia által vezérelt áttekintést az önéletrajzáról, általános pontszámmal, a legfontosabb erősségekkel és gyakorlati javaslatokkal. A funkció aktiválásához frissítse a mesterséges intelligencia beállításait."
+msgstr "Kap egy mélyreható, MI által vezérelt áttekintést az önéletrajzáról, általános pontszámmal, a legfontosabb erősségekkel és gyakorlati javaslatokkal. A funkció aktiválásához frissítse az MI-beállításokat."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,7 +2116,7 @@ msgstr "Vissza"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Menj haza"
+msgstr "Vissza a főoldalra"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2127,7 +2127,7 @@ msgstr "Tovább az irányítópultra"
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Menjen az önéletrajzok műszerfalára"
+msgstr "Menjen az önéletrajzok irányítópultjára"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Osztályzat"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "görög"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Főcím"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "héber"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Kiemelő szín"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "magyar"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2353,7 +2353,7 @@ msgstr "{0} jelentkezés importálva."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "A PDF vagy Word fájlokból történő importáláshoz csatlakoztatott mesterséges intelligencia szolgáltatóra van szükség."
+msgstr "A PDF vagy Word fájlokból történő importáláshoz csatlakoztatott MI-szolgáltatóra van szükség."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Nagyítás növelése"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "indonéz"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Kiállító"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "olasz"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Dőlt"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "japán"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Sorkizárt igazítás"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Tartsuk együtt"
+msgstr "Együtt tartás"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Kulcsszavak"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "koreai"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Utoljára megtekintve ekkor: {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "lett"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Lista"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "litván"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "MI-szolgáltatók betöltése folyamatban. Kérjük, próbálja újra eg
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Alkalmazások betöltése…"
+msgstr "Jelentkezések betöltése…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Önéletrajzok betöltése…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Szálak betöltése…"
+msgstr "Beszélgetések betöltése…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "A tapasztalati részt tedd eredményorientáltabbá, és távolítsd el 
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "maláj"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "malajálam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "maráthi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Név"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "nepáli"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2889,12 +2889,12 @@ msgstr "Új címke…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Új téma"
+msgstr "Új beszélgetés"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Új téma"
+msgstr "Új beszélgetés"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2956,11 +2956,11 @@ msgstr "Nincs tesztelt szolgáltató"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Még nincsenek témák."
+msgstr "Még nincsenek beszélgetések."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "norvég"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Jegyzetek"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "odija"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Megnyitás"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Nyílt AI-ügynök"
+msgstr "AI-ügynök megnyitása"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-kompatibilis"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "perzsa"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Kérjük, várjon, amíg a PDF-fájl generálása folyamatban van…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "lengyel"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Álló"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "portugál (Brazília)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "portugál (Portugália)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume – Ugrás a kezdőlapra"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktív önéletrajz (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktív önéletrajz v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktív önéletrajz v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Szerepkör-előmenetel"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Román"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Futtassa le az első elemzést, hogy kapjon egy értékelőlapot, erőss
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "orosz"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3846,7 +3846,7 @@ msgstr "Válasszon önéletrajzot"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "Válasszon egy szálat"
+msgstr "Válasszon egy beszélgetést"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "Elválasztó"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "szerb"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "MI-szolgáltató beállítása"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Állítson be egy AI-szolgáltatót egy szál indítása előtt."
+msgstr "Állítson be egy AI-szolgáltatót egy beszélgetés indítása előtt."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Ugrás a fő tartalomra"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "szlovák"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Szlovén"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Térköz (függőleges)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "spanyol"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "Adj csillagot nekünk GitHubon, jelenleg {0} csillag (új lapon nyílik 
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Új téma indítása"
+msgstr "Új beszélgetés indítása"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Indíts egy témát"
+msgstr "Indíts egy beszélgetést"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Kezdd el az önéletrajzod építését a nulláról"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Új téma indítása"
+msgstr "Új beszélgetés indítása"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Kezdés új oldalon"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Téma indítása"
+msgstr "Beszélgetés indítása"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4223,7 +4223,7 @@ msgstr "Statisztikák"
 
 #: src/hooks/use-form-blocker.tsx
 msgid "Stay"
-msgstr "Maradás"
+msgstr "Marad"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Stop generation"
@@ -4276,7 +4276,7 @@ msgstr "Támogasd az alkalmazást, amivel csak tudod!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "svéd"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "A testreszabás nem sikerült."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Szövegszín"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "A megadott URL érvénytelen."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "A munkaköri önéletrajz törölve. Ez a téma csak olvasható."
+msgstr "A munkaköri önéletrajz törölve. Ez a beszélgetés csak olvasható."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4468,7 +4468,7 @@ msgstr "Ez a művelet nem vonható vissza. Az üzenetek és a beszélgetésekhez
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Ez az ügynökszál nem nyitható meg."
+msgstr "Ez az ügynökbeszélgetés nem nyitható meg."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "Ez a lépés opcionális, de ajánlott."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Ez a téma archiválva van. Új üzenetek küldése nem lehetséges."
+msgstr "Ez a beszélgetés archiválva van. Új üzenetek küldése nem lehetséges."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Ez a szál csak olvasható"
+msgstr "Ez a beszélgetés csak olvasható"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Ez a téma csak olvasható, mert a működő önéletrajz vagy a mesterséges intelligencia szolgáltató nem érhető el."
+msgstr "Ez a beszélgetés csak olvasható, mert a működő önéletrajz vagy a mesterséges intelligencia szolgáltató nem érhető el."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,22 +4545,22 @@ msgstr "Ezzel az összes elemet eltávolítja ebből a szakaszból."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "Szálműveletek"
+msgstr "Beszélgetések műveletei"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "A téma archiválva."
+msgstr "A beszélgetés archiválva."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Téma törölve."
+msgstr "Beszélgetés törölve."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Szálak"
+msgstr "Beszélgetések"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "Jobb oldalsáv bekapcsolása"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Témák ki-/bekapcsolása"
+msgstr "Beszélgetések ki-/bekapcsolása"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4647,7 +4647,7 @@ msgstr "Próbáld újra"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "török"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipográfia"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "ukrán"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Felhasználók"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "üzbég"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Verzióelőzmények"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "vietnámi"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Kicsinyítés"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/id-ID.po
+++ b/apps/web/locales/id-ID.po
@@ -260,7 +260,7 @@ msgstr "Tambahkan tag lalu tekan Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Tambahkan dan uji penyedia sebelum memulai thread agen."
+msgstr "Tambahkan dan uji penyedia sebelum memulai utas agen."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -311,7 +311,7 @@ msgstr "Sesuaikan resume Anda untuk peran yang mengutamakan kerja jarak jauh dan
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "Canggih"
+msgstr "Lanjutan"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
@@ -332,7 +332,7 @@ msgstr "Agen"
 
 #: src/dialogs/resume/import.tsx
 msgid "AI"
-msgstr "Kecerdasan Buatan"
+msgstr "AI"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "AI agent setup is unavailable right now. Please try again in a moment."
@@ -364,7 +364,7 @@ msgstr "Penyedia AI memerlukan REDIS_URL dan ENCRYPTION_SECRET untuk dikonfigura
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albania"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Sudah punya akun? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharik"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Lamaran dihapus."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Statistik Aplikasi"
+msgstr "Statistik Lamaran"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Diterapkan dengan peringatan"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arab"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Penghargaan"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaijani"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Template indah untuk dipilih, dengan lebih banyak lagi yang akan datang.
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Palet Perintah Builder"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgaria"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Tidak dapat dipulihkan; resume telah berubah sejak perubahan ini diterap
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katala"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Memeriksa draf"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Cina (Sederhana)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Cina (Tradisional)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Lingkaran"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Jelas"
+msgstr "Bersihkan"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Gaya Kustom"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Ceko"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Zona Berbahaya"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Denmark"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "Menduplikasi resume Anda..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Belanda"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Mengaktifkan otentikasi dua faktor…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Inggris"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Inggris (Britania Raya)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Gagal menganalisis resume."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Thread gagal diarsipkan."
+msgstr "Utas gagal diarsipkan."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Gagal menghapus kunci API. Silakan coba lagi."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Gagal menghapus thread."
+msgstr "Gagal menghapus utas."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Gagal keluar. Silakan coba lagi."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Gagal memulai thread agen."
+msgstr "Gagal memulai utas agen."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Temukan poin-poin yang lemah dan tulis ulang dengan hasil, angka, cakupa
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finlandia"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Sesuai untuk dilihat"
+msgstr "Sesuaikan dengan tampilan"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Bentuk bebas"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Prancis"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Hasilkan nama acak"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Jerman"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Kembali"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Pulang"
+msgstr "Ke beranda"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Nilai"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Yunani"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Headline"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Ibrani"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Warna Sorot"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Hungaria"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2425,7 +2425,7 @@ msgstr "Penerbit"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italia"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Miring"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Jepang"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Rata Kanan-Kiri"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Tetap bersatu"
+msgstr "Pertahankan tetap bersama"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Kata Kunci"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Korea"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Terakhir dilihat pada {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Latvia"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "List"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lituania"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Sedang memuat penyedia AI. Silakan coba lagi sebentar lagi."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Memuat aplikasi…"
+msgstr "Memuat lamaran…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Proses pemuatan dilanjutkan…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Memuat thread…"
+msgstr "Memuat utas…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Buat bagian pengalaman lebih berorientasi pada hasil dan hilangkan tangg
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Melayu"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Nama"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepali"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Jaringan"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Aplikasi Baru"
+msgstr "Lamaran Baru"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2956,11 +2956,11 @@ msgstr "Tidak ada penyedia yang teruji"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Belum ada thread."
+msgstr "Belum ada utas."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norwegia"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Catatan"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Buka"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Agen AI terbuka"
+msgstr "Buka agen AI"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Kompatibel dengan OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persia"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Mohon tunggu sementara PDF Anda sedang dibuat…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polandia"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Potret"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugis (Brasil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugis (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Pergi ke beranda"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Lanjutkan Reaktif (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktif Lanjutkan v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Lanjutkan Reaktif v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Perkembangan Peran"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumania"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Jalankan analisis pertama Anda untuk mendapatkan kartu skor, kekuatan, d
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Rusia"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "Pemisah"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbia"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Siapkan penyedia AI."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Siapkan penyedia AI sebelum memulai thread."
+msgstr "Siapkan penyedia AI sebelum memulai utas."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4057,7 +4057,7 @@ msgstr "Mendaftar..."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a magenta left border accent; compact and efficient for entry-level or internship applications."
-msgstr "Satu kolom dengan aksen garis tepi kiri magenta; ringkas dan efisien untuk aplikasi level pemula atau magang."
+msgstr "Satu kolom dengan aksen garis tepi kiri magenta; ringkas dan efisien untuk lamaran level pemula atau magang."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a minimal top header and lots of whitespace; clean and modern for designers or content creators."
@@ -4098,11 +4098,11 @@ msgstr "Lewati ke konten utama"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovak"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovenia"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Jarak (Vertikal)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spanyol"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4193,7 +4193,7 @@ msgstr "Mulai utas baru"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Mulailah percakapan"
+msgstr "Mulai utas"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4215,7 +4215,7 @@ msgstr "Mulai di halaman baru"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Mulai Diskusi"
+msgstr "Mulai utas"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Dukung aplikasi dengan melakukan apa yang Anda bisa!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Swedia"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Penyesuaian gagal."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Warna Teks"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "URL yang Anda masukkan tidak valid."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Riwayat pekerjaan telah dihapus. Thread ini hanya dapat dibaca."
+msgstr "Riwayat pekerjaan telah dihapus. Utas ini hanya dapat dibaca."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4468,7 +4468,7 @@ msgstr "Tindakan ini tidak dapat dibatalkan. Pesan dan lampiran percakapan akan 
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Thread agen ini tidak dapat dibuka."
+msgstr "Utas agen ini tidak dapat dibuka."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "Langkah ini opsional, tetapi direkomendasikan."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Diskusi ini telah diarsipkan. Pesan baru tidak dapat dikirim."
+msgstr "Utas ini telah diarsipkan. Pesan baru tidak dapat dikirim."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Thread ini hanya dapat dibaca."
+msgstr "Utas ini hanya dapat dibaca."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Thread ini hanya dapat dibaca karena resume kerja atau penyedia AI sedang tidak tersedia."
+msgstr "Utas ini hanya dapat dibaca karena resume kerja atau penyedia AI sedang tidak tersedia."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4549,7 +4549,7 @@ msgstr "Tindakan utas"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Diskusi telah diarsipkan."
+msgstr "Utas telah diarsipkan."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
@@ -4560,7 +4560,7 @@ msgstr "Utas dihapus."
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Benang"
+msgstr "Utas"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4647,7 +4647,7 @@ msgstr "Coba lagi"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turki"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4683,7 +4683,7 @@ msgstr "Dua kolom, bersih dan profesional dengan pemisah bagian halus; cocok unt
 
 #: src/dialogs/resume/template/data.ts
 msgid "Two-column, minimal and text-dense with no decorative elements; perfect for traditional industries or ATS-heavy applications."
-msgstr "Dua kolom, minimal dan padat teks tanpa elemen dekoratif; sempurna untuk industri tradisional atau aplikasi yang sangat mengandalkan ATS."
+msgstr "Dua kolom, minimal dan padat teks tanpa elemen dekoratif; sempurna untuk industri tradisional atau lamaran yang sangat mengandalkan ATS."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Two-column, minimal with light gray sidebar and subtle icons; professional and understated for legal, finance, or executive roles."
@@ -4728,7 +4728,7 @@ msgstr "Tipografi"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukraina"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Pengguna"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbek"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Riwayat versi"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnam"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Perkecil"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/id-ID.po
+++ b/apps/web/locales/id-ID.po
@@ -2377,7 +2377,7 @@ msgstr "Perbesar zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/id-ID.po
+++ b/apps/web/locales/id-ID.po
@@ -401,7 +401,7 @@ msgstr "Dan masih banyak lagi..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropik Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Rata Tengah"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Otak Besar"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Tutup asisten AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Berpadu"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finlandia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Kembang api"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -3207,7 +3207,7 @@ msgstr "Periode"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Kebingungan"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"

--- a/apps/web/locales/it-IT.po
+++ b/apps/web/locales/it-IT.po
@@ -260,7 +260,7 @@ msgstr "Aggiungi un tag e premi Invio…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Aggiungi e testa un provider prima di avviare un thread dell'agente."
+msgstr "Aggiungi e testa un provider prima di avviare una discussione dell'agente."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -344,7 +344,7 @@ msgstr "La configurazione dell'agente AI non è disponibile finché non vengono 
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "Assistente basato sull'intelligenza artificiale"
+msgstr "Assistente IA"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "I provider di intelligenza artificiale richiedono la configurazione di R
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanese"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Hai già un account? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amarico"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Candidatura eliminata."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Statistiche dell'applicazione"
+msgstr "Statistiche delle candidature"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Applicato con avvertenze"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabo"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Premi"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaigiano"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Modelli bellissimi tra cui scegliere, con altri in arrivo."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengalese"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Tavolo comandi del generatore"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgaro"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Impossibile ripristinare; il curriculum è stato modificato dopo l'appli
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalano"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Controllo della bozza"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Cinese (semplificato)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Cinese (tradizionale)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Cerchio"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Libero"
+msgstr "Cancella"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Stili personalizzati"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Ceco"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Zona di pericolo"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danese"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1302,7 +1302,7 @@ msgstr "Tema scuro"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Dashboard"
-msgstr "Pannello di controllo"
+msgstr "dashboard"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Data Security"
@@ -1548,7 +1548,7 @@ msgstr "Duplicazione del tuo curriculum in corso..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Olandese"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Abilitazione dell'autenticazione a due fattori…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Inglese"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Inglese (Regno Unito)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1807,7 +1807,7 @@ msgstr "Impossibile eliminare la chiave API. Provi di nuovo."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Impossibile eliminare il thread."
+msgstr "Impossibile eliminare la discussione."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Non è stato possibile effettuare l'accesso. La preghiamo di riprovare."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Impossibile avviare il thread dell'agente."
+msgstr "Impossibile avviare la discussione dell'agente."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Individua i punti deboli e riscrivili con risultati più solidi, dati pi
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finlandese"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Adatto alla visione"
+msgstr "Adatta alla vista"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Forma libera"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Francese"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Genera un nome casuale"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Tedesco"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Torna indietro"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Vai a casa"
+msgstr "Torna alla home"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2127,7 +2127,7 @@ msgstr "Vai alla dashboard"
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Vada al cruscotto dei curriculum"
+msgstr "Vai alla dashboard dei curriculum"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Voto"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Greco"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Intestazione"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Ebraico"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Colore di evidenziazione"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Ungherese"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2353,7 +2353,7 @@ msgstr "Importate {0} candidature."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "L'importazione da PDF o Word richiede un provider di intelligenza artificiale connesso."
+msgstr "L'importazione da PDF o Word richiede un provider di IA connesso."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Aumento dello zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesiano"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2433,7 +2433,7 @@ msgstr "Corsivo"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Giapponese"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Giustifica"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Restate uniti"
+msgstr "Mantieni insieme"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Parole chiave"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Coreano"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Ultima visualizzazione il {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Lettone"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Lista"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lituano"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Caricamento dei provider di intelligenza artificiale. Riprova tra un att
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Caricamento delle applicazioni…"
+msgstr "Caricamento delle candidature…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Caricamento riprese…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Caricamento thread…"
+msgstr "Caricamento discussioni…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Rendi la sezione relativa all'esperienza più orientata ai risultati ed 
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malese"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Nome"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalese"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Rete"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Nuova applicazione"
+msgstr "Nuova candidatura"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "Nuovo tag…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Nuovo thread"
+msgstr "Nuova discussione"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Nuovo thread"
+msgstr "Nuova discussione"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2960,7 +2960,7 @@ msgstr "Ancora nessuna discussione."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norvegese"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Note"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Apri"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Agente Open AI"
+msgstr "Apri l'agente IA"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Compatibile con OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persiano"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Attendi mentre il tuo PDF viene generato…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polacco"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Verticale"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portoghese (Brasile)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portoghese (Portogallo)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Vai alla homepage"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Ripresa reattiva (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Ripresa reattiva v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Ripresa reattiva v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Progressione di ruolo"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumeno"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Esegua la prima analisi per ottenere una scorecard, i punti di forza e i
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russo"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "Separatore"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbo"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Salta al contenuto principale"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovacco"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Sloveno"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Spaziatura (verticale)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spagnolo"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Sostieni l'app facendo quello che puoi!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Svedese"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Personalizzazione non riuscita."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Colore del testo"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4545,7 +4545,7 @@ msgstr "Questo rimuoverà tutti gli elementi da questa sezione."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "Azioni del thread"
+msgstr "Azioni della discussione"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
@@ -4560,7 +4560,7 @@ msgstr "Discussione eliminata."
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Fili"
+msgstr "Discussioni"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "Alterna la barra laterale destra"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Discussioni di attivazione/disattivazione"
+msgstr "Mostra/nascondi discussioni"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4647,7 +4647,7 @@ msgstr "Riprova"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turco"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipografia"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ucraino"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Utenti"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbeco"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Cronologia delle versioni"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamita"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Rimpicciolisci"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/it-IT.po
+++ b/apps/web/locales/it-IT.po
@@ -401,7 +401,7 @@ msgstr "E molti altri..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Claude antropico"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Allinea al centro"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Cervelli"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Assistente AI ravvicinato"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Coerenza"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Diminuire lo zoom"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Ricerca profonda"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Finlandese"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "fuochi d'artificio"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2797,7 +2797,7 @@ msgstr "Mancanza di curriculum vitae"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Intelligenza artificiale Mistral"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Nuvola Ollam"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Periodo"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Perplessità"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "Gli URL validi devono iniziare con http:// o https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Gateway Vercel AI"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/it-IT.po
+++ b/apps/web/locales/it-IT.po
@@ -2377,7 +2377,7 @@ msgstr "Aumento dello zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/ja-JP.po
+++ b/apps/web/locales/ja-JP.po
@@ -768,7 +768,7 @@ msgstr "中央揃え"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "脳"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "AIアシスタントを閉じる"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "調和する"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "ズームを縮小する"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "ディープシーク"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "フィンランド語"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "花火"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2162,7 +2162,7 @@ msgstr "グリッド表示"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "グロク"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "レジュメが選択されていません"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "ミストラルAI"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "オディア語"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "オラマ・クラウド"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "期間"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "困惑"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "アカウントを削除するには、確認用のテキストを入力
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "一緒に。"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/ja-JP.po
+++ b/apps/web/locales/ja-JP.po
@@ -2377,7 +2377,7 @@ msgstr "ズームイン"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/ja-JP.po
+++ b/apps/web/locales/ja-JP.po
@@ -311,11 +311,11 @@ msgstr "非同期コミュニケーションと主体性を重視する、リモ
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "高度な"
+msgstr "詳細設定"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "アフリカーンス語"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "AIプロバイダーは、REDIS_URLとENCRYPTION_SECRETの設定を必�
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "アルバニア語"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "すでにアカウントをお持ちですか？ <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "アムハラ語"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "応募を削除しました。"
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "アプリケーション統計"
+msgstr "応募統計"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "警告付きで適用"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "アラビア語"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "受賞歴"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "アゼルバイジャン語"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "選択できる美しいテンプレートを多数用意しており、
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "ベンガル語"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "ビルダーコマンドパレット"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "ブルガリア語"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "この編集以降にレジュメが変更されているため、復元
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "カタロニア語"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "下書きの確認"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "中国語（簡体字）"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "中国語（繁体字）"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1278,7 +1278,7 @@ msgstr "スタイルのカスタマイズ"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "チェコ語"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "危険ゾーン"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "デンマーク語"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1324,7 +1324,7 @@ msgstr "インデントを減らす"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "Decrease zoom"
-msgstr "ズームを縮小する"
+msgstr "ズームアウト"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
@@ -1548,7 +1548,7 @@ msgstr "レジュメを複製しています…"
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "オランダ語"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "二段階認証を有効にする…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "英語"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "英語（イギリス）"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "弱い箇条書きを見つけ出し、より力強い成果、数値、
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "フィンランド語"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "見るのにふさわしい"
+msgstr "ビューに合わせる"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "自由形式"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "フランス語"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "ランダムな名前を生成"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "ドイツ語"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "戻る"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "家に帰れ"
+msgstr "ホームに戻る"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "成績"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "ギリシャ語"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "肩書き"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "ヘブライ語"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "ハイライトカラー"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "ヒンディー語"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "ハンガリー語"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2373,11 +2373,11 @@ msgstr "インデントを増やす"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "Increase zoom"
-msgstr "ズームを拡大する"
+msgstr "ズームイン"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "インドネシア語"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "発行元"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "イタリア語"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2491,12 +2491,12 @@ msgstr "両端揃え"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "カンナダ語"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "一緒に"
+msgstr "同じページにまとめる"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "キーワード"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "クメール語"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "韓国語"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "最終閲覧日: {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "ラトビア語"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "一覧"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "リトアニア語"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "AIプロバイダーを読み込んでいます。しばらくしてか�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "アプリケーションを読み込んでいます…"
+msgstr "応募を読み込んでいます…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "職務経歴欄をより成果重視の記述にし、曖昧な責任記
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "マレー語"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "マラヤーラム語"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "マラーティー語"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "名前"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "ネパール語"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "ネットワーク"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "新規申請"
+msgstr "新規応募"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2960,7 +2960,7 @@ msgstr "まだスレッドはありません。"
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "ノルウェー語"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "メモ"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "オディア語"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "開く"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "OpenAIエージェント"
+msgstr "AIエージェントを開く"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI互換"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "ペルシア語"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "PDFが生成されるまでしばらくお待ちください…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "ポーランド語"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "縦長"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "ポルトガル語（ブラジル）"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "ポルトガル語（ポルトガル）"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3681,7 +3681,7 @@ msgstr "役職履歴"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "ルーマニア語"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "分析を実行すると、スコアカード・強み・改善提案が
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "ロシア語"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "区切り線"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "セルビア語"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "メインコンテンツへスキップ"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "スロバキア語"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "スロベニア語"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "間隔（上下）"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "スペイン語"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4223,7 +4223,7 @@ msgstr "統計"
 
 #: src/hooks/use-form-blocker.tsx
 msgid "Stay"
-msgstr "このまま"
+msgstr "このページに留まる"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Stop generation"
@@ -4276,7 +4276,7 @@ msgstr "できる範囲で、このアプリをサポートしてください。
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "スウェーデン語"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "調整に失敗しました。"
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "タミル語"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "テルグ語"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "テキストカラー"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "タイ語"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "もう一度やり直してください"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "トルコ語"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "タイポグラフィ"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "ウクライナ語"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4750,7 +4750,7 @@ msgstr "スタイルシートの編集を元に戻す"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Unlimited Resumes"
-msgstr "レジュメを無制限に作成"
+msgstr "履歴書は無制限"
 
 #: src/features/settings/authentication/components/hooks.tsx
 msgid "Unlinking your {providerName} account..."
@@ -4929,7 +4929,7 @@ msgstr "ユーザー数"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "ウズベク語"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "バージョン履歴"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "ベトナム語"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "ズームアウト"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "ズールー語"
+msgstr "isiZulu"
 

--- a/apps/web/locales/km-KH.po
+++ b/apps/web/locales/km-KH.po
@@ -2377,7 +2377,7 @@ msgstr "បង្កើនការពង្រីក"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/km-KH.po
+++ b/apps/web/locales/km-KH.po
@@ -768,7 +768,7 @@ msgstr "តម្រង់​កណ្ដាល"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "ខួរក្បាល"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "បិទជំនួយការ AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "កូហៀរ"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finnish"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "កាំជ្រួច"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2162,7 +2162,7 @@ msgstr "ក្រឡារៀបចំ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "ហ្គ្រូក"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "បាត់ប្រវត្តិរូបសង្ខេបការ
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "មីស្ត្រាល អាយអាយ"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ពពកអូឡាម៉ា"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "កំឡុងពេល"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "ភាពច្របូកច្របល់"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"

--- a/apps/web/locales/km-KH.po
+++ b/apps/web/locales/km-KH.po
@@ -364,7 +364,7 @@ msgstr "អ្នកផ្តល់សេវា AI តម្រូវឱ្យ R
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanian"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "មានគណនីរួចហើយ? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharic"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "បានលុបពាក្យសុំ។"
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "ស្ថិតិ​កម្មវិធី"
+msgstr "ស្ថិតិពាក្យសុំ"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "អនុវត្តជាមួយការព្រមាន"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabic"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "រង្វាន់"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaijani"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "គំរូ​ស្អាតៗ​ឲ្យ​ជ្រើសរើស
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "បញ្ជី​ពាក្យ​បញ្ជា​របស់​ក
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgarian"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "មិនអាចស្ដារឡើងវិញបានទេ ប�
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalan"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "កំពុងពិនិត្យមើលសេចក្តីព្
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chinese (Simplified)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chinese (Traditional)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1278,7 +1278,7 @@ msgstr "រចនាប័ទ្មផ្ទាល់ខ្លួន"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Czech"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "តំបន់​គ្រោះថ្នាក់"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danish"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "កំពុង​ស្ទួន​ប្រវត្តិរូប​
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Dutch"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "កំពុងបើកដំណើរការការផ្ទៀង
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "ភាសា​អង់គ្លេស"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "អង់គ្លេស (ចក្រភពអង់គ្លេស)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "ស្វែងរកចំណុចខ្សោយ ហើយសរស�
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finnish"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "សមនឹងមើល"
+msgstr "សមនឹងទិដ្ឋភាព"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "ទម្រង់សេរី"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "French"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "បង្កើត​ឈ្មោះចៃដន្យ"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "ភាសាអាល្លឺម៉ង់"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "ត្រឡប់​ក្រោយ"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "ទៅផ្ទះ"
+msgstr "ត្រឡប់ទៅទំព័រដើម"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "ចំណាត់ថ្នាក់"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Greek"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "ក្បាលសារពណ៌នាខ្លី"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebrew"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "ពណ៌​បន្លិច"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Hungarian"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "បង្កើនការពង្រីក"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesian"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "អ្នក​ផ្តល់​វិញ្ញាបនបត្រ"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italian"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "អក្សរ​ទ្រេត"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japanese"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "តម្រង់​សមរម្យ​ទាំង​ផ្នែក
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "ពាក្យ​គន្លឹះ"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Korean"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "បាន​មើល​ចុងក្រោយ​នៅ​ថ្ងៃ
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Latvian"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2587,7 +2587,7 @@ msgstr "ចាកចេញ"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
 msgid "Leave empty to reset the title to the original."
-msgstr "ទុក​វែងៗ ដើម្បី​កំណត់​ចំណងជើង​ឲ្យ​ត្រឡប់​ទៅ​ដើម​វិញ។"
+msgstr "ទុកឲ្យនៅទទេ ដើម្បីកំណត់ចំណងជើងឲ្យត្រឡប់ទៅដើមវិញ។"
 
 #: src/components/input/rich-input.tsx
 msgid "Left Align"
@@ -2674,7 +2674,7 @@ msgstr "បញ្ជី"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lithuanian"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "កំពុងផ្ទុកអ្នកផ្តល់សេវា AI
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "កំពុងផ្ទុកកម្មវិធី…"
+msgstr "កំពុងផ្ទុកពាក្យសុំ…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "ធ្វើឱ្យផ្នែកបទពិសោធន៍ផ្ត
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malay"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "ឈ្មោះ"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepali"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "បណ្ដាញ"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "កម្មវិធីថ្មី"
+msgstr "ពាក្យសុំថ្មី"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2960,7 +2960,7 @@ msgstr "មិនទាន់មានខ្សែស្រឡាយនៅឡើ
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norwegian"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "កំណត់ចំណាំ"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "បើក"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "ភ្នាក់ងារ AI បើក"
+msgstr "បើកភ្នាក់ងារ AI"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "ឆបគ្នាជាមួយ OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persian"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "សូមរង់ចាំខណៈពេលដែល PDF របស់�
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polish"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "រូប​ឈរ"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portuguese (Brazil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portuguese (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3681,7 +3681,7 @@ msgstr "ការរីកចម្រើនតួនាទី"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Romanian"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "ដំណើរការវិភាគលើកដំបូងរបស
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russian"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "បន្ទាត់​បំបែក"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbian"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "រំលង​ទៅ​មាតិកា​មេ"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovak"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "ស្លូវេនី"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "គម្លាត (បញ្ឈរ)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spanish"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "គាំទ្រ​កម្មវិធី ដោយ​ធ្វើ�
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Swedish"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "ការកែសម្រួលបរាជ័យ។"
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "ពណ៌​អត្ថបទ"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "ព្យាយាមម្តងទៀត"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turkish"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "រចនាប័ទ្ម​អក្សរ"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrainian"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "អ្នកប្រើ"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbek"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "ប្រវត្តិកំណែ"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamese"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5173,7 +5173,7 @@ msgstr "ការគាំទ្រ​របស់​អ្នក​ធានា
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Zoom"
-msgstr "ពង្រីក"
+msgstr "ការពង្រីក"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom in"
@@ -5190,5 +5190,5 @@ msgstr "បង្រួម"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/kn-IN.po
+++ b/apps/web/locales/kn-IN.po
@@ -768,7 +768,7 @@ msgstr "ಮಧ್ಯ ಸರಿಸು"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "ಸೆರೆಬ್ರಸ್"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "AI ಸಹಾಯಕವನ್ನು ಮುಚ್ಚಿ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "ಕೊಹೆರೆ"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "ಝೂಮ್ ಕಡಿಮೆ ಮಾಡಿ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "ಡೀಪ್‌ಸೀಕ್"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "ಫಿನ್ನಿಷ್"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "ಪಟಾಕಿಗಳು"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2162,7 +2162,7 @@ msgstr "ಗ್ರಿಡ್"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "ಗ್ರೋಕ್"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "ಕೆಲಸದ ರೆಸ್ಯೂಮ್ ಕಾಣೆಯಾಗಿದೆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "ಮಿಸ್ಟ್ರಲ್ AI"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "ಒಡಿಯಾ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ಒಲ್ಲಮಾ ಮೇಘ"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "ಅವಧಿ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "ಗೊಂದಲ"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "ನಿಮ್ಮ ಖಾತೆಯನ್ನು ಅಳಿಸಲು, ನೀ�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "ಟುಗೆದರ್.ಐ"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -5063,7 +5063,7 @@ msgstr "ಎಕ್ಸ್ (ಟ್ವಿಟರ್)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI ಗ್ರೋಕ್"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/kn-IN.po
+++ b/apps/web/locales/kn-IN.po
@@ -2377,7 +2377,7 @@ msgstr "ಜೂಮ್ ಹೆಚ್ಚಿಸಿ"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/kn-IN.po
+++ b/apps/web/locales/kn-IN.po
@@ -315,7 +315,7 @@ msgstr "ಸುಧಾರಿತ"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "ಆಫ್ರಿಕಾನ್ಸ್"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "AI ಪೂರೈಕೆದಾರರು REDIS_URL ಮತ್ತು ENCRYPTIO
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "ಅಲ್ಬೇನಿಯನ್"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "ಈಗಾಗಲೇ ಖಾತೆ ಇದೆಯೇ? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "ಅಂಹಾರಿಕ್"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "ಅರ್ಜಿಯನ್ನು ಅಳಿಸಲಾಗಿದೆ."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "ಅಪ್ಲಿಕೇಶನ್ ಅಂಕಿಅಂಶಗಳು"
+msgstr "ಅರ್ಜಿ ಅಂಕಿಅಂಶಗಳು"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "ಎಚ್ಚರಿಕೆಗಳೊಂದಿಗೆ ಅನ್ವಯಿಸ�
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "ಅರೇಬಿಕ್"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "ಪ್ರಶಸ್ತಿಗಳು"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "ಅಜರ್‌ಬೈಜಾನಿ"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "ಆಯ್ಕೆ ಮಾಡಲು ಸುಂದರವಾದ ಮಾದರಿ
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "ಬೆಂಗಾಲಿ"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "ಬಿಲ್ಡರ್ ಕಮಾಂಡ್ ಪ್ಯಾಲೆಟ್"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "ಬಲ್ಗೇರಿಯನ್"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "ಪುನಃಸ್ಥಾಪಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ; 
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "ಕ್ಯಾಟಲನ್"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "ಡ್ರಾಫ್ಟ್ ಪರಿಶೀಲಿಸಲಾಗುತ್ತ�
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "ಚೈನೀಸ್ (ಸರಳೀಕೃತ)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "ಚೈನೀಸ್ (ಸಾಂಪ್ರದಾಯಿಕ)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1278,7 +1278,7 @@ msgstr "ಕಸ್ಟಮ್ ಶೈಲಿಗಳು"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "ಚೆಕ್"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "ಅಪಾಯ ವಲಯ"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "ಡ್ಯಾನಿಶ್"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "ನಿಮ್ಮ ರೆಸ್ಯೂಮ್ ನಕಲಿಸಲಾಗುತ�
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "ಡಚ್"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "ಎರಡು-ಅಂಶದ ದೃಢೀಕರಣವನ್ನು ಸಕ್
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "ಆಂಗ್ಲ"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "ಇಂಗ್ಲಿಷ್ (ಯುನೈಟೆಡ್ ಕಿಂಗ್ಡಮ್)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "ದುರ್ಬಲ ಗುಂಡುಗಳನ್ನು ಹುಡುಕಿ 
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "ಫಿನ್ನಿಷ್"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "ಮುಕ್ತ-ರೂಪ"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "ಫ್ರೆಂಚ್"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "ಯಾದೃಚ್ಛಿಕ ಹೆಸರನ್ನು ತಯಾರಿಸ�
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "ಜರ್ಮನ್"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,13 +2116,13 @@ msgstr "ಹಿಂದೆ ಹೋಗಿ"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "ಮನೆಗೆ ಹೋಗು"
+msgstr "ಮುಖಪುಟಕ್ಕೆ ಹೋಗಿ"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "ಡ್ಯಾಶ್ಬೋರ್ಡ್ಗೆ ಹೋಗಿ"
+msgstr "ಡ್ಯಾಶ್‌ಬೋರ್ಡ್‌ಗೆ ಹೋಗಿ"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "ಗ್ರೇಡ್"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "ಗ್ರೀಕ್"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "ಶೀರ್ಷಿಕೆ"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "ಹೀಬ್ರೂ"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "ಬಣ್ಣವನ್ನು ಹೈಲೈಟ್ ಮಾಡಿ"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "ಹಿಂದಿ"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "ಹಂಗೇರಿಯನ್"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "ಜೂಮ್ ಹೆಚ್ಚಿಸಿ"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "ಇಂಡೋನೇಷಿಯನ್"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "ನೀಡುವವರು"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "ಇಟಾಲಿಯನ್"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "ಇಟಾಲಿಕ್"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "ಜಾಪನೀಸ್"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2509,11 +2509,11 @@ msgstr "ಕೀವರ್ಡ್‌ಗಳು"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "ಖ್ಮೇರ್"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "ಕೊರಿಯನ್"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "ಕೊನೆಯದಾಗಿ {0} ರಂದು ವೀಕ್ಷಿಸಲಾ
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "ಲಾಟ್ವಿಯನ್"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "ಪಟ್ಟಿ"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "ಲಿಥುವೇನಿಯನ್"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "AI ಪೂರೈಕೆದಾರರನ್ನು ಲೋಡ್ ಮಾಡಲ�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "ಅಪ್ಲಿಕೇಶನ್‌ಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ…"
+msgstr "ಅರ್ಜಿಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "ಅನುಭವ ವಿಭಾಗವನ್ನು ಹೆಚ್ಚು ಫಲ
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "ಮಲಯ್"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "ಮಲಯಾಳಂ"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "ಮರಾಠಿ"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "ಹೆಸರು"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "ನೇಪಾಳಿ"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "ನೆಟ್ವರ್ಕ್"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "ಹೊಸ ಅಪ್ಲಿಕೇಶನ್"
+msgstr "ಹೊಸ ಅರ್ಜಿ"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2960,7 +2960,7 @@ msgstr "ಇನ್ನೂ ಯಾವುದೇ ಥ್ರೆಡ್‌ಗಳಿಲ್�
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "ನಾರ್ವೇಜಿಯನ್"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "ಟಿಪ್ಪಣಿಗಳು"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "ಒಡಿಯಾ"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI- ಹೊಂದಾಣಿಕೆ"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "ಫಾರ್ಸಿ"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "ನಿಮ್ಮ PDF ರಚನೆಯಾಗುವವರೆಗೆ ಕಾಯ
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "ಪೋಲಿಷ್"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "ಭಾವ ಚಿತ್ರ"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "ಪೋರ್ಚುಗೀಸ್ (ಬ್ರೆಜಿಲ್)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "ಪೋರ್ಚುಗೀಸ್ (ಪೋರ್ಚುಗಲ್)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - ಮುಖ್ಯ ಪುಟಕ್ಕೆ ಹೋಗಿ"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "ರಿಯಾಕ್ಟಿವ್ ರೆಸ್ಯೂಮೇ (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "ಪ್ರತಿಕ್ರಿಯಾತ್ಮಕ ಪುನರಾರಂಭ v
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "ರಿಯಾಕ್ಟಿವ್ ರೆಸ್ಯೂಮೇ v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "ಪಾತ್ರ ಪ್ರಗತಿ"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "ರೊಮೇನಿಯನ್"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "ಸ್ಕೋರ್‌ಕಾರ್ಡ್, ಬಲಗಳು ಮತ್ತು
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "ರಷಿಯನ್"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "ವಿಭಜಕ"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "ಸರ್ಬಿಯನ್"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "ಮುಖ್ಯ ವಿಷಯಕ್ಕೆ ತೆರಳಿರಿ"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "ಸ್ಲೋವಾಕ್"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "ಸ್ಲೋವೇನಿಯನ್"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "ಅಂತರ (ಲಂಬ)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "ಸ್ಪ್ಯಾನಿಷ್"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "ನೀವು ಮಾಡಬಹುದಾದುದನ್ನು ಮಾಡಿ 
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "ಸ್ವೀಡಿಷ್"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "ಹೊಂದಿಸುವಿಕೆ ವಿಫಲವಾಗಿದೆ."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "ತಮಿಳು"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "ತೆಲುಗು"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "ಅಕ್ಷರದ ಬಣ್ಣ"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "ಥಾಯ್"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "ಟರ್ಕಿಶ್"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "ಮುದ್ರಣಕಲೆ"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "ಉಕ್ರೇನಿಯನ್"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "ಬಳಕೆದಾರರು"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "ಉಜ್ಬೇಕ್"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "ಆವೃತ್ತಿ ಇತಿಹಾಸ"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "ವಿಯೆಟ್ನಾಮೀಸ್"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5173,7 +5173,7 @@ msgstr "ನಿಮ್ಮ ಬೆಂಬಲವು ಈ ಯೋಜನೆ ಈಗ ಮತ�
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Zoom"
-msgstr "ಜೂಮ್ ಮಾಡಿ"
+msgstr "ಜೂಮ್"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom in"
@@ -5190,5 +5190,5 @@ msgstr "ಗಾತ್ರ ಕುಗ್ಗಿಸಿ"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "ಜೂಲೂ"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ko-KR.po
+++ b/apps/web/locales/ko-KR.po
@@ -79,7 +79,7 @@ msgstr "{label} 지난 30일 동안"
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "<0>Finally,</0><1>A free and open-source resume builder</1>"
-msgstr "<0>드디어,</0><1>무료 오픈소스 이력서 작성 도구</1>"
+msgstr "<0>드디어,</0><1>무료 오픈 소스 이력서 작성 도구</1>"
 
 #: src/routes/_home/-sections/faq.tsx
 msgctxt "Home page FAQ section heading with each word visually separated into individual spans"
@@ -2377,7 +2377,7 @@ msgstr "확대"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/ko-KR.po
+++ b/apps/web/locales/ko-KR.po
@@ -311,16 +311,16 @@ msgstr "비동기적 소통과 책임감을 중시하는 원격 근무 우선 �
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "고급의"
+msgstr "고급"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "아프리칸스어"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Agent"
-msgstr "대리인"
+msgstr "에이전트"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Agent ready"
@@ -328,7 +328,7 @@ msgstr "에이전트 준비 완료"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Agents"
-msgstr "자치령 대표"
+msgstr "에이전트"
 
 #: src/dialogs/resume/import.tsx
 msgid "AI"
@@ -364,7 +364,7 @@ msgstr "AI 제공업체는 REDIS_URL 및 ENCRYPTION_SECRET이 구성되어 있�
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "알바니아어"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "이미 계정이 있으신가요? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "암하라어"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "지원이 삭제되었습니다."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "애플리케이션 통계"
+msgstr "지원 통계"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -483,7 +483,7 @@ msgstr "시간별 지원 현황"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
-msgstr "주당 보낸 지원서 (최근 8주)"
+msgstr "주당 보낸 지원 (최근 8주)"
 
 #: src/features/applications/components/table-view.tsx
 #: src/features/resume/stylesheet/status.tsx
@@ -504,7 +504,7 @@ msgstr "경고와 함께 적용됨"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "아랍어"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -591,7 +591,7 @@ msgstr "파일 첨부"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment"
-msgstr "부착"
+msgstr "첨부파일"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment uploaded."
@@ -628,7 +628,7 @@ msgstr "수상 내역"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "아제르바이잔어"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -649,7 +649,7 @@ msgstr "백업 코드가 클립보드에 복사되었습니다."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Base URL"
-msgstr "기본 URL"
+msgstr "Base URL"
 
 #: src/libs/resume/section.tsx
 msgid "Basics"
@@ -657,11 +657,11 @@ msgstr "기본 사항"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Beautiful templates to choose from, with more on the way."
-msgstr "선택할 수 있는 아름다운 템플릿이 준비되어 있으며, 앞으로 더 추가될 예정입니다."
+msgstr "고를 수 있는 멋진 템플릿이 준비되어 있으며, 더 많은 템플릿이 곧 추가될 예정입니다."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "벵골어"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "빌더 명령 팔레트"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "불가리아어"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -722,7 +722,7 @@ msgstr "글머리 기호 목록"
 #: src/routes/_home/-sections/features.tsx
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "By the community, for the community."
-msgstr "커뮤니티에 의해, 커뮤니티를 위해."
+msgstr "커뮤니티가 만들고, 커뮤니티를 위한 서비스"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Can I export my resume to PDF?"
@@ -760,7 +760,7 @@ msgstr "복원할 수 없습니다. 이 수정 사항이 적용된 이후 이력
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "카탈루냐어"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "초안 검토"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "중국어(간체)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "중국어(번체)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1278,7 +1278,7 @@ msgstr "사용자 지정 스타일"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "체코어"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "위험 구역"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "덴마크어"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1302,7 +1302,7 @@ msgstr "다크 테마"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Dashboard"
-msgstr "계기반"
+msgstr "대시보드"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Data Security"
@@ -1320,11 +1320,11 @@ msgstr "지원일"
 
 #: src/components/input/rich-input.tsx
 msgid "Decrease indent"
-msgstr "들여쓰기 감소"
+msgstr "들여쓰기 줄이기"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "Decrease zoom"
-msgstr "확대/축소 크기 줄이기"
+msgstr "축소"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
@@ -1379,7 +1379,7 @@ msgstr "이 에이전트 스레드를 삭제하시겠습니까?"
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Delete this application?"
-msgstr "이 지원서를 삭제할까요?"
+msgstr "이 지원을 삭제할까요?"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Delete this timeline entry?"
@@ -1548,7 +1548,7 @@ msgstr "이력서를 복제하는 중입니다..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "네덜란드어"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "2단계 인증 활성화…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "영어"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "영어 (영국)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "약한 항목들을 찾아내어 더 강력한 결과, 수치, 범위 �
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "핀란드어"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "보기에 적합함"
+msgstr "화면에 맞추기"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "자유 형식"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "프랑스어"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "무작위 이름 생성"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "독일어"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "뒤로 가기"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "집에 가세요"
+msgstr "홈으로 돌아가기"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "성적"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "그리스어"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "헤드라인"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "헤브루어"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "하이라이트 색상"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "힌디어"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "헝가리어"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2373,11 +2373,11 @@ msgstr "들여쓰기 증가"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "Increase zoom"
-msgstr "확대/축소"
+msgstr "확대"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "인도네시아어"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "발급 기관"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "이탈리아어"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "기울임"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "일본어"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "양쪽 정렬"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "칸나다어"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "함께 하세요"
+msgstr "같은 페이지에 유지"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,7 +2509,7 @@ msgstr "키워드"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "크메르어"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
@@ -2571,7 +2571,7 @@ msgstr "마지막 조회: {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "라트비아어"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "목록"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "리투아니아어"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "AI 제공업체를 불러오는 중입니다. 잠시 후 다시 시도�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "애플리케이션 로딩 중…"
+msgstr "지원 로딩 중…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "경력 사항 부분을 결과 중심적으로 작성하고 모호한 �
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "말레이어"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "말라얄람어"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "마라티어"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2829,7 +2829,7 @@ msgstr "다국어 지원"
 #. Placeholder text for custom link URL field in resume builder
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom-fields.tsx
 msgid "Must start with https://"
-msgstr "https:// 으로 시작해야 합니다."
+msgstr "https://로 시작해야 합니다."
 
 #. Label for full name input on registration form
 #: src/dialogs/api-key/create.tsx
@@ -2848,7 +2848,7 @@ msgstr "이름"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "네팔어"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "네트워크"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "새로운 신청서"
+msgstr "새 지원"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2960,7 +2960,7 @@ msgstr "아직 스레드가 없습니다."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "노르웨이어"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "노트"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "오디아어"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "열기"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "오픈 AI 에이전트"
+msgstr "AI 에이전트 열기"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI 호환"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "페르시아어"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "PDF 파일이 생성되는 동안 잠시 기다려 주세요…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "폴란드어"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "세로"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "포르투갈어(브라질)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "포르투갈어(포르투갈)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - 홈페이지로 이동"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "리액티브 이력서(JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "반응형 재개 v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "리액티브 이력서 v4(JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "역할 진행"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "루마니아어"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "첫 번째 분석을 실행하여 스코어카드, 강점, 우선순위�
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "러시아어"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3846,7 +3846,7 @@ msgstr "이력서를 선택하세요"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "실을 선택하세요"
+msgstr "스레드를 선택하세요"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "구분선"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "세르비아어"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4057,7 +4057,7 @@ msgstr "가입 중..."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a magenta left border accent; compact and efficient for entry-level or internship applications."
-msgstr "마젠타색 왼쪽 테두리 포인트가 있는 단일 열 레이아웃으로, 신입·인턴 지원서에 적합한 컴팩트하고 효율적인 템플릿입니다."
+msgstr "마젠타색 왼쪽 테두리 포인트가 있는 단일 열 레이아웃으로, 신입·인턴 지원에 적합한 컴팩트하고 효율적인 템플릿입니다."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a minimal top header and lots of whitespace; clean and modern for designers or content creators."
@@ -4098,11 +4098,11 @@ msgstr "본문으로 바로 가기"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "슬로바키아어"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "슬로베니아어"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "간격(세로)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "스페인어"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,7 +4189,7 @@ msgstr "GitHub에서 Star 누르기, 현재 {0}개 스타(새 탭에서 열림)"
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "새 게시글을 작성하세요"
+msgstr "새 스레드를 시작하세요"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
@@ -4215,7 +4215,7 @@ msgstr "새 페이지에서 시작"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "시작 스레드"
+msgstr "스레드 시작"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4223,7 +4223,7 @@ msgstr "통계"
 
 #: src/hooks/use-form-blocker.tsx
 msgid "Stay"
-msgstr "머물기"
+msgstr "이 페이지에 머물기"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Stop generation"
@@ -4276,7 +4276,7 @@ msgstr "가능한 방식으로 앱을 지원해 주세요!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "스웨덴어"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "맞춤 조정에 실패했습니다."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "타밀어"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "텔루구어"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "텍스트 색상"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "태국어"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4372,7 +4372,7 @@ msgstr "후원해 주신 분들께 감사드립니다."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "The agent needs your input."
-msgstr "상담원이 고객님의 입력을 필요로 합니다."
+msgstr "에이전트가 사용자의 입력을 기다립니다."
 
 #. Error description when AI returns invalid resume analysis format
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
@@ -4419,7 +4419,7 @@ msgstr "입력하신 URL이 올바르지 않습니다."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "이력서가 삭제되었습니다. 이 게시글은 읽기 전용입니다."
+msgstr "이력서가 삭제되었습니다. 이 스레드는 읽기 전용입니다."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4520,7 +4520,7 @@ msgstr "이 단계는 선택 사항이지만 권장됩니다."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "이 게시글은 보관 처리되었습니다. 더 이상 새 메시지를 보낼 수 없습니다."
+msgstr "이 스레드는 보관되었습니다. 더 이상 새 메시지를 보낼 수 없습니다."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
@@ -4528,7 +4528,7 @@ msgstr "이 스레드는 읽기 전용입니다."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "이 게시물은 이력서 작성 도구 또는 AI 제공업체를 사용할 수 없으므로 읽기 전용입니다."
+msgstr "이 스레드는 작업 이력서 또는 AI 제공업체를 사용할 수 없어 읽기 전용입니다."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4549,18 +4549,18 @@ msgstr "스레드 작업"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "해당 게시글이 보관되었습니다."
+msgstr "스레드가 보관되었습니다."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "게시글이 삭제되었습니다."
+msgstr "스레드가 삭제되었습니다."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "실"
+msgstr "스레드"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4647,7 +4647,7 @@ msgstr "다시 시도해 보세요"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "터키어"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "타이포그래피"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "우크라이나어"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4750,7 +4750,7 @@ msgstr "스타일시트 편집 취소"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Unlimited Resumes"
-msgstr "무제한 이력서"
+msgstr "이력서 무제한"
 
 #: src/features/settings/authentication/components/hooks.tsx
 msgid "Unlinking your {providerName} account..."
@@ -4929,7 +4929,7 @@ msgstr "사용자 수"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "우즈베크어"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "버전 기록"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "베트남어"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "축소"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "줄루어"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ko-KR.po
+++ b/apps/web/locales/ko-KR.po
@@ -79,7 +79,7 @@ msgstr "{label} 지난 30일 동안"
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "<0>Finally,</0><1>A free and open-source resume builder</1>"
-msgstr "<0>마침내,</0><1>무료 오픈 소스 이력서 작성 도구</1>"
+msgstr "<0>드디어,</0><1>무료 오픈소스 이력서 작성 도구</1>"
 
 #: src/routes/_home/-sections/faq.tsx
 msgctxt "Home page FAQ section heading with each word visually separated into individual spans"
@@ -401,7 +401,7 @@ msgstr "그 외에도 더 많은 기능이 있습니다..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "인류학적 클로드"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "가운데 정렬"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "대뇌"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "AI 비서 닫기"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "응집하다"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "확대/축소 크기 줄이기"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "딥시크"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "핀란드어"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "불꽃"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "Google"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "구글 제미니 자리"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "그리드"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "그로크"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "이력서가 누락되었습니다."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "미스트랄 AI"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "오디아어"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "올라마 클라우드"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "기간"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "당황"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "계정을 삭제하려면 확인 문구를 입력한 뒤 아래 버튼�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "투게더.에이"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "유효한 URL은 http:// 또는 https://로 시작해야 합니다."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "버셀 AI 게이트웨이"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "X (트위터)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI 그록"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/lt-LT.po
+++ b/apps/web/locales/lt-LT.po
@@ -2377,7 +2377,7 @@ msgstr "Padidinti mastelį"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/lt-LT.po
+++ b/apps/web/locales/lt-LT.po
@@ -315,7 +315,7 @@ msgstr "Išplėstinis"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Afrikanso"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "Dirbtinio intelekto teikėjams reikia sukonfigūruoti REDIS_URL ir ENCRY
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanų"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Jau turite paskyrą? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharų"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Paraiška ištrinta."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Programos statistika"
+msgstr "Paraiškų statistika"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Taikoma su įspėjimais"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabų"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Apdovanojimai"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaidžaniečių"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Gražūs šablonai, iš kurių galima rinktis, ir dar daugiau pakeliui."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengalų"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Kūrėjo komandų paletė"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgarų"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Nepavyksta atkurti; gyvenimo aprašymas pasikeitė nuo tada, kai buvo pr
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalonų"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Tikrinamas juodraštis"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Kinų (supaprastinta)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Kinų (tradicinė)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Pasirinkite gyvenimo aprašymą"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Šoninėje juostoje pasirinkite esamą pokalbį arba pradėkite naują, į juodraštį orientuotą temą."
+msgstr "Šoninėje juostoje pasirinkite esamą pokalbį arba pradėkite naują, į juodraštį orientuotą giją."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "Apskritimas"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Skaidrus"
+msgstr "Išvalyti"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Pasirinktiniai stiliai"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Čekų"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Pavojinga zona"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danų"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Ištrinti teikėją"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Ištrinti šią agento temą?"
+msgstr "Ištrinti šią agento giją?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1548,7 +1548,7 @@ msgstr "Dubliuojamas jūsų gyvenimo aprašymas..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Olandų"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Dviejų veiksnių autentifikavimo įjungimas…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Anglų"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Anglų (Jungtinė Karalystė)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Nepavyko išanalizuoti atnaujinimo."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Nepavyko archyvuoti temos."
+msgstr "Nepavyko archyvuoti gijos."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Nepavyko ištrinti API rakto. Bandykite dar kartą."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Nepavyko ištrinti temos."
+msgstr "Nepavyko ištrinti gijos."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1963,7 +1963,7 @@ msgstr "Raskite silpnus sąrašus ir perrašykite juos su stipresniais rezultata
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Suomių"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Laisva forma"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Prancūzų"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Sugeneruoti atsitiktinį pavadinimą"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Vokiečių"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Grįžti"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Eik namo"
+msgstr "Eikite į pagrindinį puslapį"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Pažymys"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Graikų"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2199,11 +2199,11 @@ msgstr "6 antraštė"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
 msgid "Headline"
-msgstr "Antraštė"
+msgstr "Trumpa antraštė"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebrajų"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Paryškinimo spalva"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Vengrų"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "Padidinti mastelį"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indoneziečių"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Leidėjas"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italų"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kursyvas"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japonų"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Lygiuoti iš abiejų pusių"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kanadų"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Laikykitės kartu"
+msgstr "Laikyti kartu"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Raktiniai žodžiai"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmerų"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Korėjiečių"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Paskutinį kartą peržiūrėta {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Latvių"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2682,7 +2682,7 @@ msgstr "Įkeliami dirbtinio intelekto teikėjai. Bandykite dar kartą po akimirk
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Įkeliamos programos…"
+msgstr "Įkeliamos paraiškos…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Patirties skyrių labiau orientuoti į rezultatus ir pašalinti neaiški
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malajų"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malajalių"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Maratų"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Pavadinimas"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalų"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2889,12 +2889,12 @@ msgstr "Nauja žyma…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Nauja tema"
+msgstr "Nauja gija"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Nauja tema"
+msgstr "Nauja gija"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2960,7 +2960,7 @@ msgstr "Kol kas nėra gijų."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norvegų"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Pastabos"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odijų"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Atidaryti"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Atviras dirbtinio intelekto agentas"
+msgstr "Atidaryti dirbtinio intelekto agentą"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Suderinamas su OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persų"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Palaukite, kol generuojamas jūsų PDF failas…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Lenkų"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portretas"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugalų (Brazilija)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugalų (Portugalija)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "„Reactive Resume“ – eiti į pagrindinį puslapį"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktyvusis CV (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktyvus gyvenimo aprašymas v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktyvusis CV v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Pareigybių raida"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumunų"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Atlikite pirmąją analizę, kad gautumėte rezultatų lentelę, stipri�
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Rusų"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "Skirtukas"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbų"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Nustatykite dirbtinio intelekto teikėją"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Prieš pradėdami temą, nustatykite dirbtinio intelekto teikėją."
+msgstr "Prieš pradėdami giją, nustatykite dirbtinio intelekto teikėją."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Pereiti prie pagrindinio turinio"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovakų"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovėnų"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Tarpai (vertikalūs)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Ispanų"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "Pridėkite žvaigždutę „GitHub“, šiuo metu {0} žvaigždutės (at
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Pradėti naują temą"
+msgstr "Pradėti naują giją"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Pradėti temą"
+msgstr "Pradėti giją"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Pradėkite kurti savo gyvenimo aprašymą nuo nulio"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Pradėti naują temą"
+msgstr "Pradėti naują giją"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Pradėti naujame puslapyje"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Pradėti temą"
+msgstr "Pradėti giją"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Palaikykite programėlę darydami tai, ką galite!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Švedų"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Pritaikyti nepavyko."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamilų"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugų"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Teksto spalva"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Tajų"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "Neteisingas įvestas URL."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Darbo gyvenimo aprašymas buvo ištrintas. Ši tema skirta tik skaitymui."
+msgstr "Darbo gyvenimo aprašymas buvo ištrintas. Ši gija skirta tik skaitymui."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4520,15 +4520,15 @@ msgstr "Šis žingsnis neprivalomas, bet rekomenduojamas."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Ši tema yra archyvuota. Naujų pranešimų siųsti negalima."
+msgstr "Ši gija yra archyvuota. Naujų pranešimų siųsti negalima."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Ši tema skirta tik skaitymui"
+msgstr "Ši gija skirta tik skaitymui"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Ši tema skirta tik skaitymui, nes darbinis gyvenimo aprašymas arba dirbtinio intelekto teikėjas nepasiekiamas."
+msgstr "Ši gija skirta tik skaitymui, nes darbinis gyvenimo aprašymas arba dirbtinio intelekto teikėjas nepasiekiamas."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4560,7 +4560,7 @@ msgstr "Gija ištrinta."
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Siūlai"
+msgstr "Gijos"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4647,7 +4647,7 @@ msgstr "Bandykite dar kartą"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turkų"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipografija"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrainiečių"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Vartotojai"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbekų"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Versijų istorija"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamiečių"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Tolinti"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulų"
+msgstr "isiZulu"
 

--- a/apps/web/locales/lt-LT.po
+++ b/apps/web/locales/lt-LT.po
@@ -401,7 +401,7 @@ msgstr "Ir dar daugiau..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropinis Klodas"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Lygiuoti centre"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Smegenys"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Uždaryti DI asistentą"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Koheras"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Suomių"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Fejerverkai"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "\"Google\""
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "\"Google\" Dvyniai"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -3038,7 +3038,7 @@ msgstr "Atviro kodo"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "\"OpenAI\""
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "Suderinamas su OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "\"OpenRouter\""
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "Laikotarpis"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Sumišimas"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Norėdami ištrinti paskyrą, įveskite patvirtinimo tekstą ir spustel�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Kartu.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "Teisingi URL turi prasidėti http:// arba https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "\"Vercel AI Gateway"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "X (Twitter)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI Grokas"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/lv-LV.po
+++ b/apps/web/locales/lv-LV.po
@@ -315,7 +315,7 @@ msgstr "Paplašināts"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Afrikandu"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -344,7 +344,7 @@ msgstr "Mākslīgā intelekta aģenta iestatīšana nav pieejama, kamēr nav kon
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "Mākslīgā intelekta palīgs"
+msgstr "MI palīgs"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "Mākslīgā intelekta pakalpojumu sniedzējiem ir jākonfigurē REDIS_UR
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albāņu"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Jums jau ir konts? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharu"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Pieteikums izdzēsts."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Lietotnes statistika"
+msgstr "Pieteikumu statistika"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Pielietots ar brīdinājumiem"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arābu"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Apbalvojumi"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaidžāņu"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Skaistas veidnes, no kurām izvēlēties, un vēl vairāk drīzumā."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengāļu"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Veidotāja komandu palete"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgāru"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Nevar atjaunot; CV ir mainījies kopš šī labojuma piemērošanas."
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalāņu"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Melnraksta pārbaude"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Ķīniešu (vienkāršotā)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Ķīniešu (tradicionālā)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Aplis"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Skaidrs"
+msgstr "Notīrīt"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Pielāgoti stili"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Čehu"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Bīstamā zona"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Dāņu"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "Tiek dublēts jūsu CV..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Holandiešu"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Divfaktoru autentifikācijas iespējošana…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Angļu"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Angļu valoda (Lielbritānija)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1861,7 +1861,7 @@ msgstr "Neizdevās atiestatīt paroli. Lūdzu, mēģiniet vēlreiz."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "Neizdevās saglabāt mākslīgā intelekta pakalpojumu sniedzēju."
+msgstr "Neizdevās saglabāt MI pakalpojumu sniedzēju."
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -1963,7 +1963,7 @@ msgstr "Atrodiet vājas aizzīmes un pārrakstiet tās ar spēcīgākiem rezult�
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Somu"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Piemērots skatam"
+msgstr "Pielāgot skatam"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Brīvā forma"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Franču"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Ģenerēt nejaušu nosaukumu"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Vācu"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Saņemiet savu CV pārskatu ar vispārēju novērtējumu, norādot stipr
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Saņemiet padziļinātu ar mākslīgo intelektu aprīkotu CV pārskatu ar kopējo novērtējumu, galvenajām stiprajām pusēm un praktiskiem ieteikumiem. Lai aktivizētu šo funkciju, atjauniniet AI iestatījumus."
+msgstr "Saņemiet padziļinātu ar MI aprīkotu CV pārskatu ar kopējo novērtējumu, galvenajām stiprajām pusēm un praktiskiem ieteikumiem. Lai aktivizētu šo funkciju, atjauniniet MI iestatījumus."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,18 +2116,18 @@ msgstr "Atpakaļ"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Ej mājās"
+msgstr "Doties uz sākumlapu"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Doties uz vadības paneli"
+msgstr "Doties uz informācijas paneli"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Dodieties uz CV paneli"
+msgstr "Dodieties uz CV informācijas paneli"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Atzīme"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Grieķu"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Īss apraksts"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Ivrits"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Izcelt krāsu"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Ungāru"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2353,7 +2353,7 @@ msgstr "Importēti pieteikumi: {0}."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "Importēšanai no PDF vai Word ir nepieciešams pievienots mākslīgā intelekta pakalpojumu sniedzējs."
+msgstr "Importēšanai no PDF vai Word ir nepieciešams pievienots MI pakalpojumu sniedzējs."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Palielināt tālummaiņu"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonēziešu"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Izdevējs"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Itāļu"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Slīpraksts"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japāņu"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Izlīdzināt līdz malām"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannadu"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Turēties kopā"
+msgstr "Saglabāt kopā"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Atslēgvārdi"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmeru"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Korejiešu"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2674,7 +2674,7 @@ msgstr "Saraksts"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lietuviešu"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Notiek mākslīgā intelekta pakalpojumu sniedzēju ielāde. Lūdzu, mē
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Lietotņu ielāde…"
+msgstr "Pieteikumu ielāde…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Padariet pieredzes sadaļu vairāk orientētu uz rezultātiem un noņemi
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malajiešu"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malajalu"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathu"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Nosaukums"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepāļu"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2889,12 +2889,12 @@ msgstr "Jauna birka…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Jauna tēma"
+msgstr "Jauns pavediens"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Jauna tēma"
+msgstr "Jauns pavediens"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2960,7 +2960,7 @@ msgstr "Vēl nav pavedienu."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norvēģu"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Piezīmes"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odiju"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Atvērt"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Atvērts mākslīgā intelekta aģents"
+msgstr "Atvērt mākslīgā intelekta aģentu"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI saderīgs"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persiešu"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Lūdzu, uzgaidiet, kamēr tiek ģenerēts jūsu PDF fails…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Poļu"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portrets"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugāļu (Brazīlija)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugāļu (Portugāle)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - doties uz sākumlapu"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktīvais CV (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3681,7 +3681,7 @@ msgstr "Lomu attīstība"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumāņu"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Veiciet pirmo analīzi, lai iegūtu rezultātu tabulu, stiprās puses un
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Krievu"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "Atdalītājs"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbu"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Pāriet uz galveno saturu"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovāku"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovēņu"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Atstatums (vertikāli)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spāņu"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Atbalstiet lietotni, darot, ko vien varat!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Zviedru"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Pielāgošana neizdevās."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamilu"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Teksta krāsa"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Taju"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "Ievadītais URL nav derīgs."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Darba CV tika dzēsts. Šī tēma ir tikai lasāma."
+msgstr "Darba CV tika dzēsts. Šis pavediens ir tikai lasāms."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4520,7 +4520,7 @@ msgstr "Šis solis nav obligāts, taču ieteicams."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Šī tēma ir arhivēta. Jaunus ziņojumus nevar sūtīt."
+msgstr "Šis pavediens ir arhivēts. Jaunus ziņojumus nevar sūtīt."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
@@ -4528,7 +4528,7 @@ msgstr "Šis pavediens ir tikai lasāms"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Šī tēma ir tikai lasāma, jo darba CV vai mākslīgā intelekta nodrošinātājs nav pieejams."
+msgstr "Šis pavediens ir tikai lasāms, jo darba CV vai mākslīgā intelekta nodrošinātājs nav pieejams."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4549,18 +4549,18 @@ msgstr "Pavedienu darbības"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Tēma arhivēta."
+msgstr "Pavediens arhivēts."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Tēma izdzēsta."
+msgstr "Pavediens izdzēsts."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Vītnes"
+msgstr "Pavedieni"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4647,7 +4647,7 @@ msgstr "Mēģiniet vēlreiz"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turku"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipogrāfija"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukraiņu"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Lietotāji"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbeku"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Versiju vēsture"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vjetnamiešu"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Tālināt"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/lv-LV.po
+++ b/apps/web/locales/lv-LV.po
@@ -2377,7 +2377,7 @@ msgstr "Palielināt tālummaiņu"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/lv-LV.po
+++ b/apps/web/locales/lv-LV.po
@@ -401,7 +401,7 @@ msgstr "Un vēl daudzi citi..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropiskais Klods"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Centrēt"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Smadzenes"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Aizvērt mākslīgā intelekta palīgu"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Kohere"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Somu"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Uguņošana"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "Google"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "Google Dvīņi"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -3207,7 +3207,7 @@ msgstr "Periods"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Apjukums"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Lai dzēstu savu kontu, jums jāievada apstiprinājuma teksts un jānokl
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Kopā.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "Derīgiem URL jāsākas ar http:// vai https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Vercel AI vārtejas"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "X (Twitter)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI Groks"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/ml-IN.po
+++ b/apps/web/locales/ml-IN.po
@@ -401,7 +401,7 @@ msgstr "ഇനിയും പലതുണ്ട്..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "ആന്ത്രോപിക് ക്ലോഡ്"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "സെന്റർ അലൈനിൽ ആക്കുക"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "സെറിബ്രകൾ"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "AI അസിസ്റ്റന്റ് അടയ്ക്കുക"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "കോഹെർ"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "സൂം കുറയ്ക്കുക"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "ഡീപ്‌സീക്ക്"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "ഫിന്നിഷ്"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "വെടിക്കെട്ട്"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "ഗൂഗിൾ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "ഗൂഗിൾ ജെമിനി"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "ഗ്രിഡ്"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "ഗ്രോക്ക്"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "വർക്കിംഗ് റെസ്യൂമെ കാണുന്�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "മിസ്ട്രൽ AI"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "ഒഡിയ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ഒല്ലാമ മേഘം"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "ഓപ്പൺ സോഴ്‌സ്"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "ഓപ്പൺഎഐ"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "OpenAI-ക്ക് അനുയോജ്യം"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "ഓപ്പൺ റൂട്ടർ"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "കാലയളവ്"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "ആശയക്കുഴപ്പം"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "നിങ്ങളുടെ അക്കൗണ്ട് ഡിലീറ�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "ടുഗെദർ.ഐ"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "സാധുവായ URL‑കൾ http:// അല്ലെങ്കി�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "വെർസെൽ എഐ ഗേറ്റ്‌വേ"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "എക്സ് (ട്വിറ്റർ)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI ഗ്രോക്ക്"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/ml-IN.po
+++ b/apps/web/locales/ml-IN.po
@@ -2377,7 +2377,7 @@ msgstr "സൂം വർദ്ധിപ്പിക്കുക"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/ml-IN.po
+++ b/apps/web/locales/ml-IN.po
@@ -266,7 +266,7 @@ msgstr "ഒരു ഏജന്റ് ത്രെഡ് ആരംഭിക്ക
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "ആപ്ലിക്കേഷൻ ചേർക്കുക"
+msgstr "അപേക്ഷ ചേർക്കുക"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "വിപുലമായത്"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "ആഫ്രിക്കാൻസ്"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "AI ദാതാക്കൾക്ക് REDIS_URL ഉം ENCRYPTION_SECR
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "അൽബേനിയൻ"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "ഇതിനകം അക്കൗണ്ട് ഉണ്ടോ? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "അംഹാരിക്"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,11 +447,11 @@ msgstr "ആപ്പ്"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "ആപ്ലിക്കേഷൻ പ്രവർത്തനങ്ങൾ"
+msgstr "അപേക്ഷാ പ്രവർത്തനങ്ങൾ"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "നിങ്ങളുടെ പൈപ്പ്ലൈനിലേക്ക് ആപ്ലിക്കേഷൻ ചേർത്തു."
+msgstr "നിങ്ങളുടെ പൈപ്പ്‌ലൈനിലേക്ക് അപേക്ഷ ചേർത്തു."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
@@ -460,15 +460,15 @@ msgstr "അപേക്ഷ കോപൈലറ്റ്"
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "അപ്ലിക്കേഷൻ ഇല്ലാതാക്കി."
+msgstr "അപേക്ഷ ഇല്ലാതാക്കി."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "ആപ്ലിക്കേഷൻ സ്റ്റാറ്റിസ്റ്റിക്സ്"
+msgstr "അപേക്ഷാ സ്ഥിതിവിവരക്കണക്കുകൾ"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "ആപ്ലിക്കേഷൻ അപ്ഡേറ്റ് ചെയ്തു."
+msgstr "അപേക്ഷ അപ്‌ഡേറ്റ് ചെയ്തു."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -504,7 +504,7 @@ msgstr "മുന്നറിയിപ്പുകൾ ഉപയോഗിച്�
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "അറബിക്"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "അവാർഡുകൾ"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "അസർബൈജാനി"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "തിരഞ്ഞെടുക്കാൻ മനോഹരമായ ട�
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "ബെംഗാളി"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "ആപ്ലിക്കേഷനുകൾക്കും പങ്കിടലിനും പ്രിൻ്റിംഗിനും മികച്ചത്."
+msgstr "അപേക്ഷകൾക്കും പങ്കിടലിനും പ്രിൻ്റിംഗിനും മികച്ചത്."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "ബിൽഡർ കമാൻഡ് പാലറ്റ്"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "ബൾഗേറിയൻ"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല; 
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "കറ്റലാൻ"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "ഡ്രാഫ്റ്റ് പരിശോധിക്കുന്�
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "ചൈനീസ് (സിംപ്ലിഫൈഡ്)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "ചൈനീസ് (ട്രഡീഷണൽ)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "വൃത്തം"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "വ്യക്തമാക്കുക"
+msgstr "മായ്ക്കുക"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "കണക്ഷൻ പരിശോധിക്കാൻ കഴിഞ്�
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "ആപ്ലിക്കേഷൻ ചേർക്കാൻ കഴിഞ്ഞില്ല. ദയവായി again ശ്രമിക്കുക."
+msgstr "അപേക്ഷ ചേർക്കാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "അപ്ലിക്കേഷൻ ഇല്ലാതാക്കാൻ കഴിഞ്ഞില്ല."
+msgstr "അപേക്ഷ ഇല്ലാതാക്കാൻ കഴിഞ്ഞില്ല."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "ടൈംലൈൻ എൻട്രി ഇല്ലാതാക്കാ�
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "ആപ്ലിക്കേഷൻ നീക്കാൻ കഴിഞ്ഞില്ല. ദയവായി again ശ്രമിക്കുക."
+msgstr "അപേക്ഷ നീക്കാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "സൃഷ്‌ടിച്ചത്"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "\"{0}\" സൃഷ്‌ടിക്കുകയും ഈ അപ്ലിക്കേഷനിലേക്ക് ലിങ്ക് ചെയ്യുകയും ചെയ്‌തു."
+msgstr "\"{0}\" സൃഷ്‌ടിക്കുകയും ഈ അപേക്ഷയിലേക്ക് ലിങ്ക് ചെയ്യുകയും ചെയ്‌തു."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "ഇഷ്ടാനുസൃത ശൈലികൾ"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "ചെക്ക്"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "ഡേഞ്ചർ മേഖല"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "ഡാനിഷ്"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "ടൈംലൈൻ എൻട്രി ഇല്ലാതാക്കു�
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "{0} ആപ്ലിക്കേഷൻ(കൾ) ഇല്ലാതാക്കി."
+msgstr "{0} അപേക്ഷ(കൾ) ഇല്ലാതാക്കി."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "നിങ്ങളുടെ റിസ്യൂം ഡൂപ്ലിക�
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "ഡച്ച്"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "തിരുത്തുക {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "ആപ്ലിക്കേഷൻ എഡിറ്റ് ചെയ്യുക"
+msgstr "അപേക്ഷ എഡിറ്റ് ചെയ്യുക"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "ടു-ഫാക്ടർ പ്രാമാണീകരണം പ്ര
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "ഇംഗ്ലീഷ്"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "ഇംഗ്ലീഷ് (യുണൈറ്റഡ് കിംഗ്ഡം)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "ദുർബലമായ ബുള്ളറ്റുകൾ കണ്ട�
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "ഫിന്നിഷ്"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "കാണാൻ അനുയോജ്യം"
+msgstr "കാഴ്ചയ്ക്ക് അനുയോജ്യമാക്കുക"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "ഫ്രീ-ഫോം"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "ഫ്രഞ്ച്"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "ഒരു റാൻഡം പേരുണ്ടാക്കുക"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "ജർമ്മൻ"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,13 +2116,13 @@ msgstr "തിരികെ പോകുക"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "വീട്ടിലേക്ക് പോകൂ"
+msgstr "ഹോം പേജിലേക്ക് പോകുക"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "ഡാഷ്ബോർഡിലേക്കു പോകുക"
+msgstr "ഡാഷ്‌ബോർഡിലേക്കു പോകുക"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "ഗ്രേഡ്"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "ഗ്രീക്ക്"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "ഹെഡ്ലൈൻ"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "ഹീബ്രു"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "നിറം ഹൈലൈറ്റ് ചെയ്യുക"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "ഹിന്ദി"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "ഹംഗേറിയൻ"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "CSV-ൽ നിന്ന് ഇറക്കുമതി ചെയ്യ�
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "ഇറക്കുമതി ചെയ്ത {0} ആപ്ലിക്കേഷൻ(കൾ)."
+msgstr "ഇറക്കുമതി ചെയ്ത {0} അപേക്ഷ(കൾ)."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "സൂം വർദ്ധിപ്പിക്കുക"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "ഇന്തോനേഷ്യൻ"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "ഇഷ്യൂവർ"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "ഇറ്റാലിയൻ"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "ഇറ്റാലിക്ക്"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "ജാപ്പനീസ്"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "ജസ്റ്റിഫൈ അലൈനിൽ ആക്കുക"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "കനനഡ"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "കീവേഡുകൾ"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "ഖെമർ"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "കൊറിയൻ"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "അവസാനം {0}-ന് കണ്ടു"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "ലാറ്റ്വിയൻ"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "ലിസ്റ്റ്"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "ലിത്വാനിയൻ"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "AI ദാതാക്കളെ ലോഡ് ചെയ്യുന്ന�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "ആപ്ലിക്കേഷനുകൾ ലോഡ് ചെയ്യുന്നു…"
+msgstr "അപേക്ഷകൾ ലോഡ് ചെയ്യുന്നു…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,7 +2754,7 @@ msgstr "അനുഭവ വിഭാഗം കൂടുതൽ ഫലാധിഷ
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "മലൈ"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
@@ -2762,7 +2762,7 @@ msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "മറാത്തി"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "വിഭാഗം മറ്റൊരു നിരയിലേക്ക�
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "സ്റ്റേജ് നീക്കുക"
+msgstr "ഘട്ടം നീക്കുക"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "പേര്"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "നേപ്പാളി"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "നെറ്റ്‌വർക്ക്"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "പുതിയ ആപ്ലിക്കേഷൻ"
+msgstr "പുതിയ അപേക്ഷ"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,11 +2902,11 @@ msgstr "പരസ്യങ്ങളില്ല, ട്രാക്കിംഗ�
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "നിങ്ങളുടെ ഫിൽട്ടറുകളുമായി പൊരുത്തപ്പെടുന്ന ആപ്ലിക്കേഷനുകളൊന്നുമില്ല."
+msgstr "നിങ്ങളുടെ ഫിൽട്ടറുകളുമായി പൊരുത്തപ്പെടുന്ന അപേക്ഷകളൊന്നുമില്ല."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "ഇതുവരെ ആപ്ലിക്കേഷനുകളൊന്നുമില്ല - നിങ്ങളുടെ ഫണലും മറുപടി നിരക്കുകളും കാണുന്നതിന് കുറച്ച് ചേർക്കുക."
+msgstr "ഇതുവരെ അപേക്ഷകളൊന്നുമില്ല - നിങ്ങളുടെ ഫണലും മറുപടി നിരക്കുകളും കാണുന്നതിന് കുറച്ച് ചേർക്കുക."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2960,7 +2960,7 @@ msgstr "ഇതുവരെ ത്രെഡുകളൊന്നുമില്�
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "നോർവീജിയൻ"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "കുറിപ്പുകൾ"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "ഒഡിയ"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-ക്ക് അനുയോജ്യം"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "പേഴ്‌സിയൻ"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "പൈപ്പ്ലൈൻ ഒഴുക്ക്"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "എല്ലാ ആപ്ലിക്കേഷനുകളിലും പൈപ്പ്ലൈൻ ആരോഗ്യം"
+msgstr "എല്ലാ അപേക്ഷകളിലും പൈപ്പ്‌ലൈൻ ആരോഗ്യം"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "നിങ്ങളുടെ PDF ജനറേറ്റ് ചെയ്യ
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "പോളിഷ്"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "പോർട്രെയിറ്റ്"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "പോർച്ചുഗീസ് (ബ്രസീൽ)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "പോർച്ചുഗീസ് (പോർച്ചുഗൽ)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - ഹോംപേജിലേക്കു പോകു�
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "പ്രതികരിക്കുന്ന റെസ്യൂമെ (ജെസൺ)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "റിയാക്ടീവ് റെസ്യൂമെ v<0>{__APP_VERSI
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "റിയാക്ടീവ് റെസ്യൂമെ v4 (ജെസൺ)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "റോൾ പുരോഗതി"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "റൊമാനിയൻ"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "നിങ്ങളുടെ ആദ്യ വിശകലനം നടത
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "റഷ്യൻ"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "തിരയുക"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "ആപ്ലിക്കേഷനുകൾ തിരയുക..."
+msgstr "അപേക്ഷകൾ തിരയുക..."
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "സെപറേറ്റർ"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "സെർബിയൻ"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "പ്രധാന ഉള്ളടക്കത്തിലേക്ക�
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "സ്ലൊവാക്"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "സ്ലോവേനിയൻ"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "സ്പേസിംഗ് (ലംബം)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "സ്പാനിഷ്"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "നിങ്ങൾക്ക് കഴിയുന്ന രീതിയ�
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "സ്വീഡിഷ്"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "ടെയ്ലറിംഗ് പരാജയപ്പെട്ടു."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "തമിഴ്"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "തെലുങ്ക്"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "ടെക്സ്റ്റ് നിറം"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "തായ്"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4630,7 +4630,7 @@ msgstr "നിങ്ങൾ അപേക്ഷിക്കുന്ന ജോല�
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "നിങ്ങളുടെ ആദ്യ ആപ്ലിക്കേഷൻ ട്രാക്ക് ചെയ്യുക"
+msgstr "നിങ്ങളുടെ ആദ്യ അപേക്ഷ ട്രാക്ക് ചെയ്യുക"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "വീണ്ടും ശ്രമിക്കുക"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "ടർക്കിഷ്"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "ടൈപ്പോഗ്രഫി"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "ഉക്രേനിയൻ"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "ഈ ടൈംലൈൻ എൻട്രിക്കുള്ള കലണ
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "ഈ ആപ്ലിക്കേഷൻ്റെ details അപ്‌ഡേറ്റ് ചെയ്യുക."
+msgstr "ഈ അപേക്ഷയുടെ വിവരങ്ങൾ അപ്‌ഡേറ്റ് ചെയ്യുക."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "യൂസർമാർ"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "ഉസ്‌ബെക്ക്"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "പതിപ്പ് ചരിത്രം"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "വിയറ്റ്നാമീസ്"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "സൂം ഔട്ട് ചെയ്യുക"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "സൂളു"
+msgstr "isiZulu"
 

--- a/apps/web/locales/mr-IN.po
+++ b/apps/web/locales/mr-IN.po
@@ -315,7 +315,7 @@ msgstr "प्रगत"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "आफ्रिकान्स"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "एआय प्रोव्हायडर्सना REDIS_URL आण
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "अल्बेनियन"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "आधीच खाते आहे? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "अम्हारिक"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,7 +447,7 @@ msgstr "अ‍ॅप"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "अनुप्रयोग क्रिया"
+msgstr "अर्ज क्रिया"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
@@ -464,7 +464,7 @@ msgstr "अर्ज हटवला."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "अ‍ॅप्लिकेशन आकडेवारी"
+msgstr "अर्ज आकडेवारी"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "इशाऱ्यांसह लागू केले"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "अरबी"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "पुरस्कार"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "अझरबैजानी"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "सुंदर साचे निवडण्यासाठी उप
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "बंगाली"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "ऍप्लिकेशन्स, शेअरिंग आणि प्रिंटिंगसाठी सर्वोत्तम."
+msgstr "अर्ज, शेअरिंग आणि प्रिंटिंगसाठी सर्वोत्तम."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "बिल्डर कमांड पॅलेट"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "बल्गेरियन"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "पुनर्स्थापित करता येणार ना
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "कॅटालन"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "मसुदा तपासणे"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "चीनी (सुलभ)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "चीनी (परंपरागत)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "गोलाकार"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "स्पष्ट"
+msgstr "साफ करा"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "कनेक्शनची पडताळणी होऊ शकली
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "अनुप्रयोग जोडू शकलो नाही. कृपया again वापरून पहा."
+msgstr "अर्ज जोडू शकलो नाही. कृपया पुन्हा प्रयत्न करा."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "अनुप्रयोग हटवू शकलो नाही."
+msgstr "अर्ज हटवू शकलो नाही."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "टाइमलाइन नोंद हटवता आली ना�
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "अर्ज हलवू शकलो नाही. कृपया again वापरून पहा."
+msgstr "अर्ज हलवू शकलो नाही. कृपया पुन्हा प्रयत्न करा."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "तयार केले"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "\"{0}\" तयार केले आणि या अनुप्रयोगाशी लिंक केले."
+msgstr "\"{0}\" तयार केले आणि या अर्जाशी लिंक केले."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "सानुकूल शैली"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "चेक"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "धोकादायक क्षेत्र"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "डॅनिश"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "तुमचा रेझ्युमे डुप्लिकेट क
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "डच"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "द्वि-घटक प्रमाणीकरण सक्षम �
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "इंग्रजी"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "इंग्रजी (युनायटेड किंगडम)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "कमजोर मुद्दे शोधा आणि अधिक �
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "फिन्निश"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "पाहण्यासाठी योग्य"
+msgstr "दृश्यासाठी समायोजित करा"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "मुक्त-स्वरूप"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "फ्रेंच"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "एखादे रँडम नाव तयार करा"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "जर्मन"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "मागे जा"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "घरी जा"
+msgstr "मुख्यपृष्ठावर जा"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "ग्रेड"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "ग्रीक"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "मथळा"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "हिब्रू"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "हायलाइट रंग"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "हिंदी"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "हंगेरीयन"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "CSV वरून आयात करा"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "आयात केलेले {0} अनुप्रयोग(ले)."
+msgstr "आयात केलेले {0} अर्ज."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "झूम वाढवा"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "इंडोनेशियन"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "जारीकर्ता"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "इटालियन"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "तिरपे (Italic)"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "जपानी"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "समसमान जुळवा"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "कन्नड"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "कीवर्ड"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "ख्मेर"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "कोरियन"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "शेवटचा व्ह्यू {0} रोजी झाला"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "लॅटवियन"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "यादी"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "लिथुआनियन"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "एआय प्रोव्हायडर्स लोड होत �
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "अनुप्रयोग लोड होत आहेत…"
+msgstr "अर्ज लोड होत आहेत…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,11 +2754,11 @@ msgstr "अनुभव विभागाला अधिक परिणाम
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "मलय"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "मल्याळम"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
@@ -2848,7 +2848,7 @@ msgstr "नाव"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "नेपाळी"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2889,12 +2889,12 @@ msgstr "नवीन टॅग…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "नवीन धागा"
+msgstr "नवीन थ्रेड"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "नवीन धागा"
+msgstr "नवीन थ्रेड"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2902,11 +2902,11 @@ msgstr "जाहिरात नाही, ट्रॅकिंग नाह�
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "कोणतेही अनुप्रयोग आपल्या फिल्टरशी जुळत नाहीत."
+msgstr "कोणतेही अर्ज आपल्या फिल्टरशी जुळत नाहीत."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "अद्याप कोणतेही अनुप्रयोग नाहीत — तुमचे फनेल आणि प्रत्युत्तर दर पाहण्यासाठी काही जोडा."
+msgstr "अद्याप कोणतेही अर्ज नाहीत — तुमचे फनेल आणि प्रत्युत्तर दर पाहण्यासाठी काही जोडा."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2960,7 +2960,7 @@ msgstr "अद्याप एकही थ्रेड नाही."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "नॉर्वेजियन"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "टिपा"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "ओडिया"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "उघडा"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "ओपन एआय एजंट"
+msgstr "एआय एजंट उघडा"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "ओपनएआय-सुसंगत"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "फारसी"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "पाइपलाइन प्रवाह"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "सर्व अनुप्रयोगांमध्ये पाइपलाइन आरोग्य"
+msgstr "सर्व अर्जांमध्ये पाइपलाइन आरोग्य"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "तुमची PDF तयार होत असताना कृप�
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "पोलिश"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "पोर्ट्रेट"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "पोर्तुगीज (ब्राझील)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "पोर्तुगीज (पोर्तुगाल)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - मुखपृष्ठावर जा"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "प्रतिक्रियाशील बायोडाटा (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "रिॲक्टिव्ह रिझ्युमे v<0>{__APP_VERSI
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "प्रतिक्रियाशील बायोडाटा v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "भूमिका प्रगती"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "रोमानियन"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "तुमचे पहिले विश्लेषण चालवा
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "रशियन"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "शोध"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "अनुप्रयोग शोधा…"
+msgstr "अर्ज शोधा…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3846,7 +3846,7 @@ msgstr "रेझ्युमे निवडा"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "एक धागा निवडा"
+msgstr "एक थ्रेड निवडा"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "सेपरेटर"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "सर्बियन"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "मुख्य विषयावर जा"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "स्लोव्हाक"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "स्लोव्हेनियन"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "स्पेसिंग (उभे)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "स्पॅनिश"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "GitHub वर आम्हाला स्टार द्या, सध
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "नवीन धागा सुरू करा"
+msgstr "नवीन थ्रेड सुरू करा"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "एक धागा सुरू करा"
+msgstr "एक थ्रेड सुरू करा"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4215,7 +4215,7 @@ msgstr "नवीन पृष्ठावर सुरू करा"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "धागा सुरू करा"
+msgstr "थ्रेड सुरू करा"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "जमेल ते करून या अ‍ॅपचे समर्�
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "स्वीडिश"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "अनुकूलन अयशस्वी झाले."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "तमिळ"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "तेलगू"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "मजकुराचा रंग"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "थाई"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4553,14 +4553,14 @@ msgstr "चर्चा संग्रहित केली आहे."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "धागा हटवला."
+msgstr "थ्रेड हटवला."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "धागे"
+msgstr "थ्रेड्स"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4647,7 +4647,7 @@ msgstr "पुन्हा प्रयत्न करा"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "तुर्की"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "टायपोग्राफी"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "युक्रेनियन"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "या टाइमलाइन नोंदीसाठी कॅले
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "या अनुप्रयोगाचे details अद्यतनित करा."
+msgstr "या अर्जाचे तपशील अद्यतनित करा."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "वापरकर्ते"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "उझबेक"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "आवृत्ती इतिहास"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "व्हिएतनामी"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "बाहेर झूम करा"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "झुलू"
+msgstr "isiZulu"
 

--- a/apps/web/locales/mr-IN.po
+++ b/apps/web/locales/mr-IN.po
@@ -2377,7 +2377,7 @@ msgstr "झूम वाढवा"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/mr-IN.po
+++ b/apps/web/locales/mr-IN.po
@@ -401,7 +401,7 @@ msgstr "आणि बरेच काही..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "अँथ्रोपिक क्लॉड"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "मधोमध जुळवा"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "सेरेब्रास"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "एआय सहाय्यक बंद करा"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "कोहेअर"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "झूम कमी करा"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "डीपसीक"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "फिन्निश"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "फटाके"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "गूगल"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "गूगल जेमिनी"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "ग्रिड"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "ग्रोक"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "कामाचा बायोडाटा गहाळ आहे"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "मिस्ट्रल एआय"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "ओडिया"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ओलामा क्लाउड"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "मुक्त स्रोत"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "ओपनएआय"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "ओपनएआय-सुसंगत"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "ओपनराऊटर"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "कालावधी"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "गोंधळ"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "वैध URL ची सुरुवात http:// किंवा https
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "व्हर्सेल एआय गेटवे"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/ms-MY.po
+++ b/apps/web/locales/ms-MY.po
@@ -260,13 +260,13 @@ msgstr "Tambah tag dan tekan Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Tambah dan uji pembekal sebelum memulakan thread ejen."
+msgstr "Tambah dan uji pembekal sebelum memulakan utas ejen."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Tambah aplikasi"
+msgstr "Tambah permohonan"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -364,7 +364,7 @@ msgstr "Penyedia AI memerlukan REDIS_URL dan ENCRYPTION_SECRET dikonfigurasikan.
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanian"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Sudah mempunyai akaun? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharic"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -451,7 +451,7 @@ msgstr "Tindakan permohonan"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Aplikasi ditambahkan pada saluran paip anda."
+msgstr "Permohonan ditambahkan pada saluran paip anda."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
@@ -460,11 +460,11 @@ msgstr "Copilot Permohonan"
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Aplikasi dipadamkan."
+msgstr "Permohonan dipadamkan."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Statistik Aplikasi"
+msgstr "Statistik Permohonan"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -475,7 +475,7 @@ msgstr "Permohonan dikemas kini."
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Aplikasi"
+msgstr "Permohonan"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Digunakan dengan amaran"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Bahasa Arab"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Anugerah"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaijani"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Templat cantik untuk dipilih, dengan lebih banyak lagi akan datang."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Terbaik untuk aplikasi, perkongsian dan percetakan."
+msgstr "Terbaik untuk permohonan, perkongsian dan percetakan."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Palet Perintah Pembina"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgarian"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Tidak dapat memulihkan; resume telah berubah sejak suntingan ini digunak
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalan"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Memeriksa draf"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Cina (Ringkas)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Cina (Tradisional)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Pilih resume"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Pilih perbualan sedia ada daripada bar sisi atau mulakan thread berfokus draf baharu."
+msgstr "Pilih perbualan sedia ada daripada bar sisi atau mulakan utas berfokus draf baharu."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "Bulatan"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Jelas"
+msgstr "Kosongkan"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Tidak dapat mengesahkan sambungan. Semak kunci API, model dan URL asas."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Tidak dapat menambahkan aplikasi. Sila cuba again."
+msgstr "Tidak dapat menambahkan permohonan. Sila cuba lagi."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Tidak dapat memadamkan aplikasi."
+msgstr "Tidak dapat memadamkan permohonan."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Tidak dapat memadam entri garis masa."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Tidak dapat mengalihkan aplikasi. Sila cuba again."
+msgstr "Tidak dapat mengalihkan permohonan. Sila cuba lagi."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Dicipta"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Mencipta \"{0}\" dan memautkannya ke aplikasi ini."
+msgstr "Mencipta \"{0}\" dan memautkannya ke permohonan ini."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Gaya Tersuai"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Czech"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Zon Bahaya"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danish"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Padam pembekal"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Padamkan thread ejen ini?"
+msgstr "Padamkan utas ejen ini?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1392,7 +1392,7 @@ msgstr "Padam entri garis masa"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Aplikasi {0} dipadamkan."
+msgstr "Permohonan {0} dipadamkan."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Menduplikasi resume anda..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Belanda"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Sunting {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Edit aplikasi"
+msgstr "Edit permohonan"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Mendayakan pengesahan dua faktor…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Bahasa Inggeris"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Bahasa Inggeris (United Kingdom)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Gagal menganalisis resume."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Gagal mengarkibkan thread."
+msgstr "Gagal mengarkibkan utas."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Gagal memadam kunci API. Sila cuba lagi."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Gagal memadamkan thread."
+msgstr "Gagal memadamkan utas."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Gagal log keluar. Sila cuba lagi."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Gagal memulakan thread ejen."
+msgstr "Gagal memulakan utas ejen."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Cari poin yang lemah dan tulis semula dengan hasil, nombor, skop dan kat
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finland"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Sesuai untuk dilihat"
+msgstr "Sesuaikan dengan paparan"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Bentuk bebas"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Perancis"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Jana nama rawak"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Bahasa Jerman"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Kembali"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Pulanglah ke rumah"
+msgstr "Ke laman utama"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Gred"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Greek"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Tajuk Utama"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Ibrani"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Warna Serlahan"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Hungary"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Import daripada CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Aplikasi {0} yang diimport."
+msgstr "Permohonan {0} yang diimport."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2425,7 +2425,7 @@ msgstr "Pengeluar"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Itali"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Condong"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Jepun"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Jajaran Penuh"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Kekal bersama"
+msgstr "Kekalkan bersama"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Kata Kunci"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Korea"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Kali terakhir dilihat pada {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Latvia"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Senarai"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lithuania"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Memuatkan penyedia AI. Sila cuba lagi sebentar lagi."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Memuatkan aplikasi…"
+msgstr "Memuatkan permohonan…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Memuatkan resume…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Memuatkan thread…"
+msgstr "Memuatkan utas…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Jadikan bahagian pengalaman lebih berorientasikan hasil dan singkirkan t
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Melayu"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Alihkan bahagian ke lajur atau halaman lain"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Bergerak pentas"
+msgstr "Gerakkan peringkat"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Nama"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepal"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2889,12 +2889,12 @@ msgstr "Tag baharu…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Benang baharu"
+msgstr "Utas baharu"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Benang Baharu"
+msgstr "Utas Baharu"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2902,11 +2902,11 @@ msgstr "Tiada Pengiklanan, Tiada Penjejakan"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Tiada aplikasi yang sepadan dengan penapis anda."
+msgstr "Tiada permohonan yang sepadan dengan penapis anda."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Belum ada aplikasi — tambahkan beberapa untuk melihat corong dan kadar balasan anda."
+msgstr "Belum ada permohonan — tambahkan beberapa untuk melihat corong dan kadar balasan anda."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2956,11 +2956,11 @@ msgstr "Tiada pembekal yang diuji"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Tiada thread lagi."
+msgstr "Tiada utas lagi."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norwegian"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Nota"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Buka"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Ejen AI terbuka"
+msgstr "Buka ejen AI"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Serasi dengan OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Parsi"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Aliran saluran paip"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Kesihatan saluran paip merentas semua aplikasi"
+msgstr "Kesihatan saluran paip merentas semua permohonan"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Sila tunggu sementara PDF anda dijana…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Poland"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Potret"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugis (Brazil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugis (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Pergi ke laman utama"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Resume Reaktif (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Resume Reaktif v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktif Resume v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Kemajuan Peranan"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rom"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Jalankan analisis pertama anda untuk mendapatkan kad skor, kekuatan, dan
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Rusia"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Carian"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Cari aplikasi…"
+msgstr "Cari permohonan…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3846,7 +3846,7 @@ msgstr "Pilih resume"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "Pilih thread"
+msgstr "Pilih utas"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "Pemisah"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbia"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Sediakan penyedia AI"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Sediakan penyedia AI sebelum memulakan thread."
+msgstr "Sediakan penyedia AI sebelum memulakan utas."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Langkau ke kandungan utama"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovak"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Bahasa Slovenia"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Jarak (Menegak)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Sepanyol"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "Berikan bintang kepada kami di GitHub, kini {0} bintang (dibuka dalam ta
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Mulakan thread baharu"
+msgstr "Mulakan utas baharu"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Mulakan thread"
+msgstr "Mulakan utas"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Mula bina resume anda dari awal"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Mulakan thread baharu"
+msgstr "Mulakan utas baharu"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4276,7 +4276,7 @@ msgstr "Sokong apl ini dengan melakukan apa yang anda mampu!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Sweden"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Penyesuaian gagal."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Warna Teks"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4464,7 +4464,7 @@ msgstr "Tindakan ini tidak boleh dibuat asal. Mesej perbualan dan lampiran yang 
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
-msgstr "Tindakan ini tidak boleh dibuat asal. Mesej dan lampiran thread akan dialih keluar."
+msgstr "Tindakan ini tidak boleh dibuat asal. Mesej dan lampiran utas akan dialih keluar."
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
@@ -4545,11 +4545,11 @@ msgstr "Ini akan membuang semua item daripada bahagian ini."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "Tindakan thread"
+msgstr "Tindakan utas"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Benang diarkibkan."
+msgstr "Utas diarkibkan."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
@@ -4560,7 +4560,7 @@ msgstr "Utas dipadamkan."
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Benang"
+msgstr "Utas"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "Togol bar sisi kanan"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Togol thread"
+msgstr "Togol utas"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4647,7 +4647,7 @@ msgstr "Cuba lagi"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turki"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipografi"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukraine"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Kemas kini tarikh kalendar untuk entri garis masa ini."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Kemas kini details aplikasi ini."
+msgstr "Kemas kini butiran permohonan ini."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Pengguna"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbek"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Sejarah versi"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnam"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Zum keluar"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ms-MY.po
+++ b/apps/web/locales/ms-MY.po
@@ -768,7 +768,7 @@ msgstr "Jajaran Tengah"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Serebrum"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Tutup pembantu AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Bersatu padu"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finland"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Bunga api"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Awan Ollama"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Tempoh"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Kekeliruan"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Untuk memadam akaun anda, anda perlu memasukkan teks pengesahan dan klik
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Bersama.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "URL yang sah mesti bermula dengan http:// atau https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Pintu Gerbang AI Vercel"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/ms-MY.po
+++ b/apps/web/locales/ms-MY.po
@@ -2377,7 +2377,7 @@ msgstr "Tingkatkan zum"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/ne-NP.po
+++ b/apps/web/locales/ne-NP.po
@@ -315,7 +315,7 @@ msgstr "उन्नत"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "अफ्रिकान्स"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "AI प्रदायकहरूलाई REDIS_URL र ENCRYPTION_SECR
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "अल्बानियन"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "पहिले नै खाता छ? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "अम्हारिक"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -455,7 +455,7 @@ msgstr "तपाईंको पाइपलाइनमा आवेदन थ
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "अनुप्रयोग सहपायलट"
+msgstr "आवेदन सहपायलट"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -464,7 +464,7 @@ msgstr "आवेदन मेटाइयो।"
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "अनुप्रयोग तथ्याङ्क"
+msgstr "आवेदन तथ्याङ्क"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -475,7 +475,7 @@ msgstr "आवेदन अद्यावधिक गरियो।"
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "अनुप्रयोगहरू"
+msgstr "आवेदनहरू"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "चेतावनीहरू सहित लागू गरियो
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "अरबी"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "पुरस्कारहरू"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "अजरबैजानी"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "छान्नका लागि आकर्षक ढाँचाह
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "बंगाली"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "अनुप्रयोगहरू, साझेदारी, र मुद्रणका लागि उत्तम।"
+msgstr "आवेदनहरू, साझेदारी, र मुद्रणका लागि उत्तम।"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "बिल्डर कमान्ड प्यालेट"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "बुल्गेरियन"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "पुनर्स्थापना गर्न सकिँदैन;
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "क्याटालान"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "मस्यौदा जाँच गर्दै"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "चिनियाँ (सरल)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "चिनियाँ (परम्परागत)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "वृत्त"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "स्पष्ट"
+msgstr "खाली गर्नुहोस्"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "जडान प्रमाणित गर्न सकिएन। AP
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "अनुप्रयोग थप्न सकिएन। कृपया again प्रयास गर्नुहोस्।"
+msgstr "आवेदन थप्न सकिएन। कृपया फेरि प्रयास गर्नुहोस्।"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "एप मेटाउन सकिएन।"
+msgstr "आवेदन मेटाउन सकिएन।"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "समयरेखा प्रविष्टि मेटाउन स
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "एप सार्न सकिएन। कृपया again प्रयास गर्नुहोस्।"
+msgstr "आवेदन सार्न सकिएन। कृपया फेरि प्रयास गर्नुहोस्।"
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "बनाइएको मिति"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "\"{0}\" सिर्जना गरी यो अनुप्रयोगमा लिङ्क गरियो।"
+msgstr "\"{0}\" सिर्जना गरी यो आवेदनमा लिङ्क गरियो।"
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "अनुकूलन शैलीहरू"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "चेक"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "खतराको क्षेत्र (Danger Zone)"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "डेनिस"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "तपाईंको बायोडाटा नक्कल हुँ
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "डच"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "दुई-कारक प्रमाणीकरण सक्षम �
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "अंग्रेजी"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "अंग्रेजी (संयुक्त अधिराज्य)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "कमजोर बुलेटहरू फेला पार्नु
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "फिनिस"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "हेर्नको लागि उपयुक्त"
+msgstr "दृश्यमा मिलाउनुहोस्"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "फ्री-फर्म"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "फ्रेन्च"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2079,7 +2079,7 @@ msgstr "पूर्ण-स्क्रिन सम्पादक"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Gaps:"
-msgstr "खाली ठाउँहरू:"
+msgstr "कमीहरू:"
 
 #: src/dialogs/resume/index.tsx
 msgid "Generate a random name"
@@ -2087,7 +2087,7 @@ msgstr "अनियमित (random) नाम सिर्जना गर्
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "जर्मन"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "फर्कनुहोस्"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "घर जानुहोस्"
+msgstr "गृहपृष्ठमा जानुहोस्"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "ग्रेड"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "ग्रीक"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "मुख्य शीर्षक (Headline)"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "हिब्रु"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "हंगेरीयाली"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "जुम बढाउनुहोस्"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "इन्डोनेसियन"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "जारी गर्ने संस्था/व्यक्ति (I
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "इटालियन"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "इटालिक"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "जापानी"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "दायाँ र बायाँ दुवैतर्फ समा�
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "कन्नड"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "कुञ्जी शब्दहरू (Keywords)"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "खमेर"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "कोरियन"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "अन्तिम पटक {0} मा हेेरिएको"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "लात्भियन"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "सूची"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "लिथुआनियन"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "AI प्रदायकहरू लोड गर्दै। कृप
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "अनुप्रयोगहरू लोड गर्दै…"
+msgstr "आवेदनहरू लोड गर्दै…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,11 +2754,11 @@ msgstr "अनुभव खण्डलाई थप परिणाममुख
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "मलय"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "मलयालम"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
@@ -2902,11 +2902,11 @@ msgstr "कुनै विज्ञापन छैन, कुनै ट्र�
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "कुनै पनि अनुप्रयोगहरू तपाईंको फिल्टरहरूसँग मेल खाँदैन।"
+msgstr "कुनै पनि आवेदनहरू तपाईंको फिल्टरहरूसँग मेल खाँदैन।"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "अहिलेसम्म कुनै अनुप्रयोगहरू छैनन् — तपाईंको फनेल र जवाफ दरहरू हेर्न केही थप्नुहोस्।"
+msgstr "अहिलेसम्म कुनै आवेदनहरू छैनन् — तपाईंको फनेल र जवाफ दरहरू हेर्न केही थप्नुहोस्।"
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2960,7 +2960,7 @@ msgstr "अहिलेसम्म कुनै थ्रेड छैन।"
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "नर्वेजियन"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "नोटहरू"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "ओडिया"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "खोल्नुहोस्"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "ओपन एआई एजेन्ट"
+msgstr "एआई एजेन्ट खोल्नुहोस्"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "ओपनएआई-कम्प्याटिबल"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "फारसी"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "पाइपलाइन प्रवाह"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "सबै अनुप्रयोगहरूमा पाइपलाइन स्वास्थ्य"
+msgstr "सबै आवेदनहरूमा पाइपलाइन स्वास्थ्य"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "कृपया तपाईंको PDF उत्पन्न हु�
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "पोलिस"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "पोर्ट्रेट"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "पोर्चुगाली (ब्राजिल)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "पोर्चुगाली (पोर्चुगल)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - गृहपृष्ठमा जानुहोस�
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "प्रतिक्रियाशील बायोडाटा (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "प्रतिक्रियाशील रिजुमे v<0>{__APP
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "प्रतिक्रियाशील बायोडाटा v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "भूमिका प्रगति"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "रुमानियन"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "स्कोरकार्ड, शक्तिहरू, र प्र�
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "रुसियन"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "खोज्नुहोस्"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "खोज एपहरू…"
+msgstr "आवेदनहरू खोज्नुहोस्…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "पृथक्करण रेखा (Separator)"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "सर्बियन"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "मुख्य सामग्रीमा जानुहोस्"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "स्लोभाक"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "स्लोभेनियन"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "स्पेसिङ (ठाडो)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "स्पेनी"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "आफ्नो सामर्थ्यअनुसार सहयो�
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "स्विडिस"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Tailoring failed।"
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "तमिल"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "तेलुगु"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "पाठ रङ"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "थाइ"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "फेरि प्रयास गर्नुहोस्"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "टर्किस"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "टाइपोग्राफी"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "युक्रेनी"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "यो समयरेखा प्रविष्टिका लाग
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "यो एपको details अपडेट गर्नुहोस्।"
+msgstr "यो आवेदनको विवरण अपडेट गर्नुहोस्।"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "प्रयोगकर्ताहरू"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "उज्बेक"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "संस्करण इतिहास"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "भियतनामी"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "जूम आउट"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "जुलु"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ne-NP.po
+++ b/apps/web/locales/ne-NP.po
@@ -401,7 +401,7 @@ msgstr "र यस्ता थुप्रै..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "एन्थ्रोपिक क्लोड"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "बीचतिर क्रमबद्ध (Center Align)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "सेरेब्रास"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "एआई सहायक बन्द गर्नुहोस्"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "कोहेर"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "जुम घटाउनुहोस्"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "डीपसिक"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "फिनिस"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "आतिशबाजी"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "गुगल"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "गुगल जेमिनी"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "ग्रिड"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "ग्रोक"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "काम गर्ने बायोडाटा हराइरहे
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "मिस्ट्रल एआई"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "ओडिया"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ओलामा क्लाउड"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "खुला-स्रोत"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "ओपनएआई"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "ओपनएआई-कम्प्याटिबल"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "ओपनराउटर"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "अवधि"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "अन्योल"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "तपाईंको खाता मेटाउन, तपाईं�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Together.ai का थप वस्तुहरू"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "मान्य URL http:// वा https:// बाट सुरु ह�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "वर्सेल एआई गेटवे"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "एक्स (ट्विटर)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI ग्रोक"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/ne-NP.po
+++ b/apps/web/locales/ne-NP.po
@@ -2377,7 +2377,7 @@ msgstr "जुम बढाउनुहोस्"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/nl-NL.po
+++ b/apps/web/locales/nl-NL.po
@@ -266,7 +266,7 @@ msgstr "Voeg een provider toe en test deze voordat u een agentthread start."
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Toepassing toevoegen"
+msgstr "Sollicitatie toevoegen"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -364,7 +364,7 @@ msgstr "AI-providers vereisen dat REDIS_URL en ENCRYPTION_SECRET geconfigureerd 
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanees"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Heb je al een account? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amhaars"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "App"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Toepassingsacties"
+msgstr "Sollicitatieacties"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Applicatie toegevoegd aan uw pijplijn."
+msgstr "Sollicitatie toegevoegd aan uw pijplijn."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Toepassing Copiloot"
+msgstr "Sollicitatie-Copiloot"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Applicatie verwijderd."
+msgstr "Sollicitatie verwijderd."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Applicatiestatistieken"
+msgstr "Sollicitatiestatistieken"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Applicatie bijgewerkt."
+msgstr "Sollicitatie bijgewerkt."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Toepassingen"
+msgstr "Sollicitaties"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Toegepast met waarschuwingen"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabisch"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Prijzen"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbeidzjaans"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Prachtige sjablonen om uit te kiezen, met meer in aantocht."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengaals"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Ideaal voor toepassingen, delen en afdrukken."
+msgstr "Ideaal voor sollicitaties, delen en afdrukken."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Builder-opdrachtpalet"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgaars"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Herstellen is niet mogelijk; het cv is gewijzigd sinds deze bewerking is
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalaans"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Concept controleren"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chinees (vereenvoudigd)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chinees (traditioneel)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Kies een cv"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Kies een bestaand gesprek uit de zijbalk of start een nieuw discussieonderwerp gericht op concepten."
+msgstr "Kies een bestaand gesprek uit de zijbalk of start een nieuwe thread gericht op concepten."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "Cirkel"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Duidelijk"
+msgstr "Wis"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "De verbinding kon niet worden geverifieerd. Controleer de API-sleutel, h
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Kan de applicatie niet toevoegen. Probeer again."
+msgstr "Kan de sollicitatie niet toevoegen. Probeer het opnieuw."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Kan de applicatie niet verwijderen."
+msgstr "Kan de sollicitatie niet verwijderen."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "De tijdlijnvermelding kon niet worden verwijderd."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Kan de applicatie niet verplaatsen. Probeer again."
+msgstr "Kan de sollicitatie niet verplaatsen. Probeer het opnieuw."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Aangemaakt"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "\"{0}\" gemaakt en aan deze applicatie gekoppeld."
+msgstr "\"{0}\" gemaakt en aan deze sollicitatie gekoppeld."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Aangepaste stijlen"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Tsjechisch"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Gevarenzone"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Deens"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "Tijdlijnvermelding verwijderen"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "{0}-applicatie(s) verwijderd."
+msgstr "{0} sollicitatie(s) verwijderd."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1568,7 +1568,7 @@ msgstr "Bewerk {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Applicatie bewerken"
+msgstr "Sollicitatie bewerken"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Tweefactorauthenticatie inschakelen…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Engels"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Engels (Verenigd Koninkrijk)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Identificeer zwakke punten en herschrijf ze met sterkere resultaten, cij
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Fins"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Geschikt om te bekijken"
+msgstr "Aanpassen aan weergave"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Vrije vorm"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Frans"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Genereer een willekeurige naam"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Duits"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Ga terug"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Ga naar huis"
+msgstr "Naar de startpagina"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Cijfer"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Grieks"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Titel"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebreeuws"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Markeer de kleur"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Hongaars"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Importeren uit CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Geïmporteerde {0}-applicatie(s)."
+msgstr "Geïmporteerde {0} sollicitatie(s)."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Zoom vergroten"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesisch"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Uitgever"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italiaans"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Cursief"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japans"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Uitlijnen als blok"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Blijf bij elkaar"
+msgstr "Bij elkaar houden"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Sleutelwoorden"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Koreaans"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Laatst bekeken op {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Lets"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Lijst"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litouws"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "AI-providers worden geladen. Probeer het over een moment opnieuw."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Applicaties laden…"
+msgstr "Sollicitaties laden…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Maak het ervaringsgedeelte resultaatgerichter en verwijder vage verantwo
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Maleis"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Verplaats de sectie naar een andere kolom of pagina."
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Verplaats podium"
+msgstr "Fase verplaatsen"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Naam"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalees"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Netwerk"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Nieuwe aanvraag"
+msgstr "Nieuwe sollicitatie"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "Nieuw label…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Nieuw topic"
+msgstr "Nieuwe thread"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Nieuw topic"
+msgstr "Nieuwe thread"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2902,11 +2902,11 @@ msgstr "Geen advertenties, geen tracking"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Er zijn geen applicaties die overeenkomen met uw filters."
+msgstr "Er zijn geen sollicitaties die overeenkomen met uw filters."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Nog geen aanvragen: voeg er een paar toe om uw trechter- en antwoordpercentages te bekijken."
+msgstr "Nog geen sollicitaties: voeg er een paar toe om uw trechter- en antwoordpercentages te bekijken."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2956,11 +2956,11 @@ msgstr "Geen geteste provider"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Nog geen discussies."
+msgstr "Nog geen threads."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Noors"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Aantekeningen"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Openen"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Open AI-agent"
+msgstr "AI-agent openen"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-compatibel"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Perzisch"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Pijpleidingstroom"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Pijplijnstatus voor alle applicaties"
+msgstr "Pijplijnstatus voor alle sollicitaties"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Even geduld alstublieft terwijl uw PDF wordt gegenereerd…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Pools"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Staand"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugees (Brazilië)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugees (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Ga naar de startpagina"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reactief cv (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reactief hervatten v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reactieve cv v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Loopbaanontwikkeling"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Roemeens"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Voer uw eerste analyse uit om een scorekaart, sterke punten en gepriorit
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russisch"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Zoekopdracht"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Applicaties zoeken…"
+msgstr "Sollicitaties zoeken…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3846,7 +3846,7 @@ msgstr "Selecteer een cv"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "Selecteer een draad"
+msgstr "Selecteer een thread"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "Scheidingsteken"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Servisch"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Stel een AI-aanbieder in."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Stel een AI-provider in voordat u een discussie start."
+msgstr "Stel een AI-provider in voordat u een thread start."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Ga naar hoofdinhoud"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slowaaks"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Sloveens"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Afstand (verticaal)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spaans"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "Geef ons een ster op GitHub, momenteel {0} sterren (opent in nieuw tabbl
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Start een nieuw onderwerp"
+msgstr "Start een nieuwe thread"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Start een discussie"
+msgstr "Start een thread"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Begin met het opstellen van uw cv vanaf nul"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Een nieuw onderwerp starten"
+msgstr "Een nieuwe thread starten"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Begin op een nieuwe pagina"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Start een discussie"
+msgstr "Start een thread"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Steun de app door te doen wat u kunt!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Zweeds"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Aanpassen mislukt."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Tekstkleur"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thais"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "De ingevoerde URL is niet geldig."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Het werk-cv is verwijderd. Deze discussie is alleen-lezen."
+msgstr "Het werk-cv is verwijderd. Deze thread is alleen-lezen."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4464,7 +4464,7 @@ msgstr "Deze actie kan niet ongedaan worden gemaakt. Gespreksberichten en geüpl
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
-msgstr "Deze actie kan niet ongedaan worden gemaakt. Berichten en bijlagen in de conversatie worden verwijderd."
+msgstr "Deze actie kan niet ongedaan worden gemaakt. Berichten en threadbijlagen worden verwijderd."
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
@@ -4520,11 +4520,11 @@ msgstr "Deze stap is optioneel, maar wel aanbevolen."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Dit discussieforum is gearchiveerd. Er kunnen geen nieuwe berichten meer worden verzonden."
+msgstr "Deze thread is gearchiveerd. Er kunnen geen nieuwe berichten meer worden verzonden."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Dit discussieforum is alleen-lezen."
+msgstr "Deze thread is alleen-lezen."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
@@ -4545,22 +4545,22 @@ msgstr "Hiermee worden alle items uit deze sectie verwijderd."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "Draadacties"
+msgstr "Threadacties"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Discussie gearchiveerd."
+msgstr "Thread gearchiveerd."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Onderwerp verwijderd."
+msgstr "Thread verwijderd."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Draden"
+msgstr "Threads"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4630,7 +4630,7 @@ msgstr "Volg een vacature waarop u solliciteert en koppel het cv dat u heeft ver
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "Volg uw eerste aanvraag"
+msgstr "Volg uw eerste sollicitatie"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "Probeer het opnieuw"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turks"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typografie"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Oekraïens"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Werk de kalenderdatum voor deze tijdlijnvermelding bij."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Update de details van deze applicatie."
+msgstr "Werk de gegevens van deze sollicitatie bij."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Gebruikers"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Oezbeeks"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Versiegeschiedenis"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamees"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,7 +5039,7 @@ msgstr "Wanneer het cv is vergrendeld, kan het niet worden bijgewerkt of verwijd
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "Waar applicaties vandaan komen"
+msgstr "Waar sollicitaties vandaan komen"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
@@ -5190,5 +5190,5 @@ msgstr "Uitzoomen"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/nl-NL.po
+++ b/apps/web/locales/nl-NL.po
@@ -401,7 +401,7 @@ msgstr "En nog veel meer..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropische Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -876,7 +876,7 @@ msgstr "AI-assistent sluiten"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Samenhangen"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Verklein de zoom"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Diepzoeken"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Fins"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Vuurwerk"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "Google"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "Google Tweelingen"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -3207,7 +3207,7 @@ msgstr "Periode"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Verwarring"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Om uw account te verwijderen, moet u de bevestigingstekst invoeren en op
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Samen.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/nl-NL.po
+++ b/apps/web/locales/nl-NL.po
@@ -2377,7 +2377,7 @@ msgstr "Zoom vergroten"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/no-NO.po
+++ b/apps/web/locales/no-NO.po
@@ -768,7 +768,7 @@ msgstr "Midtstill"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Hjernen"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Lukk AI-assistenten"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Koherens"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Fyrverkeri"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Ollama-skyen"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Periode"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Forvirring"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "For å slette kontoen din må du skrive inn bekreftelsesteksten og klikk
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Sammen.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/no-NO.po
+++ b/apps/web/locales/no-NO.po
@@ -266,7 +266,7 @@ msgstr "Legg til og test en leverandør før du starter en agenttråd."
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Legg til applikasjon"
+msgstr "Legg til søknad"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -364,7 +364,7 @@ msgstr "AI-leverandører krever at REDIS_URL og ENCRYPTION_SECRET konfigureres."
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albansk"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Har du allerede en konto? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharisk"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -451,11 +451,11 @@ msgstr "Søknadshandlinger"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Applikasjon lagt til rørledningen din."
+msgstr "Søknad lagt til rørledningen din."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Program Copilot"
+msgstr "Søknads-Copilot"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -464,7 +464,7 @@ msgstr "Søknad slettet."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Applikasjonsstatistikk"
+msgstr "Søknadsstatistikk"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Brukes med advarsler"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabisk"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Priser"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Aserbajdsjansk"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Vakre maler å velge mellom, med flere på vei."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Best for programmer, deling og utskrift."
+msgstr "Best for søknader, deling og utskrift."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Bygger-kommandopalett"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgarsk"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Kan ikke gjenopprette; CV-en har endret seg siden denne redigeringen ble
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalansk"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Sjekker utkast"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Kinesisk (forenklet)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Kinesisk (tradisjonell)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1044,12 +1044,12 @@ msgstr "Kunne ikke bekrefte tilkoblingen. Sjekk API-nøkkelen, modellen og basis
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Kunne ikke legge til applikasjonen. Vennligst prøv again."
+msgstr "Kunne ikke legge til søknaden. Vennligst prøv igjen."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Kunne ikke slette applikasjonen."
+msgstr "Kunne ikke slette søknaden."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Kunne ikke slette tidslinjeoppføringen."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Kunne ikke flytte applikasjonen. Vennligst prøv again."
+msgstr "Kunne ikke flytte søknaden. Vennligst prøv igjen."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Opprettet"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Opprettet \"{0}\" og koblet den til denne applikasjonen."
+msgstr "Opprettet \"{0}\" og koblet den til denne søknaden."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Tilpassede stiler"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Tsjekkisk"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1392,7 +1392,7 @@ msgstr "Slett tidslinjeoppføring"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Slettet {0}-applikasjon(er)."
+msgstr "Slettet {0} søknad(er)."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Dupliserer CV-en din..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Nederlandsk"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Aktivering av tofaktorautentisering…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Engelsk"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Engelsk (Storbritannia)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Finn svake punkter og skriv dem om med sterkere utfall, tall, omfang og 
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finsk"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Tilpasset til visning"
+msgstr "Tilpass til visning"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Friform"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Fransk"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2079,7 +2079,7 @@ msgstr "Fullskjermredigering"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Gaps:"
-msgstr "Gull:"
+msgstr "Mangler:"
 
 #: src/dialogs/resume/index.tsx
 msgid "Generate a random name"
@@ -2087,7 +2087,7 @@ msgstr "Generer et tilfeldig navn"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Tysk"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,18 +2116,18 @@ msgstr "Gå tilbake"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Gå hjem"
+msgstr "Til forsiden"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Gå til kontrollpanelet"
+msgstr "Gå til dashbordet"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Gå til CV-oversikten"
+msgstr "Gå til dashbordet for CV-er"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Karakter"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Gresk"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2199,11 +2199,11 @@ msgstr "Overskrift 6"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
 msgid "Headline"
-msgstr "Overskrift"
+msgstr "Underoverskrift"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebraisk"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Uthevingsfarge"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Ungarsk"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Importer fra CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Importert {0}-applikasjon(er)."
+msgstr "Importert {0} søknad(er)."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Øk zoomen"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesisk"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Utsteder"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italiensk"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kursiv"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japansk"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "Blokkjuster"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "Nøkkelord"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Koreansk"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Sist vist {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Latvisk"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Liste"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litauisk"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Laster inn AI-leverandører. Prøv igjen om et øyeblikk."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Laster inn applikasjoner…"
+msgstr "Laster inn søknader…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Gjør erfaringsdelen mer resultatorientert og fjern vage ansvarsområder
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malayisk"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Navn"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepali"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Nettverk"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Ny applikasjon"
+msgstr "Ny søknad"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,11 +2902,11 @@ msgstr "Ingen annonser, ingen sporing"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Ingen apper samsvarer med filtrene dine."
+msgstr "Ingen søknader samsvarer med filtrene dine."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Ingen applikasjoner ennå – legg til noen for å se trakten og svarfrekvensen din."
+msgstr "Ingen søknader ennå – legg til noen for å se trakten og svarfrekvensen din."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2977,7 +2977,7 @@ msgstr "Notater"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Åpne"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Åpen AI-agent"
+msgstr "Åpne AI-agenten"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-kompatibel"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persisk"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Rørledningsstrøm"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Rørledningshelse på tvers av alle applikasjoner"
+msgstr "Rørledningshelse på tvers av alle søknader"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Vent mens PDF-filen din genereres…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polsk"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Stående"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugisisk (Brasil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugisisk (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3681,7 +3681,7 @@ msgstr "Rolleutvikling"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumensk"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Kjør din første analyse for å få et poengkort, styrker og prioritert
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russisk"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Søk"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Søk i apper …"
+msgstr "Søk i søknader …"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Skillelinje"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbisk"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Hopp til hovedinnhold"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovakisk"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovensk"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Avstand (vertikal)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spansk"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Støtt appen ved å gjøre det du kan!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Svensk"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Tilpasningen mislyktes."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Tekstfarge"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thai"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "Prøv igjen"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Tyrkisk"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typografi"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrainsk"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Oppdater kalenderdatoen for denne tidslinjeoppføringen."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Oppdater dette programmets details."
+msgstr "Oppdater detaljene til denne søknaden."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Brukere"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Usbekisk"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Versjonshistorikk"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamesisk"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Zoom ut"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/no-NO.po
+++ b/apps/web/locales/no-NO.po
@@ -2377,7 +2377,7 @@ msgstr "Øk zoomen"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/or-IN.po
+++ b/apps/web/locales/or-IN.po
@@ -2079,7 +2079,7 @@ msgstr "ପୂର୍ଣ୍ଣପର୍ଦ୍ଦା ସମ୍ପାଦକ"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Gaps:"
-msgstr "ତ୍ରୁଟି:"
+msgstr "ଅଭାବ:"
 
 #: src/dialogs/resume/index.tsx
 msgid "Generate a random name"
@@ -2377,7 +2377,7 @@ msgstr "ଜୁମ୍ ବଢ଼ାନ୍ତୁ"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/or-IN.po
+++ b/apps/web/locales/or-IN.po
@@ -768,7 +768,7 @@ msgstr "ମଧ୍ୟରେ ସଙ୍ଗୁଯୋଗ କରନ୍ତୁ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "ସେରେବ୍ରାସ୍"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "AI ଆସିଷ୍ଟାଣ୍ଟ ବନ୍ଦ କରନ୍ତୁ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "କୋହେର"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "ଜୁମ୍ କମାନ୍ତୁ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "ଡିପସିକ୍"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "ଫିନିଶ୍"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "ଆତସବାଜି"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2162,7 +2162,7 @@ msgstr "ଗ୍ରିଡ୍ (Grid)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "ଗ୍ରୋକ୍"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "କାର୍ଯ୍ୟକ୍ଷମ ରିଜ୍ୟୁମ୍ ଉପଲବ�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "ମିଷ୍ଟ୍ରାଲ୍ ଏଆଇ"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ଓଲାମା କ୍ଲାଉଡ୍"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "ଅବଧି"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "ଦ୍ୱନ୍ଦ୍ୱ"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "ଆପଣଙ୍କ ଆକାଉଣ୍ଟ ବିଲୋପ କରିବା
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "ଏକାଠି.ଆଇ"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -5063,7 +5063,7 @@ msgstr "X (ଟ୍ୱିଟର)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI ଗ୍ରୋକ୍"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/or-IN.po
+++ b/apps/web/locales/or-IN.po
@@ -266,7 +266,7 @@ msgstr "ଏଜେଣ୍ଟ ଥ୍ରେଡ୍ ଆରମ୍ଭ କରିବା �
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "ପ୍ରୟୋଗ ଯୋଡନ୍ତୁ |"
+msgstr "ଆବେଦନ ଯୋଡନ୍ତୁ।"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "ଅଗ୍ରୀମ"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "ଆଫ୍ରିକାନ୍ସ"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "AI ପ୍ରଦାନକାରୀମାନଙ୍କୁ REDIS_URL ଏବ�
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "ଆଲବାନିଆନ୍"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "ପୂର୍ବରୁ ଖାତା ଅଛି? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "ଆମହାରିକ୍"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "ଆପ୍"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "ପ୍ରୟୋଗ କ୍ରିୟା |"
+msgstr "ଆବେଦନ କ୍ରିୟା।"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "ଆପଣଙ୍କର ପାଇପଲାଇନରେ ପ୍ରୟୋଗ ଯୋଡା ଯାଇଛି |"
+msgstr "ଆପଣଙ୍କର ପାଇପଲାଇନରେ ଆବେଦନ ଯୋଡା ଯାଇଛି।"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "ପ୍ରୟୋଗ କପିଲଟ୍ |"
+msgstr "ଆବେଦନ କପିଲଟ୍।"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "ପ୍ରୟୋଗ ବିଲୋପ ହେଲା |"
+msgstr "ଆବେଦନ ବିଲୋପ ହେଲା।"
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "ଆପ୍ଲିକେସନ୍ ସଂଖ୍ୟାତ୍ମକ ତଥ୍ୟ"
+msgstr "ଆବେଦନ ସଂଖ୍ୟାତ୍ମକ ତଥ୍ୟ"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "ଆବେଦନ ଅଦ୍ୟତନ ହୋଇଛି |"
+msgstr "ଆବେଦନ ଅଦ୍ୟତନ ହୋଇଛି।"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "ପ୍ରୟୋଗଗୁଡ଼ିକ"
+msgstr "ଆବେଦନଗୁଡ଼ିକ"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "ଚେତାବନୀ ସହିତ ଲାଗୁ କରାଯାଇଛି
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "ଆରବୀ"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "ପୁରସ୍କାରଗୁଡିକ"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "ଆଜେରବାଇଜାନୀ"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "ଚୟନ କରିବା ପାଇଁ ସୁନ୍ଦର ଟେମ୍�
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "ବଙ୍ଗାଳୀ"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "ପ୍ରୟୋଗ, ଅଂଶୀଦାର ଏବଂ ମୁଦ୍ରଣ ପାଇଁ ସର୍ବୋତ୍ତମ |"
+msgstr "ଆବେଦନ, ଅଂଶୀଦାର ଏବଂ ମୁଦ୍ରଣ ପାଇଁ ସର୍ବୋତ୍ତମ।"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "ବିଲ୍ଡର କମାଣ୍ଡ ପ୍ୟାଲେଟ୍"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "ବଲଗେରିଆନ୍"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "ପୁନଃସ୍ଥାପନ କରାଯାଇପାରିବ ନା�
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "କାଟାଲାନ୍"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "ଡ୍ରାଫ୍ଟ ଯାଞ୍ଚ କରାଯାଉଛି"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "ଚାଇନିଜ୍ (ସରଳୀକୃତ)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "ଚାଇନିଜ୍ (ପାରମ୍ପରିକ)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1044,12 +1044,12 @@ msgstr "ସଂଯୋଗ ଯାଞ୍ଚ କରିପାରିଲା ନାହି
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "ଅନୁପ୍ରୟୋଗ ଯୋଗ କରିପାରିବ ନାହିଁ | ଦୟାକରି again ଚେଷ୍ଟା କରନ୍ତୁ |"
+msgstr "ଆବେଦନ ଯୋଡ଼ିପାରିବା ନାହିଁ। ଦୟାକରି ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ।"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "ଅନୁପ୍ରୟୋଗ ବିଲୋପ କରିପାରିଲା ନାହିଁ |"
+msgstr "ଆବେଦନ ବିଲୋପ କରିପାରିଲା ନାହିଁ।"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "ସମୟରେଖା ପ୍ରବେଶକୁ ଡିଲିଟ୍ କର
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "ଅନୁପ୍ରୟୋଗ ଘୁଞ୍ଚାଇ ପାରିଲା ନାହିଁ | ଦୟାକରି again ଚେଷ୍ଟା କରନ୍ତୁ |"
+msgstr "ଆବେଦନ ଘୁଞ୍ଚାଇ ପାରିଲା ନାହିଁ। ଦୟାକରି ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ।"
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "ତିଆରି ହୋଇଛି"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "\"{0}\" ସୃଷ୍ଟି କରି ଏହାକୁ ଏହି ଅନୁପ୍ରୟୋଗ ସହିତ ଲିଙ୍କ୍ କଲା |"
+msgstr "\"{0}\" ସୃଷ୍ଟି କରି ଏହାକୁ ଏହି ଆବେଦନ ସହିତ ଲିଙ୍କ୍ କଲା।"
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "କଷ୍ଟମ୍ ଷ୍ଟାଇଲ୍ସ"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "ଚେକ୍"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "ଡେଞ୍ଜର୍ ଜୋନ୍"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "ଡାନିସ୍"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "ସମୟରେଖା ପ୍ରବେଶ ଡିଲିଟ୍ କରନ୍
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "{0} ପ୍ରୟୋଗ (ଗୁଡିକ) ବିଲୋପ ହୋଇଛି |"
+msgstr "{0} ଆବେଦନ(ଗୁଡ଼ିକ) ବିଲୋପ ହୋଇଛି।"
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "ଆପଣଙ୍କ ରେଜ୍ୟୁମେ ନକଲ ହେଉଛି...
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "ଡଚ୍"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "{chip} ସମ୍ପାଦନ କରନ୍ତୁ"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "ପ୍ରୟୋଗ ସଂପାଦନ କରନ୍ତୁ |"
+msgstr "ଆବେଦନ ସଂପାଦନ କରନ୍ତୁ।"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "ଦୁଇ-ସ୍ତରୀୟ ପ୍ରମାଣୀକରଣ ସକ୍ଷ
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "ଇଂରାଜୀ"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "ଇଂରାଜୀ (ଯୁକ୍ତରାଜ୍ୟ)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "ଦୁର୍ବଳ ବୁଲେଟ୍ ଖୋଜନ୍ତୁ ଏବଂ �
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "ଫିନିଶ୍"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "ଦେଖିବା ପାଇଁ ଫିଟ୍"
+msgstr "ଦୃଶ୍ୟରେ ଫିଟ୍ କରନ୍ତୁ"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "ମୁକ୍ତ-ଫର୍ମ"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "ଫ୍ରେଞ୍ଚ୍"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2079,7 +2079,7 @@ msgstr "ପୂର୍ଣ୍ଣପର୍ଦ୍ଦା ସମ୍ପାଦକ"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Gaps:"
-msgstr "ଫାଙ୍କା:"
+msgstr "ତ୍ରୁଟି:"
 
 #: src/dialogs/resume/index.tsx
 msgid "Generate a random name"
@@ -2087,7 +2087,7 @@ msgstr "ଏକ ଯାଦୃଚ୍ଛିକ ନାମ ତିଆରି କରନ�
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "ଜର୍ମାନ୍"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "ପଛକୁ ଯାଆନ୍ତୁ"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "ଘରକୁ ଯାଆନ୍ତୁ"
+msgstr "ମୁଖ୍ୟ ପୃଷ୍ଠାକୁ ଯାଆନ୍ତୁ"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "ଗ୍ରେଡ୍"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "ଗ୍ରୀକ୍"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "ଶିରୋନାମା"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "ହିବ୍ରୁ"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "ହାଇଲାଇଟ୍ ରଙ୍ଗ"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "ହିନ୍ଦୀ"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "ହଙ୍ଗେରିଆନ୍"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "CSV ରୁ ଆମଦାନି କରନ୍ତୁ |"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "ଆମଦାନୀ ହୋଇଥିବା {0} ପ୍ରୟୋଗ (ଗୁଡିକ) |"
+msgstr "ଆମଦାନୀ ହୋଇଥିବା {0} ଆବେଦନ(ଗୁଡ଼ିକ)।"
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "ଜୁମ୍ ବଢ଼ାନ୍ତୁ"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "ଇଣ୍ଡୋନେସିଆନ୍"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "ଜାରିକର୍ତ୍ତା"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "ଇଟାଲିଆନ୍"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "ଇଟାଲିକ୍"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "ଜାପାନୀ"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "ଜଷ୍ଟିଫାଇ ସଙ୍ଗୁଯୋଗ"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "କନ୍ନଡ"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "ଏକାଠି ରୁହନ୍ତୁ"
+msgstr "ଏକାଠି ରଖନ୍ତୁ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "କୀୱାର୍ଡଗୁଡିକ"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "ଖ୍ମେର୍"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "କୋରିଆନ୍"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "ଶେଷ ଦେଖାଯାଇଛି {0} ରେ"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "ଲାଟଭିଆନ୍"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "ତାଲିକା (List)"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "ଲିଥୁଆନିଆନ୍"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "AI ପ୍ରଦାନକାରୀଙ୍କୁ ଲୋଡ୍ କରାଯ�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "ଆପ୍ଲିକେସନଗୁଡ଼ିକ ଲୋଡ୍ ହେଉଛି…"
+msgstr "ଆବେଦନଗୁଡ଼ିକ ଲୋଡ୍ ହେଉଛି…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "ଅଭିଜ୍ଞତା ବିଭାଗକୁ ଅଧିକ ଫଳାଫ
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "ମାଲୟ"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "ମଲୟାଳମ"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "ମରାଠୀ"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "ନାମ"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "ନେପାଳୀ"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "ନେଟୱର୍କ"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "ନୂତନ ଆପ୍ଲିକେସନ୍"
+msgstr "ନୂତନ ଆବେଦନ"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,11 +2902,11 @@ msgstr "ବିଜ୍ଞାପନ ନାହିଁ, ଟ୍ରାକିଂ ନା�
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "କ applications ଣସି ପ୍ରୟୋଗ ଆପଣଙ୍କ ଫିଲ୍ଟର ସହିତ ମେଳ ଖାଉ ନାହିଁ |"
+msgstr "କୌଣସି ଆବେଦନ ଆପଣଙ୍କ ଫିଲ୍ଟର ସହିତ ମେଳ ଖାଉ ନାହିଁ।"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "ଏପର୍ଯ୍ୟନ୍ତ କ applications ଣସି ପ୍ରୟୋଗ ନାହିଁ - ଆପଣଙ୍କର ଫନେଲ୍ ଏବଂ ଉତ୍ତର ହାର ଦେଖିବାକୁ କିଛି ଯୋଡନ୍ତୁ |"
+msgstr "ଏପର୍ଯ୍ୟନ୍ତ କୌଣସି ଆବେଦନ ନାହିଁ - ଆପଣଙ୍କର ଫନେଲ୍ ଏବଂ ଉତ୍ତର ହାର ଦେଖିବାକୁ କିଛି ଯୋଡନ୍ତୁ।"
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2960,7 +2960,7 @@ msgstr "ଏପର୍ଯ୍ୟନ୍ତ କୌଣସି ଥ୍ରେଡ୍ ନା
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "ନରୱେଜିଆନ୍"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-ସୁସଙ୍ଗତ"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "ପର୍ସିଆନ୍"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "ପାଇପଲାଇନ ପ୍ରବାହ |"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "ସମସ୍ତ ପ୍ରୟୋଗଗୁଡ଼ିକରେ ପାଇପଲାଇନ ସ୍ୱାସ୍ଥ୍ୟ |"
+msgstr "ସମସ୍ତ ଆବେଦନଗୁଡ଼ିକରେ ପାଇପଲାଇନ ସ୍ୱାସ୍ଥ୍ୟ।"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "ଆପଣଙ୍କର PDF ଜେନେରେଟ୍ ହେବା ପର�
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "ପୋଲିଶ୍"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "ପୋର୍ଟ୍ରେଟ୍"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "ପୋର୍ତୁଗିଜ୍ (ବ୍ରାଜିଲ୍)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "ପୋର୍ତୁଗିଜ୍ (ପୋର୍ତୁଗାଲ୍)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3681,7 +3681,7 @@ msgstr "ଭୂମିକା ପ୍ରଗତି"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "ରୋମାନିଆନ୍"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "ସ୍କୋରକାର୍ଡ, ଶକ୍ତି ଏବଂ ପ୍ରା�
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "ରୁଷିଆନ୍"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "ଖୋଜନ୍ତୁ"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "ପ୍ରୟୋଗଗୁଡ଼ିକ ଖୋଜ…"
+msgstr "ଆବେଦନଗୁଡ଼ିକ ଖୋଜ…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "ବିଭଜକ"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "ସର୍ବିଆନ୍"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "ମୁଖ୍ୟ ବିଷୟବସ୍ତୁକୁ ଏଡ଼ାଇ ଯା
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "ସ୍ଲୋଭାକ୍"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "ସ୍ଲୋଭେନିଆନ୍"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "ଉର୍ଦ୍ଧ୍ୱାଧର ଭାବେ ଖାଲି ସ୍ଥା
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "ସ୍ପାନିଶ୍"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "ଆପଣ ଯାହା କରିପାରିବେ ତାହା କର�
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "ସ୍ୱେଡିଶ୍"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Taioring failed।"
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "ତାମିଲ"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "ତେଲୁଗୁ"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "ପାଠ୍ୟ ରଙ୍ଗ"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "ଥାଇ"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4460,7 +4460,7 @@ msgstr "ଏହି କାର୍ଯ୍ୟ ପୁନଃ କରିହୋଇପାର
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "ଏହି କାର୍ଯ୍ୟକୁ ପୂର୍ବବତ୍ କରାଯାଇପାରିବ ନାହିଁ। ବାର୍ତ୍ତାଳାପ ମେସେଜ୍ ଏବଂ ଅପଲୋଡ୍ ହୋଇଥିବା ଆଟାଚମେଣ୍ଟଗୁଡ଼ିକୁ କାଢ଼ି ଦିଆଯିବ। କାର୍ଯ୍ୟକ୍ଷମ ରିଜ୍ୟୁମ୍ ଆପଣଙ୍କ ଡ୍ୟାସବୋର୍ଡରେ ରହିଥାଏ ଏବଂ ଏହାକୁ ପୃଥକ ଭାବରେ ଡିଲିଟ୍ କରାଯାଇପାରିବ।"
+msgstr "ଏହି କାର୍ଯ୍ୟକୁ ପୂର୍ବବତ୍ କରାଯାଇପାରିବ ନାହିଁ। ବାର୍ତ୍ତାଳାପ ମେସେଜ୍ ଏବଂ ଅପଲୋଡ୍ ହୋଇଥିବା ଆଟାଚମେଣ୍ଟଗୁଡ଼ିକୁ କାଢ଼ି ଦିଆଯିବ। କାର୍ଯ୍ୟକ୍ଷମ ରିଜ୍ୟୁମ୍ ଆପଣଙ୍କ ଡ୍ୟାଶବୋର୍ଡରେ ରହିଥାଏ ଏବଂ ଏହାକୁ ପୃଥକ ଭାବରେ ଡିଲିଟ୍ କରାଯାଇପାରିବ।"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
@@ -4630,7 +4630,7 @@ msgstr "ଆପଣ ଆବେଦନ କରୁଥିବା ଏକ କାର୍ଯ�
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "ଆପଣଙ୍କର ପ୍ରଥମ ପ୍ରୟୋଗକୁ ଟ୍ରାକ୍ କରନ୍ତୁ |"
+msgstr "ଆପଣଙ୍କର ପ୍ରଥମ ଆବେଦନକୁ ଟ୍ରାକ୍ କରନ୍ତୁ।"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "ତୁର୍କିଶ୍"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "ଟାଇପୋଗ୍ରାଫି"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "ୟୁକ୍ରେନିଆନ୍"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "ଏହି ସମୟରେଖା ପ୍ରବେଶ ପାଇଁ କ୍�
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "ଏହି ଅନୁପ୍ରୟୋଗର details ଅଦ୍ୟତନ କରନ୍ତୁ |"
+msgstr "ଏହି ଆବେଦନର ବିବରଣୀ ଅଦ୍ୟତନ କରନ୍ତୁ।"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "ଉପଯୋଗକର୍ତ୍ତାମାନେ"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "ଉଜବେକ୍"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "ସଂସ୍କରଣ ଇତିହାସ"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "ଭିଏତନାମୀ"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,11 +5039,11 @@ msgstr "ଲକ୍ ହେଉଥିବା ବେଳେ, ରେଜ୍ୟୁମେ�
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "ଯେଉଁଠାରେ ପ୍ରୟୋଗଗୁଡ଼ିକ ଆସେ |"
+msgstr "ଯେଉଁଠାରୁ ଆବେଦନଗୁଡ଼ିକ ଆସେ।"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
-msgstr "ଯେଉଁଠାରେ ଆପଣଙ୍କର ଅନୁପ୍ରୟୋଗ ଗଲା |"
+msgstr "ଆପଣଙ୍କ ଆବେଦନଗୁଡ଼ିକ କୁଆଡ଼େ ଗଲା।"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Work OpenAI"
@@ -5190,5 +5190,5 @@ msgstr "ଜୁମ୍ ଆଉଟ୍ କରନ୍ତୁ"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "ଜୁଲୁ"
+msgstr "isiZulu"
 

--- a/apps/web/locales/pl-PL.po
+++ b/apps/web/locales/pl-PL.po
@@ -364,7 +364,7 @@ msgstr "Dostawcy sztucznej inteligencji wymagają skonfigurowania parametrów RE
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albański"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Masz już konto? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharski"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -504,7 +504,7 @@ msgstr "Zastosowano z ostrzeżeniami"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabski"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Wyróżnienia"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbejdżański"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Piękne szablony do wyboru, a wkrótce kolejne."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengalski"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Paleta poleceń kreatora"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bułgarski"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Nie można przywrócić. CV uległo zmianie od momentu wprowadzenia tej 
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Kataloński"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Sprawdzanie wersji roboczej"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chiński (uproszczony)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chiński (tradycyjny)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1044,7 +1044,7 @@ msgstr "Nie udało się zweryfikować połączenia. Sprawdź klucz API, model i 
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Nie udało się dodać aplikacji. Spróbuj again."
+msgstr "Nie udało się dodać aplikacji. Spróbuj ponownie."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1057,7 +1057,7 @@ msgstr "Nie można usunąć wpisu na osi czasu."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Nie udało się przenieść aplikacji. Spróbuj again."
+msgstr "Nie udało się przenieść aplikacji. Spróbuj ponownie."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1278,7 +1278,7 @@ msgstr "Style niestandardowe"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Czeski"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Strefa zagrożenia"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Duński"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1302,7 +1302,7 @@ msgstr "Ciemny motyw"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Dashboard"
-msgstr "Panel"
+msgstr "Pulpit"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Data Security"
@@ -1548,7 +1548,7 @@ msgstr "Duplikowanie CV..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Holenderski"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Włączanie uwierzytelniania dwuskładnikowego…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Angielski"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Angielski (Wielka Brytania)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1861,7 +1861,7 @@ msgstr "Nie udało się zresetować hasła. Proszę spróbować ponownie."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "Nie udało się zapisać dostawcy sztucznej inteligencji."
+msgstr "Nie udało się zapisać dostawcy AI."
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -1963,7 +1963,7 @@ msgstr "Znajdź słabe punkty i przepisz je, podając mocniejsze wyniki, liczby,
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Fiński"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Forma dowolna"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Francuski"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Wygeneruj losową nazwę"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Niemiecki"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Otrzymają Państwo przegląd swojego CV z ogólną oceną, mocnymi stro
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Otrzymają Państwo dogłębną, opartą na sztucznej inteligencji ocenę swojego CV z ogólnym wynikiem, kluczowymi mocnymi stronami i praktycznymi sugestiami. Aby aktywować tę funkcję, proszę zaktualizować ustawienia AI."
+msgstr "Otrzymają Państwo dogłębną, opartą na AI ocenę swojego CV z ogólnym wynikiem, kluczowymi mocnymi stronami i praktycznymi sugestiami. Aby aktywować tę funkcję, proszę zaktualizować ustawienia AI."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,7 +2116,7 @@ msgstr "Wróć"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Idź do domu"
+msgstr "Wróć do strony głównej"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Ocena"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Grecki"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2199,11 +2199,11 @@ msgstr "Nagłówek 6"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
 msgid "Headline"
-msgstr "Nagłówek"
+msgstr "Podtytuł"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebrajski"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Podświetl kolor"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Węgierski"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2353,7 +2353,7 @@ msgstr "Zaimportowane aplikacje {0}."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "Importowanie z plików PDF lub Word wymaga podłączonego dostawcy sztucznej inteligencji."
+msgstr "Importowanie z plików PDF lub Word wymaga podłączonego dostawcy AI."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Zwiększ powiększenie"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonezyjski"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Wydawca"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Włoski"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kursywa"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japoński"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Wyjustuj"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Trzymać się razem"
+msgstr "Trzymaj razem"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Słowa kluczowe"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Koreański"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Ostatnio wyświetlono dnia {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Łotewski"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Lista"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litewski"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2754,15 +2754,15 @@ msgstr "Ukierunkuj sekcję dotyczącą doświadczenia na wyniki i usuń niejasne
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malajski"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malajalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Przenieś sekcję do innej kolumny lub strony"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Przesuń scenę"
+msgstr "Przenieś etap"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Nazwa"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalski"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2960,7 +2960,7 @@ msgstr "Brak wątków."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norweski"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Notatki"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Otwórz"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Otwarty agent AI"
+msgstr "Otwórz agenta AI"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Zgodny z OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Perski"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3281,11 +3281,11 @@ msgstr "Portret"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugalski (Brazylia)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugalski (Portugalia)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3681,7 +3681,7 @@ msgstr "Rozwój kariery"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumuński"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Proszę przeprowadzić pierwszą analizę, aby uzyskać kartę wyników,
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Rosyjski"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "Separator"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbski"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Przejdź do głównej treści"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Słowacki"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Słoweński"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Odstępy (pionowe)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Hiszpański"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Wesprzyj aplikację, robiąc to, co możesz!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Szwedzki"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Dostosowanie nie powiodło się."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamilski"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Kolor tekstu"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Tajski"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4460,7 +4460,7 @@ msgstr "Tej akcji nie można cofnąć. Wszystkie Twoje dane zostaną trwale usun
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "Tej czynności nie można cofnąć. Wiadomości z konwersacji i przesłane załączniki zostaną usunięte. Działające CV pozostaje w Twoim panelu i można je usunąć osobno."
+msgstr "Tej czynności nie można cofnąć. Wiadomości z konwersacji i przesłane załączniki zostaną usunięte. Działające CV pozostaje w Twoim pulpicie i można je usunąć osobno."
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
@@ -4647,7 +4647,7 @@ msgstr "Spróbuj ponownie"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turecki"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typografia"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukraiński"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Zaktualizuj datę kalendarza dla tego wpisu na osi czasu."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Zaktualizuj plik details tej aplikacji."
+msgstr "Zaktualizuj szczegóły tej aplikacji."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Użytkownicy"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbecki"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Historia wersji"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Wietnamski"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5173,7 +5173,7 @@ msgstr "Twoje wsparcie zapewnia, że projekt pozostanie darmowy i dostępny dla 
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Zoom"
-msgstr "Brzęczenie"
+msgstr "Zoom"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom in"
@@ -5190,5 +5190,5 @@ msgstr "Pomniejsz"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/pl-PL.po
+++ b/apps/web/locales/pl-PL.po
@@ -2377,7 +2377,7 @@ msgstr "Zwiększ powiększenie"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/pl-PL.po
+++ b/apps/web/locales/pl-PL.po
@@ -768,7 +768,7 @@ msgstr "Wyrównaj do środka"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Mózgi"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Zamknij asystenta AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Przystać do siebie"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Zmniejsz powiększenie"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Głębokie poszukiwania"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Fiński"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Fajerwerki"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Chmura Ollama"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Okres"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Zakłopotanie"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Aby usunąć konto, wpisz tekst potwierdzający i kliknij przycisk poni�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Razem.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/pt-BR.po
+++ b/apps/web/locales/pt-BR.po
@@ -768,7 +768,7 @@ msgstr "Alinhar ao centro"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Cérebros"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Fechar assistente de IA"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Coerência"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finlandês"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Fogos de artifício"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2797,7 +2797,7 @@ msgstr "Currículo de trabalho ausente"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "IA Mistral"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Nuvem de Ollama"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Período"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Perplexidade"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Para excluir sua conta, você precisa inserir o texto de confirmação e
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Juntos.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "URLs válidos devem começar com http:// ou https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Gateway de IA da Vercel"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/pt-BR.po
+++ b/apps/web/locales/pt-BR.po
@@ -356,7 +356,7 @@ msgstr "O gerenciamento de provedores de IA não está disponível. Tente novame
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI Providers"
-msgstr "Fornecedores de IA"
+msgstr "Provedores de IA"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI providers require REDIS_URL and ENCRYPTION_SECRET to be configured."
@@ -512,7 +512,7 @@ msgstr "العربية"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Archive"
-msgstr "Arquivo"
+msgstr "Arquivar"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Archived"
@@ -609,7 +609,7 @@ msgstr "Preenchimento automático"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Auto-fill failed. Paste the description instead."
-msgstr "Preenchimento automático failed. Cole a descrição."
+msgstr "O preenchimento automático falhou. Cole a descrição em vez disso."
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Available in multiple languages. If you would like to contribute, check out Crowdin."
@@ -673,7 +673,7 @@ msgstr "Rascunho em branco"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Board"
-msgstr "Conselho"
+msgstr "Quadro"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/typography.tsx
 msgctxt "Body Text (paragraphs, lists, etc.)"
@@ -707,11 +707,11 @@ msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
-msgstr "Exclusão em massa failed. Por favor, tente again."
+msgstr "A exclusão em massa falhou. Tente novamente."
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk update failed. Please try again."
-msgstr "Atualização em massa failed. Por favor, tente again."
+msgstr "A atualização em massa falhou. Tente novamente."
 
 #: src/components/input/rich-input.tsx
 msgid "Bullet List"
@@ -1662,7 +1662,7 @@ msgstr "Ativando proteção por senha..."
 
 #: src/dialogs/auth/enable-two-factor.tsx
 msgid "Enabling two-factor authentication…"
-msgstr "Habilitar a autenticação de dois fatores…"
+msgstr "Ativando a autenticação de dois fatores…"
 
 #: src/libs/locale.ts
 msgid "English"
@@ -2037,7 +2037,7 @@ msgstr "Esqueceu a sua senha?"
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgctxt "Page Format (A4, Letter, Free-form)"
 msgid "Format"
-msgstr "Formatar"
+msgstr "Formato"
 
 #: src/features/resume/stylesheet/toolbar.tsx
 msgid "Format stylesheet"
@@ -2339,7 +2339,7 @@ msgstr "Importar CSV"
 
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Import failed. Check the CSV and try again."
-msgstr "Importar failed. Verifique o CSV e tente again."
+msgstr "A importação falhou. Verifique o CSV e tente novamente."
 
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/routes/dashboard/applications/index.tsx
@@ -2595,7 +2595,7 @@ msgstr "Alinhar à esquerda"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Let AI read the posting and fill the fields below."
-msgstr "Deixe AI ler a postagem e preencher os campos abaixo."
+msgstr "Deixe a IA ler a postagem e preencher os campos abaixo."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Letter"
@@ -2642,7 +2642,7 @@ msgstr "Vincular um Reactive Resume (recomendado)"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Link a resume and add a job description (Edit) to score your fit and tailor a copy."
-msgstr "Vincule um currículo e adicione uma descrição do cargo (Editar) para avaliar sua adequação e tailor uma cópia."
+msgstr "Vincule um currículo e adicione uma descrição do cargo (Editar) para avaliar sua adequação e personalizar uma cópia."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Linked Reactive Resume"
@@ -2778,7 +2778,7 @@ msgstr "Marca rejeitada"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Match scoring failed."
-msgstr "Pontuação da partida failed."
+msgstr "A pontuação de compatibilidade falhou."
 
 #. Impact severity label in resume analysis suggestion card
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
@@ -2952,7 +2952,7 @@ msgstr "Ainda não há regras de estilo."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "No tested provider"
-msgstr "Nenhum fornecedor testado"
+msgstr "Nenhum provedor testado"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
@@ -2998,7 +2998,7 @@ msgstr "Aplica-se somente quando a seção cabe em uma única página."
 
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Only the first {MAX_IMPORT} rows import at once — {overflow} left out. Split the file to import the rest."
-msgstr "Somente as primeiras linhas {MAX_IMPORT} são importadas de uma vez – {overflow} deixada de fora. Divida o arquivo para importar o restante."
+msgstr "Somente as primeiras {MAX_IMPORT} linhas são importadas de uma vez — {overflow} ficam de fora. Divida o arquivo para importar o restante."
 
 #. Resume card context menu action to open the resume editor
 #. Resume card dropdown action to open the resume editor
@@ -3158,15 +3158,15 @@ msgstr "A proteção por senha foi ativada."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Paste a job posting URL"
-msgstr "Cole um anúncio de emprego URL"
+msgstr "Cole a URL do anúncio de emprego"
 
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Paste rows or upload a .csv. We map columns like Company, Role, Stage, Stage Date, Salary, Source and Tags."
-msgstr "Cole linhas ou carregue um .csv. Mapeamos colunas como Empresa, Função, Estágio, Data do estágio, Salário, Origem e Tags."
+msgstr "Cole linhas ou carregue um .csv. Mapeamos colunas como Empresa, Função, Etapa, Data da etapa, Salário, Origem e Tags."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Paste the posting — powers AI match scoring and tailoring."
-msgstr "Cole a postagem – potencializa a pontuação da partida AI e tailoring."
+msgstr "Cole a postagem — potencializa a pontuação de compatibilidade da IA e a personalização."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Patch applied"
@@ -3240,7 +3240,7 @@ msgstr "Integridade do pipeline em todas as candidaturas"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
-msgstr "Texto Plain, ideal para ferramentas AI e edições rápidas."
+msgstr "Texto simples, ideal para ferramentas de IA e edições rápidas."
 
 #: src/features/auth/pages/reset-password.tsx
 msgid "Please enter a new password for your account"
@@ -3428,7 +3428,7 @@ msgstr "O Reactive Resume permanece gratuito, de código aberto e independente p
 #. App version label in footer; includes semantic version variable
 #: src/components/ui/copyright.tsx
 msgid "Reactive Resume v<0>{__APP_VERSION__}</0>"
-msgstr "Retomar reativo v<0>{__APP_VERSION__}</0>"
+msgstr "Reactive Resume v<0>{__APP_VERSION__}</0>"
 
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
@@ -3720,7 +3720,7 @@ msgstr "Salvar"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Save & Test Provider"
-msgstr "Fornecedor de salvamento e teste"
+msgstr "Salvar e testar o provedor"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Save & Upload"
@@ -3858,7 +3858,7 @@ msgstr "Selecione um modelo de agente"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Select an AI provider"
-msgstr "Selecione um fornecedor de IA"
+msgstr "Selecione um provedor de IA"
 
 #: src/components/ui/combobox.tsx
 msgid "Select..."
@@ -4172,11 +4172,11 @@ msgstr "Quadrado"
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Stage"
-msgstr "Palco"
+msgstr "Etapa"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Stage date"
-msgstr "Data do estágio"
+msgstr "Data da etapa"
 
 #: src/components/input/github-stars-button.tsx
 msgid "Star us on GitHub (opens in new tab)"
@@ -4297,7 +4297,7 @@ msgstr "Alterações sincronizadas feitas em outra aba."
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Table"
-msgstr "Mesa"
+msgstr "Tabela"
 
 #: src/dialogs/resume/index.tsx
 #: src/features/applications/components/application-form-sheet.tsx
@@ -4311,7 +4311,7 @@ msgstr "Tags podem ser usadas para categorizar seu currículo por palavras-chave
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Tailor my resume"
-msgstr "Tailor meu currículo"
+msgstr "Personalizar meu currículo"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tailor this resume to a product manager job description and emphasize roadmap ownership, stakeholder communication, and measurable launch outcomes."
@@ -4613,7 +4613,7 @@ msgstr "Alternar empilhamento de páginas"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle resume preview"
-msgstr "Alternar pré-visualização do resumo"
+msgstr "Alternar pré-visualização do currículo"
 
 #. Screen-reader label for opening or closing the right sidebar in resume builder
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -4768,7 +4768,7 @@ msgstr "Desbloquear"
 
 #: src/features/settings/authentication/components/passkeys.tsx
 msgid "Unnamed passkey"
-msgstr "Chave secreta sem nome"
+msgstr "Chave de acesso sem nome"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Unverified"

--- a/apps/web/locales/pt-BR.po
+++ b/apps/web/locales/pt-BR.po
@@ -260,13 +260,13 @@ msgstr "Adicione uma tag e pressione Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Adicione e teste um provedor antes de iniciar uma thread do agente."
+msgstr "Adicione e teste um provedor antes de iniciar uma conversa do agente."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Adicionar aplicativo"
+msgstr "Adicionar candidatura"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "Avançado"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Africâner"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "Os provedores de IA exigem que REDIS_URL e ENCRYPTION_SECRET sejam confi
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanês"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Já tem uma conta? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amárico"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Aplicativo"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Ações de aplicativo"
+msgstr "Ações de candidatura"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Aplicativo adicionado ao seu pipeline."
+msgstr "Candidatura adicionada ao seu pipeline."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Copiloto de Aplicativo"
+msgstr "Copiloto de Candidatura"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Aplicativo excluído."
+msgstr "Candidatura excluída."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Estatísticas do aplicativo"
+msgstr "Estatísticas de candidatura"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Aplicativo atualizado."
+msgstr "Candidatura atualizada."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Aplicativos"
+msgstr "Candidaturas"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Aplicado com ressalvas."
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Árabe"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Prêmios"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaijano"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Modelos bonitos para escolher, com mais a caminho."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Melhor para aplicativos, compartilhamento e impressão."
+msgstr "Melhor para candidaturas, compartilhamento e impressão."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Paleta de Comandos do Construtor"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Búlgaro"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Não é possível restaurar; o currículo foi alterado desde que esta ed
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalão"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Verificando rascunho"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chinês (Simplificado)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chinês (Tradicional)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Escolha um currículo"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Escolha uma conversa existente na barra lateral ou inicie uma nova discussão focada em rascunhos."
+msgstr "Escolha uma conversa existente na barra lateral ou inicie uma nova conversa focada em rascunhos."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "Círculo"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Limpo"
+msgstr "Limpar"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Não foi possível verificar a conexão. Verifique a chave da API, o mod
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Não foi possível adicionar o aplicativo. Por favor, tente again."
+msgstr "Não foi possível adicionar a candidatura. Por favor, tente novamente."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Não foi possível excluir o aplicativo."
+msgstr "Não foi possível excluir a candidatura."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Não foi possível excluir a entrada da linha do tempo."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Não foi possível mover o aplicativo. Por favor, tente again."
+msgstr "Não foi possível mover a candidatura. Por favor, tente novamente."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Criado em"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Criou \"{0}\" e vinculou-o a este aplicativo."
+msgstr "Criou \"{0}\" e vinculou-a a esta candidatura."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Estilos personalizados"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Tcheco"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Zona de perigo"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Dinamarquês"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Excluir provedor"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Excluir esta thread do agente?"
+msgstr "Excluir esta conversa do agente?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1392,7 +1392,7 @@ msgstr "Excluir entrada da linha do tempo"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Aplicativo(s) {0} excluído(s)."
+msgstr "{0} candidatura(s) excluída(s)."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Duplicando seu currículo..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Holandês"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Editar {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Editar aplicativo"
+msgstr "Editar candidatura"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Habilitar a autenticação de dois fatores…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Inglês"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Inglês (Reino Unido)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Falha ao analisar o currículo."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Falha ao arquivar a thread."
+msgstr "Falha ao arquivar a conversa."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Falha ao excluir a chave da API. Tente novamente."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Falha ao excluir a thread."
+msgstr "Falha ao excluir a conversa."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Falha ao sair. Por favor, tente novamente."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Falha ao iniciar a thread do agente."
+msgstr "Falha ao iniciar a conversa do agente."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Identifique os pontos fracos e reescreva-os com resultados mais impactan
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finlandês"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Adequado para visualização"
+msgstr "Ajustar à visualização"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Forma livre"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Francês"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Gerar um nome aleatório"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Alemão"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Voltar"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Ir para casa"
+msgstr "Ir para a página inicial"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Nota"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Grego"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Título"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebraico"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Cor de destaque"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Húngaro"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Importar de CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Aplicativo(s) {0} importado(s)."
+msgstr "{0} candidatura(s) importada(s)."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Aumentar zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonésio"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2433,7 +2433,7 @@ msgstr "Itálico"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japonês"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Justificar alinhamento"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Canarim"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Mantenham-se unidos"
+msgstr "Manter junto"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Palavras-chave"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Coreano"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Última visualização em {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Letão"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Lista"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lituano"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Carregando provedores de IA. Tente novamente em instantes."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Carregando aplicativos…"
+msgstr "Carregando candidaturas…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Carregando retomadas…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Carregando threads…"
+msgstr "Carregando conversas…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Torne a seção de experiência mais orientada a resultados e remova res
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malaio"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malaiala"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marata"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Nome"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalês"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Rede"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Novo aplicativo"
+msgstr "Nova candidatura"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "Nova etiqueta…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Novo tópico"
+msgstr "Nova conversa"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Novo tópico"
+msgstr "Nova conversa"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2902,11 +2902,11 @@ msgstr "Sem publicidade, sem rastreamento"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Nenhum aplicativo corresponde aos seus filtros."
+msgstr "Nenhuma candidatura corresponde aos seus filtros."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Ainda não há inscrições. Adicione algumas para ver seu funil e taxas de resposta."
+msgstr "Ainda não há candidaturas. Adicione algumas para ver seu funil e taxas de resposta."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2956,11 +2956,11 @@ msgstr "Nenhum fornecedor testado"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Ainda não há tópicos."
+msgstr "Ainda não há conversas."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norueguês"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Anotações"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Abrir"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Agente de IA aberta"
+msgstr "Abrir o agente de IA"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Compatível com OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persa"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Fluxo de pipeline"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Integridade do pipeline em todos os aplicativos"
+msgstr "Integridade do pipeline em todas as candidaturas"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Aguarde enquanto seu PDF é gerado…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polonês"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Ir para a página inicial"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Currículo reativo (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Retomar reativo v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Currículo reativo v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Progressão de cargo"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Romeno"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Faça sua primeira análise para obter um quadro de resultados, pontos f
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russo"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Procurar"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Pesquisar aplicativos…"
+msgstr "Pesquisar candidaturas…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3846,7 +3846,7 @@ msgstr "Selecione um currículo"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "Selecione um tópico"
+msgstr "Selecione uma conversa"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "Separador"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Sérvio"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Configure um provedor de IA"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Configure um provedor de IA antes de iniciar uma thread."
+msgstr "Configure um provedor de IA antes de iniciar uma conversa."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Pular para o conteúdo principal"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Eslovaco"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Esloveno"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Espaçamento (vertical)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Espanhol"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "Dê uma estrela para nós no GitHub, atualmente {0} estrelas (abre em no
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Inicie um novo tópico"
+msgstr "Inicie uma nova conversa"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Inicie um tópico"
+msgstr "Inicie uma conversa"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Comece a construir seu currículo do zero"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Iniciar novo tópico"
+msgstr "Iniciar nova conversa"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Começar em uma nova página"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Iniciar tópico"
+msgstr "Iniciar conversa"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Apoie o aplicativo fazendo o que puder!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Sueco"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "A adaptação falhou."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tâmil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Cor do texto"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Tailandês"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "O URL que você digitou não é válido."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "O currículo em questão foi apagado. Este tópico é somente para leitura."
+msgstr "O currículo em questão foi apagado. Esta conversa é somente para leitura."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4468,7 +4468,7 @@ msgstr "Esta ação não pode ser desfeita. As mensagens e os anexos da conversa
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Não foi possível abrir esta thread do agente."
+msgstr "Não foi possível abrir esta conversa do agente."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "Esta etapa é opcional, mas recomendada."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Este tópico foi arquivado. Não é possível enviar novas mensagens."
+msgstr "Esta conversa foi arquivada. Não é possível enviar novas mensagens."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Este tópico é somente para leitura."
+msgstr "Esta conversa é somente para leitura."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Este tópico é somente para leitura porque o currículo funcional ou o provedor de IA não estão disponíveis."
+msgstr "Esta conversa é somente para leitura porque o currículo funcional ou o provedor de IA não estão disponíveis."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,22 +4545,22 @@ msgstr "Isso removerá todos os itens dessa seção."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "Ações do tópico"
+msgstr "Ações da conversa"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Tópico arquivado."
+msgstr "Conversa arquivada."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Tópico excluído."
+msgstr "Conversa excluída."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Fios"
+msgstr "Conversas"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "Alternar a barra lateral direita"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Alternar tópicos"
+msgstr "Alternar conversas"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4630,7 +4630,7 @@ msgstr "Acompanhe uma vaga para a qual você está se candidatando e vincule o c
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "Acompanhe sua primeira aplicação"
+msgstr "Acompanhe sua primeira candidatura"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "Tente novamente"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turco"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipografia"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ucraniano"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Atualize a data do calendário para esta entrada da linha do tempo."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Atualize o details deste aplicativo."
+msgstr "Atualize os detalhes desta candidatura."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Usuários"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbeque"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Histórico de versões"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamita"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,11 +5039,11 @@ msgstr "Quando bloqueado, o currículo não pode ser atualizado ou excluído."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "De onde vêm os aplicativos"
+msgstr "De onde vêm as candidaturas"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
-msgstr "Para onde foram seus aplicativos"
+msgstr "Para onde foram suas candidaturas"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Work OpenAI"
@@ -5190,5 +5190,5 @@ msgstr "Diminuir zoom"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/pt-BR.po
+++ b/apps/web/locales/pt-BR.po
@@ -2377,7 +2377,7 @@ msgstr "Aumentar zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/pt-PT.po
+++ b/apps/web/locales/pt-PT.po
@@ -460,7 +460,7 @@ msgstr "Copiloto de Candidatura"
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Candidatura excluída."
+msgstr "Candidatura eliminada."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
@@ -2377,7 +2377,7 @@ msgstr "Aumentar zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/pt-PT.po
+++ b/apps/web/locales/pt-PT.po
@@ -401,7 +401,7 @@ msgstr "E muitas mais..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Claude antrópico"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Alinhar ao centro"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Cérebros"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Fechar assistente de IA"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Coerência"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finlandês"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Fogos de artifício"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2797,7 +2797,7 @@ msgstr "Currículo de trabalho ausente"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "IA Mistral"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Nuvem de Ollama"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Período"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Perplexidade"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Para eliminar a sua conta, tem de introduzir o texto de confirmação e 
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Juntos.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/pt-PT.po
+++ b/apps/web/locales/pt-PT.po
@@ -260,13 +260,13 @@ msgstr "Adicione uma etiqueta e prima Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Adicione e teste um fornecedor antes de iniciar um thread do agente."
+msgstr "Adicione e teste um fornecedor antes de iniciar uma conversa do agente."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Adicionar aplicação"
+msgstr "Adicionar candidatura"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "Avançado"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Africâner"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "Os fornecedores de IA exigem que REDIS_URL e ENCRYPTION_SECRET estejam c
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanês"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Já tem uma conta? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amárico"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Aplicação"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Ações de aplicação"
+msgstr "Ações de candidatura"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Aplicação adicionada ao seu pipeline."
+msgstr "Candidatura adicionada ao seu pipeline."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Copiloto de Aplicação"
+msgstr "Copiloto de Candidatura"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Aplicativo excluído."
+msgstr "Candidatura excluída."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Estatísticas da aplicação"
+msgstr "Estatísticas de candidatura"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Aplicativo atualizado."
+msgstr "Candidatura atualizada."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Aplicativos"
+msgstr "Candidaturas"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Aplicado com reservas."
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Árabe"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -591,7 +591,7 @@ msgstr "Anexar ficheiros"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment"
-msgstr "Apego"
+msgstr "Anexo"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment uploaded."
@@ -628,7 +628,7 @@ msgstr "Prémios"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbaijano"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Modelos bonitos para escolher, com mais a caminho."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Melhor para aplicações, partilha e impressão."
+msgstr "Melhor para candidaturas, partilha e impressão."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Paleta de comandos do editor"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Búlgaro"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Não é possível restaurar; o currículo foi alterado desde que esta ed
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalão"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Verificando rascunho"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chinês (simplificado)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chinês (tradicional)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Escolha um currículo"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Escolha uma conversa existente na barra lateral ou inicie uma nova discussão focada em rascunhos."
+msgstr "Escolha uma conversa existente na barra lateral ou inicie uma nova conversa focada em rascunhos."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -1044,12 +1044,12 @@ msgstr "Não foi possível verificar a ligação. Verifique a chave API, o model
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Não foi possível adicionar a aplicação. Por favor, tente novamente."
+msgstr "Não foi possível adicionar a candidatura. Por favor, tente novamente."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Não foi possível eliminar a aplicação."
+msgstr "Não foi possível eliminar a candidatura."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Não foi possível eliminar a entrada da linha do tempo."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Não foi possível mover a aplicação. Por favor, tente novamente."
+msgstr "Não foi possível mover a candidatura. Por favor, tente novamente."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Criado"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Criou \"{0}\" e ligou-o a esta aplicação."
+msgstr "Criou \"{0}\" e ligou-a a esta candidatura."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Estilos personalizados"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Checo"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Zona de perigo"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Dinamarquês"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Apagar provedor"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Apagar esta thread do agente?"
+msgstr "Apagar esta conversa do agente?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1392,7 +1392,7 @@ msgstr "Eliminar entrada da linha do tempo"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "{0} aplicações eliminadas."
+msgstr "{0} candidaturas eliminadas."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "A duplicar o seu currículo..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Neerlandês"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Edite {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Editar aplicação"
+msgstr "Editar candidatura"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Ativar a autenticação de dois fatores…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Inglês"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Inglês (Reino Unido)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Falha na análise do currículo."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Falha ao arquivar o thread."
+msgstr "Falha ao arquivar a conversa."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Falha ao eliminar a chave da API. Tente novamente."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Falha ao eliminar o thread."
+msgstr "Falha ao eliminar a conversa."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Não conseguiu terminar a sessão. Tente novamente."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Falha ao iniciar o thread do agente."
+msgstr "Falha ao iniciar a conversa do agente."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Identifique os pontos fracos e reescreva-os com resultados mais impactan
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finlandês"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Adequado para visualização"
+msgstr "Ajustar à visualização"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Forma livre"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Francês"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Gerar um nome aleatório"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Alemão"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,18 +2116,18 @@ msgstr "Voltar"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Ir para casa"
+msgstr "Ir para a página inicial"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Ir para o dashboard"
+msgstr "Ir para o painel"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Aceda ao painel de controlo dos currículos"
+msgstr "Ir para o painel de currículos"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Nota final"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Grego"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Título"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebraico"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Cor de destaque"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Húngaro"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Importar de CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "{0} aplicações importadas."
+msgstr "{0} candidaturas importadas."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Aumentar zoom"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonésio"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2433,7 +2433,7 @@ msgstr "Itálico"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japonês"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Alinhar justificado"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Canarim"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Mantenham-se unidos"
+msgstr "Manter junto"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Palavras-chave"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Coreano"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Última visualização em {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Letão"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Lista"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lituano"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Carregando fornecedores de IA. Tente novamente dentro de instantes."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "A carregar aplicações…"
+msgstr "A carregar candidaturas…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "A carregar retomas…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "A carregar threads…"
+msgstr "A carregar conversas…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Torne a secção de experiência mais orientada para os resultados e rem
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malaio"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malaiala"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marata"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Nome"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalês"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Rede social"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Novo aplicativo"
+msgstr "Nova candidatura"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "Nova etiqueta…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Novo tópico"
+msgstr "Nova conversa"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Novo tópico"
+msgstr "Nova conversa"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2902,11 +2902,11 @@ msgstr "Sem publicidade, sem rastreamento"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Nenhuma aplicação corresponde aos seus filtros."
+msgstr "Nenhuma candidatura corresponde aos seus filtros."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Ainda não há inscrições. Adicione algumas para ver o seu funil e as taxas de resposta."
+msgstr "Ainda não há candidaturas. Adicione algumas para ver o seu funil e as taxas de resposta."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2956,11 +2956,11 @@ msgstr "Nenhum fornecedor testado"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Ainda não há tópicos."
+msgstr "Ainda não há conversas."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norueguês"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Notas"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Abrir"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Agente de IA aberta"
+msgstr "Abrir o agente de IA"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Compatível com OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persa"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Fluxo de pipeline"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Integridade do pipeline em todas as aplicações"
+msgstr "Integridade do pipeline em todas as candidaturas"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Aguarde enquanto o seu PDF é gerado…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polaco"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Ir para a página inicial"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Currículo reativo (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reativo reativo v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Currículo reativo v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Progressão de função"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Romeno"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Execute a sua primeira análise para obter um quadro de pontuação, pon
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Russo"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Pesquisa"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Pesquisar aplicações…"
+msgstr "Pesquisar candidaturas…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3846,7 +3846,7 @@ msgstr "Selecione um currículo"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "Selecione um tópico"
+msgstr "Selecione uma conversa"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "Separador"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Sérvio"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Configure um fornecedor de IA"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Configure um fornecedor de IA antes de iniciar um thread."
+msgstr "Configure um fornecedor de IA antes de iniciar uma conversa."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Saltar para o conteúdo principal"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Eslovaco"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Esloveno"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Espaçamento (vertical)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Espanhol"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "Dê-nos uma estrela no GitHub, atualmente {0} estrelas (abre num novo se
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Iniciar um novo tópico"
+msgstr "Iniciar uma nova conversa"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Iniciar um tópico"
+msgstr "Iniciar uma conversa"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Comece a criar o seu currículo do zero"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Iniciar novo tópico"
+msgstr "Iniciar nova conversa"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Começar numa nova página"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Iniciar tópico"
+msgstr "Iniciar conversa"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Apoie a aplicação fazendo o que puder!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Sueco"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "A alfaiataria falhou."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tâmil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Télugo"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Cor do texto"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Tailandês"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "O URL que introduziu não é válido."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "O currículo em causa foi apagado. Este tópico é apenas para leitura."
+msgstr "O currículo em causa foi apagado. Esta conversa é apenas para leitura."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4468,7 +4468,7 @@ msgstr "Esta ação não pode ser anulada. As mensagens e os anexos da conversa 
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Não foi possível abrir este thread do agente."
+msgstr "Não foi possível abrir esta conversa do agente."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "Este passo é opcional, mas recomendado."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Este tópico foi arquivado. Não é possível enviar novas mensagens."
+msgstr "Esta conversa foi arquivada. Não é possível enviar novas mensagens."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Este tópico é apenas para leitura."
+msgstr "Esta conversa é apenas para leitura."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Este tópico é apenas para leitura porque o currículo funcional ou o fornecedor de IA não estão disponíveis."
+msgstr "Esta conversa é apenas para leitura porque o currículo funcional ou o fornecedor de IA não estão disponíveis."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,22 +4545,22 @@ msgstr "Isto irá remover todos os itens desta secção."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "Ações do tópico"
+msgstr "Ações da conversa"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Tópico arquivado."
+msgstr "Conversa arquivada."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Tópico eliminado."
+msgstr "Conversa eliminada."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Fios"
+msgstr "Conversas"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "Alternar a barra lateral direita"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Alternar tópicos"
+msgstr "Alternar conversas"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4630,7 +4630,7 @@ msgstr "Acompanhe uma vaga para a qual se está a candidatar e vincule o curríc
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "Acompanhe a sua primeira aplicação"
+msgstr "Acompanhe a sua primeira candidatura"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "Tente novamente"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turco"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Fontes"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ucraniano"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Atualize a data do calendário desta entrada da linha do tempo."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Atualize os detalhes desta aplicação."
+msgstr "Atualize os detalhes desta candidatura."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Utilizadores"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbeque"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Histórico de versões"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamita"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,11 +5039,11 @@ msgstr "Quando bloqueado, o currículo não pode ser atualizado nem eliminado."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "De onde vêm as aplicações"
+msgstr "De onde vêm as candidaturas"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
-msgstr "Para onde foram as suas aplicações"
+msgstr "Para onde foram as suas candidaturas"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Work OpenAI"
@@ -5190,5 +5190,5 @@ msgstr "Afastar"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ro-RO.po
+++ b/apps/web/locales/ro-RO.po
@@ -260,13 +260,13 @@ msgstr "Adaugă o etichetă și apasă Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Adăugați și testați un furnizor înainte de a porni un fir de execuție pentru agent."
+msgstr "Adăugați și testați un furnizor înainte de a porni un fir de discuție pentru agent."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Adăugați aplicația"
+msgstr "Adăugați candidatura"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -364,7 +364,7 @@ msgstr "Furnizorii de inteligență artificială necesită configurarea REDIS_UR
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albaneză"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Ai deja un cont? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharică"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Aplicație"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Acțiuni de aplicare"
+msgstr "Acțiuni pentru candidatură"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Aplicație adăugată la conducta dvs."
+msgstr "Candidatură adăugată la conducta dvs."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Copilotul aplicației"
+msgstr "Copilotul candidaturii"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Aplicația a fost ștearsă."
+msgstr "Candidatura a fost ștearsă."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Statistici aplicație"
+msgstr "Statistici candidaturi"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Aplicația a fost actualizată."
+msgstr "Candidatura a fost actualizată."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Aplicații"
+msgstr "Candidaturi"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Aplicat cu avertismente"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabă"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Distincții"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azeră"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Șabloane frumoase din care să alegeți, cu altele pe drum."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengaleză"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Ideal pentru aplicații, partajare și imprimare."
+msgstr "Ideal pentru candidaturi, partajare și imprimare."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Paletă de comenzi a constructorului"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgară"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Nu se poate restaura; CV-ul s-a modificat de când a fost aplicată acea
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Catalană"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Verificare schiță"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Chineză (simplificată)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Chineză (tradițională)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Cerc"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Clar"
+msgstr "Șterge"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Nu s-a putut verifica conexiunea. Verificați cheia API, modelul și adr
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Aplicația nu a putut fi adăugată. Vă rugăm să încercați din nou."
+msgstr "Candidatura nu a putut fi adăugată. Vă rugăm să încercați din nou."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Nu s-a putut șterge aplicația."
+msgstr "Nu s-a putut șterge candidatura."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Nu s-a putut șterge intrarea din cronologie."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Aplicația nu a putut fi mutată. Vă rugăm să încercați din nou."
+msgstr "Candidatura nu a putut fi mutată. Vă rugăm să încercați din nou."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Creat"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "A creat „{0}” și l-a conectat la această aplicație."
+msgstr "A creat „{0}” și l-a conectat la această candidatură."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Stiluri personalizate"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Cehă"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Zonă periculoasă"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Daneză"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1302,7 +1302,7 @@ msgstr "Temă întunecată"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Dashboard"
-msgstr "Bord"
+msgstr "Tablou de bord"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Data Security"
@@ -1392,7 +1392,7 @@ msgstr "Ștergeți intrarea din cronologie"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "S-au șters {0} aplicații."
+msgstr "S-au șters {0} candidaturi."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Se duplică CV-ul..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Olandeză"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Editează {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Editați aplicația"
+msgstr "Editați candidatura"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Activarea autentificării cu doi factori…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Engleză"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Engleză (Regatul Unit)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Găsește punctele slabe și rescrie-le cu rezultate, numere, domenii de
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finlandeză"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Potrivire pentru vizualizare"
+msgstr "Ajustare la vizualizare"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Formă liberă"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Franceză"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Generați un nume aleatoriu"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Germană"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,13 +2116,13 @@ msgstr "Înapoi"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Du-te acasă"
+msgstr "Înapoi la pagina principală"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Mergi la panoul de control"
+msgstr "Mergi la tabloul de bord"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "Notă"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Greacă"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Headline"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Ebraică"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Culoare evidențiere"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Maghiară"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Importă din CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Au importat {0} aplicații."
+msgstr "Au importat {0} candidaturi."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Măriți zoomul"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indoneziană"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Emitent"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italiană"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Cursiv"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japoneză"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Aliniere justificată"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Rămâneți împreună"
+msgstr "Păstrați împreună"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Cuvinte cheie"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Coreeană"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Ultima vizualizare la {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Letonă"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Listă"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lituaniană"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Se încarcă furnizorii de inteligență artificială. Vă rugăm să î
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Se încarcă aplicațiile…"
+msgstr "Se încarcă candidaturile…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Orientați secțiunea de experiență mai mult spre rezultate și elimin
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malay"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Mutați secțiunea în altă coloană sau pagină"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Mutați scena"
+msgstr "Mutați etapa"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Nume"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepaleză"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Rețea"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Aplicație nouă"
+msgstr "Candidatură nouă"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2894,7 +2894,7 @@ msgstr "Fir nou"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Subiect nou"
+msgstr "Fir de discuție nou"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2902,11 +2902,11 @@ msgstr "Fără reclame, fără urmărire"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Nicio aplicație nu se potrivește cu filtrele dvs."
+msgstr "Nicio candidatură nu se potrivește cu filtrele dvs."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Încă nu există aplicații — adăugați câteva pentru a vedea canalul și ratele de răspuns."
+msgstr "Încă nu există candidaturi — adăugați câteva pentru a vedea canalul și ratele de răspuns."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2956,11 +2956,11 @@ msgstr "Niciun furnizor testat"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Încă nu există subiecte de discuție."
+msgstr "Încă nu există fire de discuție."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norvegiană"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Notițe"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Deschis"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Agent deschis de inteligență artificială"
+msgstr "Deschideți agentul de inteligență artificială"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Compatibil cu OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persană"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Debitul conductei"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Sănătatea conductei în toate aplicațiile"
+msgstr "Sănătatea conductei în toate candidaturile"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Vă rugăm să așteptați în timp ce se generează PDF-ul…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Poloneză"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portret"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugheză (Brazilia)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugheză (Portugalia)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Mergi la pagina principală"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Rezumat reactiv (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "CV reactiv v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "CV reactiv v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3701,7 +3701,7 @@ msgstr "Efectuați prima analiză pentru a obține o fișă de evaluare, puncte 
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Rusă"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Căutare"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Căutați aplicații..."
+msgstr "Căutați candidaturi..."
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Separator"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Sârbă"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Configurați un furnizor de inteligență artificială"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Configurați un furnizor de inteligență artificială înainte de a începe un thread."
+msgstr "Configurați un furnizor de inteligență artificială înainte de a începe un fir de discuție."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Săriți la conținutul principal"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovacă"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovenă"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Spațiere (verticală)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spaniolă"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Sprijiniți aplicația făcând tot ce puteți!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Suedeză"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Croitoria a eșuat."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamilă"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Culoare text"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thailandeză"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4630,7 +4630,7 @@ msgstr "Urmăriți un loc de muncă la care aplicați și conectați CV-ul pe ca
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "Urmăriți prima aplicație"
+msgstr "Urmăriți prima candidatură"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "Încearcă din nou"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turcă"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4683,7 +4683,7 @@ msgstr "Două coloane, curat și profesional cu separatoare subtile între secț
 
 #: src/dialogs/resume/template/data.ts
 msgid "Two-column, minimal and text-dense with no decorative elements; perfect for traditional industries or ATS-heavy applications."
-msgstr "Două coloane, minimal și dens în text fără elemente decorative; perfect pentru industrii tradiționale sau aplicații unde contează mult compatibilitatea cu ATS."
+msgstr "Două coloane, minimal și dens în text fără elemente decorative; perfect pentru industrii tradiționale sau candidaturi unde contează mult compatibilitatea cu ATS."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Two-column, minimal with light gray sidebar and subtle icons; professional and understated for legal, finance, or executive roles."
@@ -4728,7 +4728,7 @@ msgstr "Tipografie"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ucraineană"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Actualizați data calendaristică pentru această intrare din cronologie
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Actualizați detaliile acestei aplicații."
+msgstr "Actualizați detaliile acestei candidaturi."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Utilizatori"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbecă"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Istoricul versiunilor"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnameză"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,11 +5039,11 @@ msgstr "Când este blocat, CV-ul nu poate fi actualizat sau șters."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "De unde vin aplicațiile"
+msgstr "De unde vin candidaturile"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
-msgstr "Unde au mers aplicațiile dvs"
+msgstr "Unde au mers candidaturile dvs"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Work OpenAI"
@@ -5190,5 +5190,5 @@ msgstr "Micșorează"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ro-RO.po
+++ b/apps/web/locales/ro-RO.po
@@ -401,7 +401,7 @@ msgstr "Și multe altele..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropicul Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Aliniere la centru"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Cerebra"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Închide asistentul AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Coerență"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Reduceți zoomul"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Căutare profundă"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Finlandeză"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Focuri de artificii"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Norul Ollama"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Perioadă"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Perplexitate"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Pentru a vă șterge contul, trebuie să introduceți textul de confirma
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Împreună.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/ro-RO.po
+++ b/apps/web/locales/ro-RO.po
@@ -2377,7 +2377,7 @@ msgstr "Măriți zoomul"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/ru-RU.po
+++ b/apps/web/locales/ru-RU.po
@@ -260,13 +260,13 @@ msgstr "Добавьте тег и нажмите Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Добавьте и протестируйте поставщика услуг, прежде чем запускать поток агента."
+msgstr "Добавьте и протестируйте поставщика услуг, прежде чем начать тему агента."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Добавить приложение"
+msgstr "Добавить заявку"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -311,11 +311,11 @@ msgstr "Адаптируйте резюме под удаленную работ
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "Передовой"
+msgstr "Расширенные"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Африкаанс"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "Для работы с системами искусственного �
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Албанский"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Уже есть аккаунт? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Амхарский"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Приложение"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Действия приложения"
+msgstr "Действия заявки"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Приложение добавлено в ваш конвейер."
+msgstr "Заявка добавлена в ваш конвейер."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Второй пилот приложения"
+msgstr "Помощник по заявкам"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Приложение удалено."
+msgstr "Заявка удалена."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Статистика приложения"
+msgstr "Статистика заявок"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Приложение обновлено."
+msgstr "Заявка обновлена."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Приложения"
+msgstr "Заявки"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Применяется с предупреждениями."
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Арабский"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Награды"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Азербайджанский"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Красивые шаблоны на ваш выбор, и скоро п
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Бенгальский"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Лучше всего подходит для приложений, обмена и печати."
+msgstr "Лучше всего подходит для заявок, обмена и печати."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Командная палитра редактора"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Болгарский"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Восстановить невозможно; резюме измени
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Каталанский"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Проверка черновика"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Китайский (упрощенный)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Китайский (традиционный)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Выберите резюме"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Выберите существующую беседу на боковой панели или начните новую ветку обсуждения, посвященную черновикам."
+msgstr "Выберите существующую беседу на боковой панели или начните новую тему, посвященную черновикам."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "Круг"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Clear"
+msgstr "Очистить"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Не удалось проверить соединение. Прове�
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Не удалось добавить приложение. Пожалуйста, попробуйте еще раз."
+msgstr "Не удалось добавить заявку. Пожалуйста, попробуйте еще раз."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Не удалось удалить приложение."
+msgstr "Не удалось удалить заявку."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Не удалось удалить запись хронологии."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Не удалось переместить приложение. Пожалуйста, попробуйте еще раз."
+msgstr "Не удалось переместить заявку. Пожалуйста, попробуйте еще раз."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Создано"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Создал \"{0}\" и связал его с этим приложением."
+msgstr "Создано \"{0}\" и связано с этой заявкой."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Пользовательские стили"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Чешский"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Опасная зона"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Датский"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Удалить поставщика"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Удалить эту ветку обсуждения с агентом?"
+msgstr "Удалить эту тему агента?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1392,7 +1392,7 @@ msgstr "Удалить запись хронологии"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Удалены приложения ({0})."
+msgstr "Удалено заявок: {0}."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Дублирование вашего резюме..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Нидерландский"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Включение двухфакторной аутентификаци
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Английский"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Английский (Великобритания)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Не удалось проанализировать резюме."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Не удалось заархивировать ветку обсуждения."
+msgstr "Не удалось заархивировать тему."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Не удалось удалить ключ API. Пожалуйста, �
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Не удалось удалить ветку обсуждения."
+msgstr "Не удалось удалить тему."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Не удалось выйти из системы. Пожалуйста
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Не удалось запустить поток агента."
+msgstr "Не удалось начать тему агента."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Найдите слабые пункты и переформулируй
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Финский"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Подходит для просмотра"
+msgstr "Вписать в окно"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Свободная форма"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Французский"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Сгенерировать случайное название"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Немецкий"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Получите обзор Вашего резюме с общей оц
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Получите углубленный анализ Вашего резюме с помощью искусственного интеллекта с общей оценкой, ключевыми достоинствами и практическими рекомендациями. Чтобы активировать эту функцию, пожалуйста, обновите настройки искусственного интеллекта."
+msgstr "Получите углубленный анализ Вашего резюме с помощью ИИ с общей оценкой, ключевыми достоинствами и практическими рекомендациями. Чтобы активировать эту функцию, пожалуйста, обновите настройки ИИ."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,7 +2116,7 @@ msgstr "Назад"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Иди домой"
+msgstr "На главную"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2127,7 +2127,7 @@ msgstr "Перейти к панели управления"
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Перейдите на панель резюме"
+msgstr "Перейдите на панель управления резюме"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Оценка"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Греческий"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Подзаголовок"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Иврит"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Цвет выделения"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Хинди"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Венгерский"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,11 +2349,11 @@ msgstr "Импорт из CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Импортировано приложений: {0}."
+msgstr "Импортировано заявок: {0}."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "Для импорта из PDF или Word требуется подключенный поставщик услуг искусственного интеллекта."
+msgstr "Для импорта из PDF или Word требуется подключенный поставщик ИИ."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Увеличить масштаб"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Индонезийский"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Выдавший"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Итальянский"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Курсив"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Японский"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Выровнять по ширине"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Каннада"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Держитесь вместе"
+msgstr "Не разрывать"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Ключевые слова"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Кхмерский"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Корейский"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Последний просмотр: {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Латышский"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Список"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Литовский"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Загрузка поставщиков ИИ. Пожалуйста, по
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Загрузка приложений…"
+msgstr "Загрузка заявок…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Загрузка возобновляется…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Загрузка потоков…"
+msgstr "Загрузка тем…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Сделайте раздел «Опыт работы» более ор�
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Малайский"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Малаялам"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Маратхи"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2793,7 +2793,7 @@ msgstr "Microsoft Word"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "Missing working resume"
-msgstr "Отсутствует резюме с места работы."
+msgstr "Отсутствует рабочее резюме."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
@@ -2848,7 +2848,7 @@ msgstr "Название"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Непальский"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Сеть"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Новое приложение"
+msgstr "Новая заявка"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,7 +2902,7 @@ msgstr "Без рекламы и отслеживания"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Ни одно приложение не соответствует вашим фильтрам."
+msgstr "Ни одна заявка не соответствует вашим фильтрам."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
@@ -2960,7 +2960,7 @@ msgstr "Тем пока нет."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Норвежский"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Заметки"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Ория"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Открыть"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Открытый агент ИИ"
+msgstr "Открыть агента ИИ"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Совместимость с OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Персидский"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Поток трубопровода"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Состояние конвейера во всех приложениях"
+msgstr "Состояние конвейера по всем заявкам"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Пожалуйста, подождите, пока генерирует�
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Польский"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Портретная"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Португальский (Бразилия)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Португальский (Португалия)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume — перейти на главную страницу"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Реактивное резюме (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3681,7 +3681,7 @@ msgstr "Карьерный рост"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Румынский"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3788,7 +3788,7 @@ msgstr "Поиск"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Поиск приложений…"
+msgstr "Поиск заявок…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Разделитель"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Сербский"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Настройте поставщика ИИ."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Перед началом обсуждения настройте поставщика ИИ."
+msgstr "Настройте поставщика ИИ, прежде чем начать тему."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Перейти к основному содержимому"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Словацкий"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Английский"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Интервал (по вертикали)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Испанский"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4193,7 +4193,7 @@ msgstr "Начать новую тему"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Начать обсуждение"
+msgstr "Начать тему"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4215,7 +4215,7 @@ msgstr "Начать с новой страницы"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Начало темы"
+msgstr "Начать тему"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Поддержите приложение, делая всё, что м�
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Шведский"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Пошив не удался."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Тамильский"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Телугу"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Цвет текста"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Тайский"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4464,11 +4464,11 @@ msgstr "Это действие необратимо. Сообщения в пе
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
-msgstr "Это действие необратимо. Сообщения и вложения в переписке будут удалены."
+msgstr "Это действие необратимо. Сообщения и вложения темы будут удалены."
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Не удалось открыть этот поток сообщений от агента."
+msgstr "Не удалось открыть эту тему агента."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4524,11 +4524,11 @@ msgstr "Эта тема архивирована. Новые сообщения 
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Эта ветка обсуждения доступна только для чтения."
+msgstr "Эта тема доступна только для чтения."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Эта ветка доступна только для чтения, поскольку рабочее резюме или поставщик услуг ИИ недоступны."
+msgstr "Эта тема доступна только для чтения, поскольку рабочее резюме или поставщик услуг ИИ недоступны."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,7 +4545,7 @@ msgstr "Это позволит удалить все элементы из эт
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "Действия потока"
+msgstr "Действия темы"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
@@ -4560,7 +4560,7 @@ msgstr "Тема удалена."
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Нити"
+msgstr "Темы"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "Переключите правую боковую панель"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Переключить потоки"
+msgstr "Переключить темы"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4647,7 +4647,7 @@ msgstr "Попробуйте еще раз"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Турецкий"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Типография"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Украинский"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Обновите календарную дату для этой зап�
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Обновите сведения об этом приложении."
+msgstr "Обновите сведения об этой заявке."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Пользователи"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Узбекский"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "История версий"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Вьетнамский"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Уменьшить"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Зулу"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ru-RU.po
+++ b/apps/web/locales/ru-RU.po
@@ -2377,7 +2377,7 @@ msgstr "Увеличить масштаб"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/ru-RU.po
+++ b/apps/web/locales/ru-RU.po
@@ -401,7 +401,7 @@ msgstr "И многое другое..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Антропный Клод"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Выровнять по центру"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Мозги"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Закрыть ИИ-помощника"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Когере"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Финский"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Фейерверк"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "Google"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "Google Близнецы"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "Плитка"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "Грок"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2981,7 +2981,7 @@ msgstr "Ория"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Облако Алламы"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Период"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Замешательство"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"

--- a/apps/web/locales/sk-SK.po
+++ b/apps/web/locales/sk-SK.po
@@ -266,7 +266,7 @@ msgstr "Pred spustením vlákna agenta pridajte a otestujte poskytovateľa."
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Pridať aplikáciu"
+msgstr "Pridať žiadosť"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "Pokročilé"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Afrikánčina"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -344,7 +344,7 @@ msgstr "Nastavenie agenta AI nie je k dispozícii, kým nie sú nakonfigurované
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "Asistent s umelou inteligenciou"
+msgstr "Asistent AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "Poskytovatelia umelej inteligencie vyžadujú konfiguráciu REDIS_URL a 
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albánčina"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Máte už účet? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharčina"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Aplikácia"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Akcie aplikácie"
+msgstr "Akcie žiadosti"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Aplikácia bola pridaná do vášho kanála."
+msgstr "Žiadosť bola pridaná do vášho kanála."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Kopilot aplikácie"
+msgstr "Kopilot žiadostí"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Aplikácia bola odstránená."
+msgstr "Žiadosť bola odstránená."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Štatistiky aplikácie"
+msgstr "Štatistiky žiadostí"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Aplikácia bola aktualizovaná."
+msgstr "Žiadosť bola aktualizovaná."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Aplikácie"
+msgstr "Žiadosti"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Použité s upozorneniami"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabčina"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Ocenenia"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbajdžančina"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Krásne šablóny, z ktorých si môžeš vybrať, a ďalšie sú na ces
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengálčina"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Najlepšie pre aplikácie, zdieľanie a tlač."
+msgstr "Najlepšie pre žiadosti, zdieľanie a tlač."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Príkazová paleta editora"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulharčina"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Nedá sa obnoviť; životopis sa od vykonania tejto úpravy zmenil."
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalánčina"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Kontrola konceptu"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Čínština (zjednodušená)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Čínština (tradičná)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Kruh"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Jasné"
+msgstr "Vyčistiť"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Nepodarilo sa overiť pripojenie. Skontrolujte kľúč API, model a zák
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Aplikáciu sa nepodarilo pridať. Skúste to znova."
+msgstr "Žiadosť sa nepodarilo pridať. Skúste to znova."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Aplikáciu sa nepodarilo odstrániť."
+msgstr "Žiadosť sa nepodarilo odstrániť."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Nepodarilo sa odstrániť záznam časovej osi."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Aplikáciu sa nepodarilo presunúť. Skúste to znova."
+msgstr "Žiadosť sa nepodarilo presunúť. Skúste to znova."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Vytvorené"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Vytvoril sa „{0}“ a prepojil sa s touto aplikáciou."
+msgstr "Vytvoril sa „{0}“ a prepojil sa s touto žiadosťou."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1288,7 +1288,7 @@ msgstr "Nebezpečná zóna"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Dánčina"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1302,7 +1302,7 @@ msgstr "Tmavá téma"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Dashboard"
-msgstr "Prístrojová doska"
+msgstr "Dashboard"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Data Security"
@@ -1392,7 +1392,7 @@ msgstr "Odstrániť záznam časovej osi"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Odstránené aplikácie (počet: {0})."
+msgstr "Odstránené žiadosti (počet: {0})."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Duplikujem tvoj životopis..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Holandčina"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Upraviť {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Upraviť aplikáciu"
+msgstr "Upraviť žiadosť"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Povolenie dvojfaktorového overenia…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Angličtina"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Angličtina (Spojené kráľovstvo)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1861,7 +1861,7 @@ msgstr "Nepodarilo sa obnoviť heslo. Skúste to prosím znova."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "Uloženie poskytovateľa umelej inteligencie zlyhalo."
+msgstr "Uloženie poskytovateľa AI zlyhalo."
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -1963,7 +1963,7 @@ msgstr "Nájdite slabé odrážky a prepíšte ich so silnejšími výsledkami, 
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Fínčina"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Voľný tvar"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Francúzština"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Vygenerovať náhodný názov"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Nemčina"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,18 +2116,18 @@ msgstr "Prejsť späť"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Choď domov"
+msgstr "Prejsť na úvodnú stránku"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Prejsť na nástenku"
+msgstr "Prejsť na Dashboard"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Prejsť na ovládací panel životopisov"
+msgstr "Prejsť na Dashboard životopisov"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Známka"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Gréčtina"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Titulok"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebrejčina"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Farba zvýraznenia"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindčina"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Maďarčina"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,11 +2349,11 @@ msgstr "Importovať z CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Počet importovaných aplikácií: {0}."
+msgstr "Počet importovaných žiadostí: {0}."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "Import z PDF alebo Wordu vyžaduje pripojeného poskytovateľa umelej inteligencie."
+msgstr "Import z PDF alebo Wordu vyžaduje pripojeného poskytovateľa AI."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Zväčšiť priblíženie"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonézština"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Vydavateľ"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Taliančina"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kurzíva"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japončina"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Zarovnať do bloku"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannadčina"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Držte sa spolu"
+msgstr "Ponechať pohromade"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Kľúčové slová"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmerčina"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Kórejčina"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Naposledy zobrazené {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Lotyština"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Zoznam"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litovčina"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Načítavajú sa poskytovatelia umelej inteligencie. Skúste to znova o 
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Načítavajú sa aplikácie…"
+msgstr "Načítavajú sa žiadosti…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Zamerajte sekciu skúseností viac na výsledky a odstráňte nejasné z
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malajčina"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malajálamčina"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Maráthčina"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Presunúť sekciu do iného stĺpca alebo na inú stranu"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Presuňte javisko"
+msgstr "Presuňte fázu"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Názov"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepálčina"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Sieť"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Nová aplikácia"
+msgstr "Nová žiadosť"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,11 +2902,11 @@ msgstr "Bez reklám, bez sledovania"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Vašim filtrom nevyhovujú žiadne aplikácie."
+msgstr "Vašim filtrom nevyhovujú žiadne žiadosti."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Zatiaľ žiadne aplikácie – pridajte niekoľko, aby ste videli svoje zúženie a miery odpovedí."
+msgstr "Zatiaľ žiadne žiadosti – pridajte niekoľko, aby ste videli svoje zúženie a miery odpovedí."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2960,7 +2960,7 @@ msgstr "Zatiaľ žiadne vlákna."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Nórčina"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Poznámky"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Urijčina"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Otvoriť"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Otvorený agent AI"
+msgstr "Otvoriť agenta AI"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Kompatibilné s OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Perzština"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Prietok potrubím"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Zdravie potrubia vo všetkých aplikáciách"
+msgstr "Zdravie potrubia vo všetkých žiadostiach"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Počkajte, prosím, kým sa vygeneruje váš PDF súbor…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Poľština"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Na výšku"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugalčina (Brazília)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugalčina (Portugalsko)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume – prejsť na domovskú stránku"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktívny životopis (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktívny životopis v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktívny životopis v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Kariérny postup"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumunčina"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Spustite prvú analýzu, aby ste získali hodnotiacu tabuľku, silné st
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Ruština"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Hľadať"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Hľadať aplikácie…"
+msgstr "Hľadať žiadosti…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Oddeľovač"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Srbčina"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4102,7 +4102,7 @@ msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovinčina"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Rozostup (zvisle)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Španielčina"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Podpor aplikáciu tak, ako môžeš!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Švédčina"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Šitie na mieru zlyhalo."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamilčina"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugčina"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Farba textu"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thajčina"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4460,7 +4460,7 @@ msgstr "Túto akciu nemožno vrátiť späť. Všetky tvoje dáta budú natrvalo
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "Túto akciu nie je možné vrátiť späť. Konverzačné správy a nahrané prílohy budú odstránené. Pracovný životopis zostane vo vašom ovládacom paneli a je možné ho odstrániť samostatne."
+msgstr "Túto akciu nie je možné vrátiť späť. Konverzačné správy a nahrané prílohy budú odstránené. Pracovný životopis zostane na vašom Dashborde a je možné ho odstrániť samostatne."
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
@@ -4630,7 +4630,7 @@ msgstr "Sledujte prácu, o ktorú sa uchádzate, a prepojte životopis, ktorý s
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "Sledujte svoju prvú aplikáciu"
+msgstr "Sledujte svoju prvú žiadosť"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "Skúste to znova"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turečtina"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typografia"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrajinčina"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Aktualizujte kalendárny dátum pre tento záznam časovej osi."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Aktualizujte podrobnosti tejto aplikácie."
+msgstr "Aktualizujte podrobnosti tejto žiadosti."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Používatelia"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbečtina"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "História verzií"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamčina"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,11 +5039,11 @@ msgstr "Keď je životopis uzamknutý, nemožno ho aktualizovať ani vymazať."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "Odkiaľ pochádzajú aplikácie"
+msgstr "Odkiaľ pochádzajú žiadosti"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
-msgstr "Kam smerovali vaše prihlášky"
+msgstr "Kam smerovali vaše žiadosti"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Work OpenAI"
@@ -5190,5 +5190,5 @@ msgstr "Oddialiť"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/sk-SK.po
+++ b/apps/web/locales/sk-SK.po
@@ -401,7 +401,7 @@ msgstr "A mnoho ďalšieho..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropický Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Zarovnať na stred"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Mozgy"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Zatvoriť asistenta s umelou inteligenciou"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Súdržnosť"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Zmenšiť priblíženie"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Hlboké vyhľadávanie"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Fínčina"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Ohňostroj"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -3207,7 +3207,7 @@ msgstr "Obdobie"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Zmätok"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Na vymazanie účtu musíš zadať potvrdzujúci text a kliknúť na tla
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Spolu.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "Platné URL adresy musia začínať http:// alebo https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Brána Vercel AI"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/sk-SK.po
+++ b/apps/web/locales/sk-SK.po
@@ -2377,7 +2377,7 @@ msgstr "Zväčšiť priblíženie"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/sl-SI.po
+++ b/apps/web/locales/sl-SI.po
@@ -401,7 +401,7 @@ msgstr "In še veliko več..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropični Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -876,7 +876,7 @@ msgstr "Zapri pomočnika umetne inteligence"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Skladno"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Zmanjšaj povečavo"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Globoko iskanje"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Finščina"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Ognjemet"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -3207,7 +3207,7 @@ msgstr "Obdobje"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Zmedenost"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Za izbris računa morate vnesti potrditveno besedilo in klikniti spodnji
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Skupaj.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/sl-SI.po
+++ b/apps/web/locales/sl-SI.po
@@ -266,7 +266,7 @@ msgstr "Preden začnete nit agenta, dodajte in preizkusite ponudnika."
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Dodaj aplikacijo"
+msgstr "Dodaj prijavo"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "Napredno"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Afriščina"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "Ponudniki umetne inteligence zahtevajo konfiguracijo REDIS_URL in ENCRYP
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanščina"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Že imate račun? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharščina"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Aplikacija"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Dejanja aplikacije"
+msgstr "Dejanja prijave"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Aplikacija je dodana v vaš cevovod."
+msgstr "Prijava je dodana v vaš cevovod."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Aplikacija Copilot"
+msgstr "Copilot za prijave"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Aplikacija izbrisana."
+msgstr "Prijava izbrisana."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Statistika aplikacije"
+msgstr "Statistika prijav"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Aplikacija posodobljena."
+msgstr "Prijava posodobljena."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Aplikacije"
+msgstr "Prijave"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Uporabljeno z opozorili"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabščina"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Priznanja"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbajdžanščina"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Čudovite predloge na izbiro, dodatne prihajajo."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengalščina"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Najboljše za aplikacije, skupno rabo in tiskanje."
+msgstr "Najboljše za prijave, skupno rabo in tiskanje."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Paleta ukazov graditelja"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bolgarščina"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Ni mogoče obnoviti; življenjepis se je od uveljavitve te spremembe spr
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalonščina"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Preverjanje osnutka"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Kitajščina (poenostavljena)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Kitajščina (tradicionalna)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Krog"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Jasno"
+msgstr "Počisti"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Povezave ni bilo mogoče preveriti. Preverite ključ API-ja, model in os
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Aplikacije ni bilo mogoče dodati. prosim poskusite ponovno"
+msgstr "Prijave ni bilo mogoče dodati. Prosimo, poskusite znova."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Aplikacije ni bilo mogoče izbrisati."
+msgstr "Prijave ni bilo mogoče izbrisati."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Vnosa na časovnici ni bilo mogoče izbrisati."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Aplikacije ni bilo mogoče premakniti. prosim poskusite ponovno"
+msgstr "Prijave ni bilo mogoče premakniti. Prosimo, poskusite znova."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Ustvarjeno"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Ustvaril »{0}« in ga povezal s to aplikacijo."
+msgstr "Ustvaril »{0}« in ga povezal s to prijavo."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Slogi po meri"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Češčina"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Nevarna cona"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danščina"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "Izbriši vnos na časovnici"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Št. izbrisanih aplikacij: {0}."
+msgstr "Izbrisanih prijav: {0}."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Podvajam vaš življenjepis..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Nizozemščina"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Uredi {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Uredi aplikacijo"
+msgstr "Uredi prijavo"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Omogočanje dvofaktorske avtentikacije…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Angleščina"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Angleščina (Združeno kraljestvo)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Poiščite šibke točke in jih preoblikujte z močnejšimi rezultati, �
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finščina"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Prosta oblika"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Francoščina"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Ustvari naključno ime"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Nemščina"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Nazaj"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Pojdi domov"
+msgstr "Nazaj na domačo stran"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Ocena"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Grščina"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Glava"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebrejščina"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Barva označevanja"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindujščina"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Madžarščina"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Uvoz iz CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Št. uvoženih aplikacij: {0}."
+msgstr "Uvoženih prijav: {0}."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Povečaj povečavo"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonezijščina"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Izdajatelj"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italijanščina"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Ležeče"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japonščina"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Poravnaj obojestransko"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannadaščina"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Ostanite skupaj"
+msgstr "Ohrani skupaj"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Ključne besede"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Kmerščina"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Korejščina"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Nazadnje ogledano dne {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Latvijščina"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Seznam"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litovščina"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Nalaganje ponudnikov umetne inteligence. Poskusite znova čez trenutek."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Nalaganje aplikacij…"
+msgstr "Nalaganje prijav…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Razdelek o izkušnjah naj bo bolj usmerjen k rezultatom in naj bodo odgo
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malajščina"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "malajalamščina"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "maratščina"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Premakni razdelek v drug stolpec ali na drugo stran"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Premakni oder"
+msgstr "Premakni fazo"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Ime"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "nepalščina"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Omrežje"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Nova aplikacija"
+msgstr "Nova prijava"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,11 +2902,11 @@ msgstr "Brez oglaševanja, brez sledenja"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Nobena aplikacija ne ustreza vašim filtrom."
+msgstr "Nobena prijava ne ustreza vašim filtrom."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Ni še nobenih aplikacij — dodajte jih nekaj, da si ogledate tok in število odgovorov."
+msgstr "Ni še nobenih prijav — dodajte jih nekaj, da si ogledate tok in število odgovorov."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2960,7 +2960,7 @@ msgstr "Še ni niti."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "norveščina"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Opombe"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "odijščina"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Odpri"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Odprti agent umetne inteligence"
+msgstr "Odprite agenta umetne inteligence"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Združljivo z OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "perzijščina"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Pretok cevovoda"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Zdravje cevovoda v vseh aplikacijah"
+msgstr "Zdravje cevovoda v vseh prijavah"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Počakajte, medtem ko se vaš PDF ustvarja…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "poljščina"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portret"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "portugalščina (Brazilija)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "portugalščina (Portugalska)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Pojdi na domačo stran"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktivni življenjepis (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktivni življenjepis v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktivni življenjepis v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Napredovanje v vlogi"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "romunščina"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Izvedite prvo analizo in pridobite preglednico, prednosti in prednostne 
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "ruščina"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Iskanje"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Iskanje aplikacij ..."
+msgstr "Iskanje prijav ..."
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Ločilo"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "srbščina"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,7 +4098,7 @@ msgstr "Preskoči na glavno vsebino"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "slovaščina"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
@@ -4153,7 +4153,7 @@ msgstr "Razmik (navpično)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "španščina"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Podprite aplikacijo na kakršen koli način lahko!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "švedščina"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Krojenje ni uspelo."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "tamilščina"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "teluguščina"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Barva besedila"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "tajščina"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4630,7 +4630,7 @@ msgstr "Sledite delovnemu mestu, na katerega se prijavljate, in povežite življ
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "Spremljajte svojo prvo aplikacijo"
+msgstr "Spremljajte svojo prvo prijavo"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "Poskusi znova"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "turščina"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipografija"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "ukrajinščina"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Posodobite koledarski datum za ta vnos na časovnici."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Posodobite podrobnosti te aplikacije."
+msgstr "Posodobite podrobnosti te prijave."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Uporabniki"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "uzbeščina"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Zgodovina različic"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "vietnamščina"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,7 +5039,7 @@ msgstr "Ko je zaklenjen, življenjepisa ni mogoče posodobiti ali izbrisati."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "Od kod prihajajo aplikacije"
+msgstr "Od kod prihajajo prijave"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
@@ -5190,5 +5190,5 @@ msgstr "Oddalji"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zuluščina"
+msgstr "isiZulu"
 

--- a/apps/web/locales/sl-SI.po
+++ b/apps/web/locales/sl-SI.po
@@ -2377,7 +2377,7 @@ msgstr "Povečaj povečavo"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/sq-AL.po
+++ b/apps/web/locales/sq-AL.po
@@ -2377,7 +2377,7 @@ msgstr "Rrit zmadhimin"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/sq-AL.po
+++ b/apps/web/locales/sq-AL.po
@@ -260,13 +260,13 @@ msgstr "Shto një etiketë dhe shtyp Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Shtoni dhe testoni një ofrues përpara se të filloni një fije diskutimi agjentësh."
+msgstr "Shtoni dhe testoni një ofrues përpara se të filloni një fije agjentësh."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Shto aplikacion"
+msgstr "Shto aplikim"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "I avancuar"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Afrikanisht"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -376,7 +376,7 @@ msgstr "Keni tashmë një llogari? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharisht"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -451,31 +451,31 @@ msgstr "Veprimet e aplikimit"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Aplikacioni u shtua në tubacionin tuaj."
+msgstr "Aplikimi u shtua në tubacionin tuaj."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Kopilot i aplikacionit"
+msgstr "Kopilot i aplikimeve"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Aplikacioni u fshi."
+msgstr "Aplikimi u fshi."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Statistikat e aplikacionit"
+msgstr "Statistikat e aplikimeve"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Aplikacioni u përditësua."
+msgstr "Aplikimi u përditësua."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Aplikacionet"
+msgstr "Aplikimet"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Zbatuar me paralajmërime"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabisht"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Çmime"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbajxhanisht"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Shabllone të bukura për të zgjedhur, me më shumë që po vijnë."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengalisht"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Më e mira për aplikacione, ndarje dhe printim."
+msgstr "Më e mira për aplikime, ndarje dhe printim."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Paneli i komandave të ndërtuesit"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bullgarisht"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Nuk mund të rikthehet; CV-ja ka ndryshuar që kur është aplikuar ky n
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalanisht"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Duke kontrolluar draftin"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Kinezçe (E thjeshtuar)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Kinezçe (Tradicionale)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Zgjidhni një CV"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Zgjidh një bisedë ekzistuese nga shiriti anësor ose fillo një temë të re të fokusuar në draft."
+msgstr "Zgjidh një bisedë ekzistuese nga shiriti anësor ose fillo një fije të re të fokusuar në draft."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "Rreth"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "E qartë"
+msgstr "Pastro"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Nuk mundi të verifikojë lidhjen. Kontrolloni çelësin API, modelin dh
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Aplikacioni nuk mund të shtohej. Ju lutemi provoni përsëri."
+msgstr "Aplikimi nuk mund të shtohej. Ju lutemi provoni përsëri."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Aplikacioni nuk mund të fshihej."
+msgstr "Aplikimi nuk mund të fshihej."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Nuk mund të fshihej hyrja e afatit kohor."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Aplikacioni nuk mund të zhvendosej. Ju lutemi provoni përsëri."
+msgstr "Aplikimi nuk mund të zhvendosej. Ju lutemi provoni përsëri."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Krijuar"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Krijoi \"{0}\" dhe e lidhi me këtë aplikacion."
+msgstr "Krijoi \"{0}\" dhe e lidhi me këtë aplikim."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Stilet e Personalizuara"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Çekisht"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Zonë rreziku"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danisht"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Fshi ofruesin"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Të fshihet kjo temë diskutimi e agjentëve?"
+msgstr "Të fshihet kjo fije e agjentëve?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1392,7 +1392,7 @@ msgstr "Fshi hyrjen e afatit kohor"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "U fshinë {0} aplikacione."
+msgstr "U fshinë {0} aplikime."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Po dyfishohet CV-ja juaj..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Holandisht"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Redakto {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Redakto aplikacionin"
+msgstr "Redakto aplikimin"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Aktivizimi i vërtetimit me dy faktorë…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Anglisht"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Anglisht (Mbretëria e Bashkuar)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Dështoi të analizojë CV-në."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Arkivimi i temës dështoi."
+msgstr "Arkivimi i fijes dështoi."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1963,7 +1963,7 @@ msgstr "Gjej pikat e dobëta dhe rishkruani ato me rezultate, numra, fushëvepri
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finlandisht"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "I përshtatshëm për t’u parë"
+msgstr "Përshtat për pamje"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Formë e lirë"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Frëngjisht"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Gjenero një emër të rastësishëm"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Gjermanisht"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,13 +2116,13 @@ msgstr "Kthehu mbrapa"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Shko në shtëpi"
+msgstr "Kthehu te faqja kryesore"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Shko te paneli kryesor"
+msgstr "Shko te paneli i kontrollit"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "Nota / Vlerësimi"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Greqisht"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Titulli"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebraisht"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Ngjyra e theksimit"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Indisht (Hindi)"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Hungarisht"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Importo nga CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "U importuan {0} aplikacione."
+msgstr "U importuan {0} aplikime."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Rrit zmadhimin"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonezisht"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Lëshuesi"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italisht"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Të pjerrëta"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japonisht"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "Rreshto i justifikuar"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kanadisht (Kannada)"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "Fjalët kyçe"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Kmerisht"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Koreanisht"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Shikuar së fundmi më {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Letonisht"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Listë"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Lituanisht"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Duke ngarkuar ofruesit e inteligjencës artificiale. Ju lutemi provoni p
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Duke ngarkuar aplikacionet…"
+msgstr "Duke ngarkuar aplikimet…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Bëjeni seksionin e përvojës më të orientuar drejt rezultateve dhe h
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malajisht"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malajalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Maratisht"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Emri"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalisht"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Rrjeti"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Aplikacion i ri"
+msgstr "Aplikim i ri"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,11 +2902,11 @@ msgstr "Pa reklama, pa gjurmim"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Asnjë aplikacion nuk përputhet me filtrat tuaj."
+msgstr "Asnjë aplikim nuk përputhet me filtrat tuaj."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Ende nuk ka aplikacione — shtoni disa për të parë gypin tuaj dhe normat e përgjigjeve."
+msgstr "Ende nuk ka aplikime — shtoni disa për të parë gypin tuaj dhe normat e përgjigjeve."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2956,11 +2956,11 @@ msgstr "Asnjë ofrues i testuar"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Nuk ka ende tema."
+msgstr "Nuk ka ende fije."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norvegjisht"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Shënime"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Hap"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Agjent i hapur i inteligjencës artificiale"
+msgstr "Hap agjentin e inteligjencës artificiale"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "I pajtueshëm me OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persisht"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Rrjedha e tubacionit"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Shëndeti i tubacionit në të gjitha aplikacionet"
+msgstr "Shëndeti i tubacionit në të gjitha aplikimet"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Ju lutemi prisni ndërsa PDF-ja juaj po gjenerohet…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polonisht"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portret"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugalisht (Brazil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugalisht (Portugali)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Shko në faqen kryesore"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Rezervë Reaktive (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3681,7 +3681,7 @@ msgstr "Progresi i rolit"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumanisht"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Ekzekutoni analizën tuaj të parë për të marrë një kartë rezultat
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Rusisht"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Kërko"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Kërko aplikacione…"
+msgstr "Kërko aplikime…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Ndarës"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbisht"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Vendosni një ofrues të inteligjencës artificiale"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Konfiguro një ofrues të inteligjencës artificiale përpara se të fillosh një temë diskutimi."
+msgstr "Konfiguro një ofrues të inteligjencës artificiale përpara se të fillosh një fije."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Kalo te përmbajtja kryesore"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Sllovakisht"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Sllovenisht"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Hapësira (Vertikale)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spanjisht"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "Jepna yll në GitHub, aktualisht {0} yje (hapet në skedë të re)"
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Fillo një temë të re"
+msgstr "Fillo një fije të re"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Fillo një fije diskutimi"
+msgstr "Fillo një fije"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4215,7 +4215,7 @@ msgstr "Filloni në faqe të re"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Filloni temën"
+msgstr "Fillo fijen"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Mbështetni aplikacionin duke bërë çfarë të mundni!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Suedisht"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Rrobaqepësia dështoi."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamile"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Ngjyra e tekstit"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Tajlandisht"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "URL-ja që keni futur nuk është e vlefshme."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "CV-ja e punës u fshi. Kjo temë diskutimi është vetëm për lexim."
+msgstr "CV-ja e punës u fshi. Kjo fije është vetëm për lexim."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4468,7 +4468,7 @@ msgstr "Ky veprim nuk mund të anulohet. Mesazhet dhe bashkëngjitjet e fijeve d
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Kjo temë diskutimi për agjentët nuk mund të hapej."
+msgstr "Kjo fije e agjentëve nuk mund të hapej."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "Ky hap është opsional, por i rekomanduar."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Kjo temë diskutimi është arkivuar. Mesazhe të reja nuk mund të dërgohen."
+msgstr "Kjo fije është arkivuar. Mesazhe të reja nuk mund të dërgohen."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Kjo temë është vetëm për lexim"
+msgstr "Kjo fije është vetëm për lexim"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Kjo temë është vetëm për lexim sepse CV-ja ose ofruesi i inteligjencës artificiale nuk është i disponueshëm."
+msgstr "Kjo fije është vetëm për lexim sepse CV-ja ose ofruesi i inteligjencës artificiale nuk është i disponueshëm."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4549,11 +4549,11 @@ msgstr "Veprimet e fijeve"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Tema u arkivua."
+msgstr "Fija u arkivua."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Tema u fshi."
+msgstr "Fija u fshi."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -4622,7 +4622,7 @@ msgstr "Aktivizo shiritin anësor të djathtë"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Aktivizo/çaktivizo temat"
+msgstr "Aktivizo/çaktivizo fijet"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4630,7 +4630,7 @@ msgstr "Ndiqni një punë për të cilën po aplikoni dhe lidhni CV-në që keni
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "Ndiqni aplikacionin tuaj të parë"
+msgstr "Ndiqni aplikimin tuaj të parë"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "Provo përsëri"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turqisht"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipografia"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrainisht"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Përditësoni datën e kalendarit për këtë hyrje të afatit kohor."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Përditësoni detajet e këtij aplikacioni."
+msgstr "Përditësoni detajet e këtij aplikimi."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Përdorues"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbeke"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Historiku i versioneve"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnameze"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5173,7 +5173,7 @@ msgstr "Mbështetja juaj siguron që projekti të mbetet falas dhe i aksesueshë
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Zoom"
-msgstr "Zmadho"
+msgstr "Zmadhimi"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom in"
@@ -5190,5 +5190,5 @@ msgstr "Zvogëlo"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/sq-AL.po
+++ b/apps/web/locales/sq-AL.po
@@ -401,7 +401,7 @@ msgstr "Dhe shumë të tjera..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropik Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -876,7 +876,7 @@ msgstr "Mbyll asistentin e inteligjencës artificiale"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Koherë"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Zvogëlo zmadhimin"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Kërkim i thellë"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Finlandisht"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Fishekzjarre"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Reja Ollama"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3046,7 +3046,7 @@ msgstr "I pajtueshëm me OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "Ruter i hapur"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "Periudha"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Hutim"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Për të fshirë llogarinë tuaj, duhet të shkruani tekstin e konfirmim
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Së bashku.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "URL-të e vlefshme duhet të fillojnë me http:// ose https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Porta Vercel AI"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/sr-SP.po
+++ b/apps/web/locales/sr-SP.po
@@ -401,7 +401,7 @@ msgstr "И још много тога..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Антропик Клод"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Поравнај по средини"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Церебрас"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Затвори AI асистент"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Кохерентно"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Смањи зумирање"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "ДипСеек"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Фински"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Ватромет"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "Гугл"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "Гугл Џемини"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "Мрежа"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "Грок"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "Недостаје радни животопис"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Мистрал АИ"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Одија"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Олама Клауд"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "Отворени код"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "ОпенАИ"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "Компатибилно са OpenAI-ом"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "Отворени рутер"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "Период"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Збуњеност"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Да бисте обрисали свој налог, потребно �
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Заједно.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "Важећи URL-ови морају да почињу са http:// ил
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Версел АИ Гејтвеј"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "X (Твитер)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI Грок"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/sr-SP.po
+++ b/apps/web/locales/sr-SP.po
@@ -2377,7 +2377,7 @@ msgstr "Повећај зумирање"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/sr-SP.po
+++ b/apps/web/locales/sr-SP.po
@@ -266,7 +266,7 @@ msgstr "Додајте и тестирајте провајдера пре по�
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Додајте апликацију"
+msgstr "Додајте пријаву"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "Напредно"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Африканс"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "Добављачи вештачке интелигенције захт�
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Албански"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Већ имате налог? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Амхарски"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,35 +447,35 @@ msgstr "Апликација"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Акције апликације"
+msgstr "Акције пријаве"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Апликација је додата у ваш цевовод."
+msgstr "Пријава је додата у ваш цевовод."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "Апликација Цопилот"
+msgstr "Копилот пријава"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "Апликација је избрисана."
+msgstr "Пријава је избрисана."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Статистика апликације"
+msgstr "Статистика пријава"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Апликација је ажурирана."
+msgstr "Пријава је ажурирана."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "Апликације"
+msgstr "Пријаве"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
@@ -504,7 +504,7 @@ msgstr "Примењено са упозорењима"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Арапски"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Награде"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Азербејџански"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Лепи шаблони из којих можете да бирате, 
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Бенгалски"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Најбоље за апликације, дељење и штампање."
+msgstr "Најбоље за пријаве, дељење и штампање."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Командна палета уређивача"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Бугарски"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Није могуће вратити; резиме се променио
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Каталонски"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Текућа верзија"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Кинески (поједностављени)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Кинески (традиционални)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Круг"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Јасно"
+msgstr "Очисти"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Није могуће проверити везу. Проверите AP
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Није могуће додати апликацију. Покушајте поново."
+msgstr "Није могуће додати пријаву. Покушајте поново."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Брисање апликације није успело."
+msgstr "Брисање пријаве није успело."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Није могуће избрисати унос временске л�
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Премештање апликације није успело. Покушајте поново."
+msgstr "Премештање пријаве није успело. Покушајте поново."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Креирано"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Направио је „{0}“ и повезао га са овом апликацијом."
+msgstr "Направио је „{0}“ и повезао га са овом пријавом."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Прилагођени стилови"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Чешки"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Опасна зона"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Дански"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Обриши добављача"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Да ли желите да обришете ову тему агента?"
+msgstr "Да ли желите да обришете ову нит агента?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1392,7 +1392,7 @@ msgstr "Избриши унос временске линије"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Избрисане апликације ({0})."
+msgstr "Избрисане пријаве ({0})."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Дуплирање вашег резимеа..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Холандски"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "Уреди {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "Уреди апликацију"
+msgstr "Уреди пријаву"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "Омогућавање двофакторске аутентификац
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Енглески"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Енглески (Уједињено Краљевство)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Пронађите слабе тачке и препишите их са
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Фински"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Слободан облик"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Француски"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2079,7 +2079,7 @@ msgstr "Уређивач у пуном екрану"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Gaps:"
-msgstr "празнине:"
+msgstr "Празнине:"
 
 #: src/dialogs/resume/index.tsx
 msgid "Generate a random name"
@@ -2087,7 +2087,7 @@ msgstr "Генериши насумично име"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Немачки"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Иди назад"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Иди кући"
+msgstr "На почетну страницу"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "Оцена"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Грчки"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Наслов"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Хебрејски"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Боја истицања"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Хинди"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Мађарски"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Увези из ЦСВ-а"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Увезено је {0} апликација(а)."
+msgstr "Увезено је {0} пријава."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Повећај зумирање"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Индонежански"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Издавач сертификата"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Италијански"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Курзив"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Јапански"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Поравнај обострано"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Канада"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Држите се заједно"
+msgstr "Задржи заједно"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Кључне речи"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Кмерски"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Корејски"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Последњи пут прегледано {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Летонски"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Листа"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Литвански"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Учитавање добављача вештачке интелиге�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Учитавање апликација…"
+msgstr "Учитавање пријава…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Учитавање биографија…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Учитавање тема…"
+msgstr "Учитавање нити…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Учините одељак о искуству више оријент�
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Малајски"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Малајалам"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Марати"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Преместите одељак у другу колону или ст
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Померите позорницу"
+msgstr "Померите фазу"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Име"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Непалски"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Мрежа"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Нова апликација"
+msgstr "Нова пријава"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "Нова ознака…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Нова тема"
+msgstr "Нова нит"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Нова тема"
+msgstr "Нова нит"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2902,11 +2902,11 @@ msgstr "Без оглашавања, без праћења"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Ниједна апликација не одговара вашим филтерима."
+msgstr "Ниједна пријава не одговара вашим филтерима."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "Још нема апликација — додајте неколико да видите свој ток и стопе одговора."
+msgstr "Још нема пријава — додајте неколико да видите свој ток и стопе одговора."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2956,11 +2956,11 @@ msgstr "Нема тестираног добављача"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Још нема тема."
+msgstr "Још нема нити."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Норвешки"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Белешке"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Одија"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Компатибилно са OpenAI-ом"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Персијски"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Проток цевовода"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Здравље цевовода у свим апликацијама"
+msgstr "Здравље цевовода у свим пријавама"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Молимо сачекајте док се ваш PDF генерише�
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Пољски"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Портрет"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Португалски (Бразил)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Португалски (Португал)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Реактивни Резиме - Иди на почетну стран�
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Реактивни резиме (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Реактивни резиме v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Реактивни резиме v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Напредовање у улози"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Румунски"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Покрените прву анализу да бисте добили 
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Руски"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Претрага"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Претражи апликације…"
+msgstr "Претражи пријаве…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3916,7 +3916,7 @@ msgstr "Подесите добављача вештачке интелиген�
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Подесите добављача вештачке интелигенције пре него што започнете тему."
+msgstr "Подесите добављача вештачке интелигенције пре него што започнете нит."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Прескочи на главни садржај"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Словачки"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Словеначки"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Размак (вертикални)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Шпански"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "Дај нам звездицу на GitHub-у, тренутно {0} зв
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Започни нову тему"
+msgstr "Започни нову нит"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Започни тему"
+msgstr "Започни нит"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Почните да креирате свој резиме од нуле
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Покрени нову тему"
+msgstr "Покрени нову нит"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Почни на новој страници"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Покрени тему"
+msgstr "Покрени нит"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Подржите апликацију колико можете!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Шведски"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Кројење није успело."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Тамилски"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Телугу"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Боја текста"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Тајландски"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "URL који сте унели није важећи."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Радни резиме је обрисан. Ова тема је само за читање."
+msgstr "Радни резиме је обрисан. Ова нит је само за читање."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4520,15 +4520,15 @@ msgstr "Овај корак је опционо, али препоручен."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Ова тема је архивирана. Нове поруке се не могу слати."
+msgstr "Ова нит је архивирана. Нове поруке се не могу слати."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Ова тема је само за читање"
+msgstr "Ова нит је само за читање"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Ова тема је само за читање јер радни животопис или добављач вештачке интелигенције нису доступни."
+msgstr "Ова нит је само за читање јер радни животопис или добављач вештачке интелигенције нису доступни."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4549,11 +4549,11 @@ msgstr "Радње у нитима"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Тема је архивирана."
+msgstr "Нит је архивирана."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Тема је обрисана."
+msgstr "Нит је обрисана."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -4647,7 +4647,7 @@ msgstr "Покушај поново"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Турски"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Типографија"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Украјински"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Ажурирајте календарски датум за овај у�
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Ажурирајте детаље ове апликације."
+msgstr "Ажурирајте детаље ове пријаве."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Корисници"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Узбечки"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Историја верзија"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Вијетнамски"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,7 +5039,7 @@ msgstr "Када је закључан, резиме се не може ажур
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "Одакле долазе апликације"
+msgstr "Одакле долазе пријаве"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
@@ -5190,5 +5190,5 @@ msgstr "Умањи"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Зулу"
+msgstr "isiZulu"
 

--- a/apps/web/locales/sv-SE.po
+++ b/apps/web/locales/sv-SE.po
@@ -2377,7 +2377,7 @@ msgstr "Öka zoomen"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/sv-SE.po
+++ b/apps/web/locales/sv-SE.po
@@ -401,7 +401,7 @@ msgstr "Och många fler..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropiska Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -876,7 +876,7 @@ msgstr "Stäng AI-assistenten"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Sammanhängande"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Finska"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Fyrverkeri"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Ollama-molnet"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Period"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Bryderi"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "För att radera ditt konto måste du ange bekräftelsetexten och klicka 
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Tillsammans.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx

--- a/apps/web/locales/sv-SE.po
+++ b/apps/web/locales/sv-SE.po
@@ -266,7 +266,7 @@ msgstr "Lägg till och testa en leverantör innan du startar en agenttråd."
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "Lägg till applikation"
+msgstr "Lägg till ansökan"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -315,7 +315,7 @@ msgstr "Avancerad"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Afrikanska"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "AI-leverantörer kräver att REDIS_URL och ENCRYPTION_SECRET konfigurera
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Albanska"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Har du redan ett konto? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amhariska"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,11 +447,11 @@ msgstr "App"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "Programåtgärder"
+msgstr "Ansökningsåtgärder"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "Applikation har lagts till i din pipeline."
+msgstr "Ansökan har lagts till i din pipeline."
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
@@ -464,11 +464,11 @@ msgstr "Ansökan raderad."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Applikationsstatistik"
+msgstr "Ansökningsstatistik"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "Applikationen uppdaterad."
+msgstr "Ansökan uppdaterad."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -504,7 +504,7 @@ msgstr "Tillämpas med varningar"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arabiska"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -591,7 +591,7 @@ msgstr "Bifoga filer"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment"
-msgstr "Fastsättning"
+msgstr "Bilaga"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment uploaded."
@@ -628,7 +628,7 @@ msgstr "Utmärkelser"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerbajdzjanska"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "Vackra mallar att välja mellan, fler är på väg."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengali"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "Bäst för applikationer, delning och utskrift."
+msgstr "Bäst för ansökningar, delning och utskrift."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "Kommandopalett För Byggaren"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgariska"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Det går inte att återställa; CV:t har ändrats sedan den här rediger
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalanska"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Kontrollerar utkast"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Kinesiska (förenklad)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Kinesiska (traditionell)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Cirkel"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Klart"
+msgstr "Rensa"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "Kunde inte verifiera anslutningen. Kontrollera API-nyckeln, modellen och
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "Det gick inte att lägga till appen. Försök igen."
+msgstr "Det gick inte att lägga till ansökan. Försök igen."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "Det gick inte att ta bort programmet."
+msgstr "Det gick inte att ta bort ansökan."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "Det gick inte att ta bort tidslinjeposten."
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "Det gick inte att flytta applikationen. Försök igen."
+msgstr "Det gick inte att flytta ansökan. Försök igen."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "Skapad"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "Skapade \"{0}\" och länkade den till denna applikation."
+msgstr "Skapade \"{0}\" och länkade den till denna ansökan."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "Anpassade stilar"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Tjeckiska"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Farozon"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danska"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "Ta bort tidslinjepost"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "Raderade {0} applikation(er)."
+msgstr "Raderade {0} ansökning(ar)."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "Duplicerar ditt CV..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Nederländska"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Aktivera tvåfaktorsautentisering…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Engelska"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Engelska (Storbritannien)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "Hitta svaga punkter och skriv om dem med starkare utfall, siffror, omfat
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Finska"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Anpassa för visning"
+msgstr "Anpassa till vy"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Fri form"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Franska"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Generera ett slumpmässigt namn"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Tyska"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2122,12 +2122,12 @@ msgstr "Gå hem"
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Gå till dashboard"
+msgstr "Gå till instrumentpanelen"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Gå till kontrollpanelen för CV"
+msgstr "Gå till instrumentpanelen för CV"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Betyg"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Grekiska"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Rubrik"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Hebreiska"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Markeringsfärg"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Ungerska"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "Importera från CSV"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "Importerade {0} program."
+msgstr "Importerade {0} ansökningar."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "Öka zoomen"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesiska"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Utfärdare"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italienska"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kursiv"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japanska"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "Marginaljustera"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kanadensiska"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "Nyckelord"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Koreanska"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Senast visad den {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Lettiska"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Lista"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litauiska"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Laddar AI-leverantörer. Försök igen om en stund."
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Laddar applikationer…"
+msgstr "Laddar ansökningar…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Gör erfarenhetsdelen mer resultatinriktad och ta bort vaga ansvarsområ
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malajiska"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "Flytta avsnitt till en annan kolumn eller sida"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "Flytta scenen"
+msgstr "Flytta fas"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "Namn"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalesiska"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Nätverk"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Ny applikation"
+msgstr "Ny ansökan"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2902,7 +2902,7 @@ msgstr "Ingen reklam, ingen spårning"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "Inga appar matchar dina filter."
+msgstr "Inga ansökningar matchar dina filter."
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
@@ -2960,7 +2960,7 @@ msgstr "Inga trådar än."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norska"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Anteckningar"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Öppna"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Öppen AI-agent"
+msgstr "Öppna AI-agenten"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-kompatibel"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Persiska"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "Rörledningsflöde"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "Pipeline hälsa i alla applikationer"
+msgstr "Pipeline-hälsa för alla ansökningar"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "Vänta medan din PDF genereras…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polska"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Porträtt"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugisiska (Brasilien)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugisiska (Portugal)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Gå till startsida"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktivt CV (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktivt CV v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktivt CV v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Rollutveckling"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumänska"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Kör din första analys för att få ett scorecard, styrkor och priorite
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Ryska"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "Söka"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "Sök applikationer..."
+msgstr "Sök ansökningar..."
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3899,7 +3899,7 @@ msgstr "Avskiljare"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbiska"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Hoppa till huvudinnehåll"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovakiska"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovenska"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Mellanrum (vertikalt)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Spanska"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4323,11 +4323,11 @@ msgstr "Skräddarsytt misslyckades."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Textfärg"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thailändska"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "Försök igen"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turkiska"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Typografi"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrainska"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "Uppdatera kalenderdatumet för den här tidslinjeposten."
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "Uppdatera denna applikations information."
+msgstr "Uppdatera informationen för denna ansökan."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "Användare"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbekiska"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Versionshistorik"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamesiska"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Zooma ut"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ta-IN.po
+++ b/apps/web/locales/ta-IN.po
@@ -260,7 +260,7 @@ msgstr "ஒரு குறிச்சொல்லைச் சேர்த்�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "ஏஜென்ட் த்ரெட்டைத் தொடங்குவதற்கு முன், ஒரு வழங்குநரைச் சேர்த்துச் சோதிக்கவும்."
+msgstr "முகவர் உரையாடலைத் தொடங்குவதற்கு முன், ஒரு வழங்குநரைச் சேர்த்துச் சோதிக்கவும்."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -315,7 +315,7 @@ msgstr "மேம்பட்ட"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "ஆஃப்ரிகான்ஸ்"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "AI வழங்குநர்களுக்கு REDIS_URL மற்�
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "அல்பேனியன்"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "ஏற்கனவே கணக்கு உள்ளதா? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "அம்ஹாரிக்"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,11 +464,11 @@ msgstr "விண்ணப்பம் நீக்கப்பட்டது."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "செயலி புள்ளிவிபரங்கள்"
+msgstr "விண்ணப்பப் புள்ளிவிவரங்கள்"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "பயன்பாடு புதுப்பிக்கப்பட்டது."
+msgstr "விண்ணப்பம் புதுப்பிக்கப்பட்டது."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -504,7 +504,7 @@ msgstr "எச்சரிக்கைகளுடன் கூடிய அற�
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "அரபிக்"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "விருதுகள்"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "அசர்பைஜானி"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,11 +661,11 @@ msgstr "தேர்வு செய்ய அழகான டெம்ப்ள
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "பெங்காலி"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "பயன்பாடுகள், பகிர்தல் மற்றும் அச்சிடுவதற்கு சிறந்தது."
+msgstr "விண்ணப்பங்கள், பகிர்தல் மற்றும் அச்சிடுவதற்கு சிறந்தது."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -703,7 +703,7 @@ msgstr "பில்டர் கட்டளைத் தேர்வு பட
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "பல்கேரியன்"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "மீட்டெடுக்க முடியாது; இந்த
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "கட்டலான்"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "வரைவைச் சரிபார்த்தல்"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "சீனம் (எளிய)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "சீனம் (சம்பிரதாய)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "வட்டம்"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "தெளிவான"
+msgstr "நீக்கு"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1044,12 +1044,12 @@ msgstr "இணைப்பைச் சரிபார்க்க முடி�
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "பயன்பாட்டைச் சேர்க்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்."
+msgstr "விண்ணப்பத்தைச் சேர்க்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "பயன்பாட்டை நீக்க முடியவில்லை."
+msgstr "விண்ணப்பத்தை நீக்க முடியவில்லை."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "காலவரிசை உள்ளீட்டை நீக்க ம
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "பயன்பாட்டை நகர்த்த முடியவில்லை. மீண்டும் முயற்சிக்கவும்."
+msgstr "விண்ணப்பத்தை நகர்த்த முடியவில்லை. மீண்டும் முயற்சிக்கவும்."
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1233,7 +1233,7 @@ msgstr "உருவாக்கப்பட்டது"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "\"{0}\" உருவாக்கி, இந்தப் பயன்பாட்டுடன் இணைக்கப்பட்டது."
+msgstr "\"{0}\" உருவாக்கி, இந்த விண்ணப்பத்துடன் இணைக்கப்பட்டது."
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "தனிப்பயன் பாணிகள்"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "செக்"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "அபாய பகுதி"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "டேனிஷ்"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1392,7 +1392,7 @@ msgstr "காலவரிசை உள்ளீட்டை நீக்கு"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "நீக்கப்பட்ட {0} பயன்பாடு(கள்)."
+msgstr "நீக்கப்பட்ட {0} விண்ணப்பம்(கள்)."
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "உங்கள் ரெஸ்யூமியின் நகலை உ
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "டச்சு"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "திருத்து {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "பயன்பாட்டைத் திருத்தவும்"
+msgstr "விண்ணப்பத்தைத் திருத்தவும்"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "இரு காரணி அங்கீகாரத்தை இயக
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "ஆங்கிலம்"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "ஆங்கிலம் (ஐக்கிய இராச்சியம்)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "வாழ்க்கை வரலாற்றை பகுப்பா�
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "இழையை காப்பகப்படுத்த முடியவில்லை."
+msgstr "உரையாடலை காப்பகப்படுத்த முடியவில்லை."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "API சாவியை நீக்கத் தவறிவிட்ட
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "திரியை நீக்க முடியவில்லை."
+msgstr "உரையாடலை நீக்க முடியவில்லை."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "உள்நுழையத் தவறியது. மீண்டு
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "முகவர் திரியைத் தொடங்க முடியவில்லை."
+msgstr "முகவர் உரையாடலைத் தொடங்க முடியவில்லை."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "பலவீனமான அம்சங்களைக் கண்ட�
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "ஃபின்னிஷ்"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "பார்வைக்கு ஏற்றது"
+msgstr "பார்வைக்குப் பொருத்து"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "இலவச வடிவம்"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "ஃபிரென்ச்"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "ஒரு சீரற்ற பெயரை உருவாக்கு
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "ஜெர்மன்"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "திரும்பிச் செல்"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "வீட்டிற்குச் செல்லுங்கள்"
+msgstr "முகப்புப் பக்கத்திற்குச் செல்லுங்கள்"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2127,7 +2127,7 @@ msgstr "டாஷ்போர்டுக்கு செல்லவும்"
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "விண்ணப்பங்கள் டாஷ்போர்டுக்குச் செல்லவும்"
+msgstr "ரெஸ்யூம் டாஷ்போர்டுக்குச் செல்லவும்"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "மதிப்பெண்"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "கிரேக்கம்"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "தலைவரி"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "ஹீப்ரூ"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "ஹைலைட் நிறம்"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "ஹிந்தி"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "ஹங்கேரியன்"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,7 +2349,7 @@ msgstr "CSV இலிருந்து இறக்குமதி செய்
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "{0} பயன்பாடு(கள்) இறக்குமதி செய்யப்பட்டது."
+msgstr "{0} விண்ணப்பம்(கள்) இறக்குமதி செய்யப்பட்டது."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
@@ -2377,7 +2377,7 @@ msgstr "பெரிதாக்கத்தை அதிகரிக்கவ�
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "இந்தோனேஷியன்"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "வெளியீட்டாளர்"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "இத்தாலியன்"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "சாய்ந்த"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "ஜப்பானியம்"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "இரு விளிமைகளும் ஒழுங்காக்�
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "கன்னடம்"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "முக்கிய சொற்கள்"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "கமெர்"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "கொரியன்"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "கடைசியாக {0} அன்று பார்க்கப்
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "லாட்வியன்"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "பட்டியல்"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "லிதுவேனியன்"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2697,7 +2697,7 @@ msgstr "ஏற்றுதல் மீண்டும் தொடங்கு�
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "இழைகள் ஏற்றப்படுகின்றன…"
+msgstr "உரையாடல்கள் ஏற்றப்படுகின்றன…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "அனுபவப் பகுதியை முடிவுகளை 
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "மலாய்"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "மலையாளம்"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "மராத்தி"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2809,7 +2809,7 @@ msgstr "பகுதியை மற்றொரு பத்திக்கோ 
 
 #: src/features/applications/components/table-view.tsx
 msgid "Move stage"
-msgstr "மேடையை நகர்த்தவும்"
+msgstr "கட்டத்தை நகர்த்தவும்"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -2848,7 +2848,7 @@ msgstr "பெயர்"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "நேபாளி"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2889,12 +2889,12 @@ msgstr "புதிய குறிச்சொல்…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "புதிய இழை"
+msgstr "புதிய உரையாடல்"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "புதிய இழை"
+msgstr "புதிய உரையாடல்"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2906,7 +2906,7 @@ msgstr "உங்கள் வடிப்பான்களுடன் பொ�
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "இதுவரை பயன்பாடுகள் இல்லை — உங்கள் புனல் மற்றும் பதில் விகிதங்களைக் காண சிலவற்றைச் சேர்க்கவும்."
+msgstr "இதுவரை விண்ணப்பங்கள் இல்லை — உங்கள் புனல் மற்றும் பதில் விகிதங்களைக் காண சிலவற்றைச் சேர்க்கவும்."
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2956,11 +2956,11 @@ msgstr "சோதிக்கப்பட்ட வழங்குநர் இ�
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "இன்னும் இழைகள் எதுவும் இல்லை."
+msgstr "இன்னும் உரையாடல்கள் எதுவும் இல்லை."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "நார்வேஜியன்"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "குறிப்புகள்"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "ஒடியா"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "திற"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "திறந்த AI முகவர்"
+msgstr "AI முகவரைத் திற"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-இணக்கமானது"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "பேர்ஷியன்"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3236,7 +3236,7 @@ msgstr "குழாய் ஓட்டம்"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "அனைத்து பயன்பாடுகளிலும் பைப்லைன் ஆரோக்கியம்"
+msgstr "அனைத்து விண்ணப்பங்களிலும் பைப்லைன் ஆரோக்கியம்"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "உங்கள் PDF உருவாக்கப்படும் வ
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "போலிஷ்"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "செங்குத்துப் படம்"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "போர்ச்சுகீஸ் (பிரேஸில்)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "போர்ச்சுகீஸ் (போர்ச்சுகல்)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - முகப்புப் பக்கத்து�
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "எதிர்வினை விவரக்குறிப்பு (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "ரியாக்டிவ் ரெஸ்யூம் v<0>{__APP_VERSI
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "எதிர்வினை ரெஸ்யூம் v4 (ஜேசன்)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "பங்கு முன்னேற்றம்"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "ரோமேனியன்"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "மதிப்பெண் அட்டை, பலங்கள் ம�
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "ரஷ்யன்"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "தேடல்"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "பயன்பாடுகளைத் தேடு…"
+msgstr "விண்ணப்பங்களைத் தேடு…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3846,7 +3846,7 @@ msgstr "ஒரு சுயவிவரத்தைத் தேர்ந்த�
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "ஒரு இழையைத் தேர்ந்தெடுக்கவும்"
+msgstr "ஒரு உரையாடலைத் தேர்ந்தெடுக்கவும்"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "பிரிப்பான்"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "செர்பியன்"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "ஒரு AI வழங்குநரை அமைக்கவும்"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "ஒரு த்ரெட்டைத் தொடங்குவதற்கு முன், ஒரு AI வழங்குநரை அமைக்கவும்."
+msgstr "ஒரு உரையாடலைத் தொடங்குவதற்கு முன், ஒரு AI வழங்குநரை அமைக்கவும்."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "முக்கிய உள்ளடக்கத்துக்கு �
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "ஸ்லோவாக்"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "ஸ்லோவேனியன்"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "இடைவெளி (செங்குத்து)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "ஸ்பானிஷ்"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4215,7 +4215,7 @@ msgstr "புதிய பக்கத்தில் தொடங்கு"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "நூலைத் தொடங்கு"
+msgstr "உரையாடலைத் தொடங்கு"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "உங்களால் இயன்ற அளவு செய்து
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "ஸ்வீடிஷ்"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4327,7 +4327,7 @@ msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "தெலுங்கு"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "எழுத்து நிறம்"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "தாய்"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "நீங்கள் உள்ளிட்ட URL தவறானது
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "பணி சுயவிவரம் நீக்கப்பட்டது. இந்தத் திரி படிக்க மட்டுமேயானது."
+msgstr "பணி சுயவிவரம் நீக்கப்பட்டது. இந்த உரையாடல் படிக்க மட்டுமேயானது."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4524,7 +4524,7 @@ msgstr "இந்த உரையாடல் காப்பகப்படு�
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "இந்தத் திரி படிக்க மட்டுமே முடியும்"
+msgstr "இந்த உரையாடல் படிக்க மட்டுமே முடியும்"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
@@ -4545,7 +4545,7 @@ msgstr "இது இந்தப் பிரிவிலிருந்து 
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "நூல் செயல்கள்"
+msgstr "உரையாடல் செயல்கள்"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
@@ -4553,14 +4553,14 @@ msgstr "இந்த உரையாடல் காப்பகப்படு�
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "இழை நீக்கப்பட்டது."
+msgstr "உரையாடல் நீக்கப்பட்டது."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "இழைகள்"
+msgstr "உரையாடல்கள்"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "வலது பக்கப் பட்டை மாற்று"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "இழைகளை நிலைமாற்று"
+msgstr "உரையாடல்களை நிலைமாற்று"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4630,7 +4630,7 @@ msgstr "நீங்கள் விண்ணப்பிக்கும் வ�
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "உங்கள் முதல் பயன்பாட்டைக் கண்காணிக்கவும்"
+msgstr "உங்கள் முதல் விண்ணப்பத்தைக் கண்காணிக்கவும்"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "மீண்டும் முயற்சிக்கவும்"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "துருக்கி"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "எழுத்துரு வடிவமைப்பு"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "உக்ரேனியன்"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4859,7 +4859,7 @@ msgstr "இந்த காலவரிசை உள்ளீட்டிற்�
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "இந்த பயன்பாட்டின் விவரங்களைப் புதுப்பிக்கவும்."
+msgstr "இந்த விண்ணப்பத்தின் விவரங்களைப் புதுப்பிக்கவும்."
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "பயனர்கள்"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "உஸ்பெக்"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "பதிப்பு வரலாறு"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "வியட்‌നாமீஸ்"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "சிறிதாக்கு"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "ஜூலு"
+msgstr "isiZulu"
 

--- a/apps/web/locales/ta-IN.po
+++ b/apps/web/locales/ta-IN.po
@@ -2377,7 +2377,7 @@ msgstr "பெரிதாக்கத்தை அதிகரிக்கவ�
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/ta-IN.po
+++ b/apps/web/locales/ta-IN.po
@@ -401,7 +401,7 @@ msgstr "மேலும் பல..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "ஆந்த்ரோபிக் கிளாட்"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "நடுவில் சீரமை"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "பெருமூளைகள்"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "AI உதவியாளரை மூடு"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "கோஹியர்"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "ஜூம் அளவைக் குறைக்கவும்"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "டீப்சீக்"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "ஃபின்னிஷ்"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "பட்டாசுகள்"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "கூகிள்"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "கூகிள் ஜெமினி"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "கட்டம்"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "க்ரோக்"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "வேலைக்கான ரெஸ்யூம் காணவில�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "மிஸ்ட்ரல் ஏஐ"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "ஒடியா"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ஒல்லாமா கிளவுட்"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "திறந்த மூல"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "ஓப்பன்ஏஐ"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "OpenAI-இணக்கமானது"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "ஓப்பன்ரவுட்டர்"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "காலம்"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "குழப்பம்"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "சரியான URL-கள் http:// அல்லது https:// க
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "வெர்சல் ஏஐ கேட்வே"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "X (ட்விட்டர்)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI க்ரோக்"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/te-IN.po
+++ b/apps/web/locales/te-IN.po
@@ -401,7 +401,7 @@ msgstr "మరియు మరెన్నో..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "ఆంత్రోపిక్ క్లాడ్"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "మద్యAlign"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "సెరెబ్రాస్"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "AI సహాయకుడిని మూసివేయండి"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "పొందికగా"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "జూమ్‌ను తగ్గించండి"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "డీప్‌సీక్"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "ఫిన్నిష్"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "బాణసంచా"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "గూగుల్"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "గూగుల్ జెమిని"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "గ్రిడ్"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "గ్రోక్"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "తప్పిపోయిన వర్కింగ్ రెజ్య�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "మిస్ట్రాల్ AI"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "ఒడియా"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "ఒల్లామా క్లౌడ్"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "ఓపెన్ సోర్స్"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "ఓపెన్ఏఐ"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "OpenAI-అనుకూలమైనది"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "ఓపెన్‌రౌటర్"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "కాలము"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "గందరగోళం"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "మీ ఖాతాను తొలగించడానికి, క�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "కలిసి.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "చెల్లే URLలు తప్పనిసరిగా http:// �
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "వర్సెల్ AI గేట్‌వే"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "X (ట్విట్టర్)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI గ్రోక్"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/te-IN.po
+++ b/apps/web/locales/te-IN.po
@@ -2377,7 +2377,7 @@ msgstr "జూమ్‌ను పెంచండి"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -4057,7 +4057,7 @@ msgstr "సైన్ అప్ చేస్తున్నారు..."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a magenta left border accent; compact and efficient for entry-level or internship applications."
-msgstr "ఒకే-కాలమ్, ఎడమ వైపు గులాబీ రంగు సరిహద్దుతో; ఎంట్రీ-లెవల్ లేదా ఇంటర్న్‌షిప్ దరఖాస్తులకు కాంపాక్ట్ మరియు సమర్థవంతమైనది."
+msgstr "ఒకే-కాలమ్, ఎడమ వైపు మెజెంటా సరిహద్దుతో; ఎంట్రీ-లెవల్ లేదా ఇంటర్న్‌షిప్ దరఖాస్తులకు కాంపాక్ట్ మరియు సమర్థవంతమైనది."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a minimal top header and lots of whitespace; clean and modern for designers or content creators."

--- a/apps/web/locales/te-IN.po
+++ b/apps/web/locales/te-IN.po
@@ -315,7 +315,7 @@ msgstr "అధునాతన"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "ఆఫ్రికాన్స్"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "AI ప్రొవైడర్లకు REDIS_URL మరియు ENCRYP
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "అల్బేనియన్"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "ఇప్పటికే ఖాతా ఉందా? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "అంహారిక్"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "దరఖాస్తు తొలగించబడింది."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "యాప్ గణాంకాలు"
+msgstr "దరఖాస్తు గణాంకాలు"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "హెచ్చరికలతో వర్తింపజేయబడ�
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "అరబిక్"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "పురస్కారాలు"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "అజర్బైజానీ"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "ఎంపిక చేసుకోవడానికి అందమై�
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "బెంగాలీ"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "బిల్డర్ కమాండ్ పలెట్"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "బల్గేరియన్"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "పునరుద్ధరించడం సాధ్యం కాద�
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "కాటలాన్"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "డ్రాఫ్ట్‌ను తనిఖీ చేయడం"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "చైనీస్ (సరళీకృత)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "చైనీస్ (సాంప్రదాయ)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1278,7 +1278,7 @@ msgstr "కస్టమ్ స్టైల్స్"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "చెక్"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "డేంజర్ జోన్"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "డానిష్"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "మీ రిజ్యూమ్‌ను నకిలీ చేస్త
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "డచ్"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "రెండు-కారకాల ప్రమాణీకరణను 
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "ఆంగ్లం"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "ఆంగ్లం (యునైటెడ్ కింగ్‌డమ్)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1963,7 +1963,7 @@ msgstr "బలహీనమైన అంశాలను గుర్తించ�
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "ఫిన్నిష్"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "స్వేచ్ఛా రూపం"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "ఫ్రెంచ్"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "యాదృచ్ఛిక పేరు రూపొందించం�
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "జర్మన్"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,13 +2116,13 @@ msgstr "వెనక్కు వెళ్ళండి"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "ఇంటికి వెళ్ళండి"
+msgstr "హోమ్ పేజీకి వెళ్ళండి"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "డాష్బోర్డ్ కి వెళ్లండి"
+msgstr "డాష్‌బోర్డ్ కి వెళ్లండి"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "గ్రేడ్"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "గ్రీకు"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "హెడ్లైన్"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "హీబ్రూ"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "హైలైట్ రంగు"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "హిందీ"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "హంగేరియన్"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "జూమ్‌ను పెంచండి"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "ఇండోనేషియన్"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "ఇష్యూర్"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "ఇటాలియన్"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "ఇటాలిక్"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "జపానీస్"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,7 +2491,7 @@ msgstr "జస్టిఫై అలైన్"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "కన్నడ"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2509,11 +2509,11 @@ msgstr "కీవర్డ్స్"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "ఖ్మేర్"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "కొరియన్"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "{0} న చివరిసారిగా వీక్షించబడ
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "లాత్వియన్"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "జాబితా"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "లిథువేనియన్"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "AI ప్రొవైడర్లు లోడ్ అవుతున్�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "అప్లికేషన్లు లోడ్ అవుతున్నాయి…"
+msgstr "దరఖాస్తులు లోడ్ అవుతున్నాయి…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "అనుభవ విభాగాన్ని మరింత ఫలి
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "మలయ్"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "మలయాళం"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "మరాఠీ"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "పేరు"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "నేపాళీ"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2960,7 +2960,7 @@ msgstr "ఇంకా థ్రెడ్‌లు లేవు."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "నార్వేజియన్"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "నోట్స్"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "ఒడియా"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "ఓపెన్"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "ఓపెన్ AI ఏజెంట్"
+msgstr "AI ఏజెంట్‌ను తెరవండి"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI-అనుకూలమైనది"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "పర్షియన్"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "మీ PDF రూపొందించబడుతున్నంత వ
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "పోలిష్"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "పోర్ట్రెయిట్"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "పోర్చుగీస్ (బ్రెజిల్)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "పోర్చుగీస్ (పోర్చుగల్)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - హోమ్‌పేజీకి వెళ్ళం�
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "ప్రతిస్పందించే రెస్యూమ్ (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "రియాక్టివ్ రెజ్యూమ్ v<0>{__APP_VERSI
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "రియాక్టివ్ రెజ్యూమ్ v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "పాత్ర పురోగతి"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "రోమేనియన్"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "స్కోర్‌కార్డ్, బలాలు మరియు
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "రష్యన్"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3899,7 +3899,7 @@ msgstr "వేర్పాటు రేఖ"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "సెర్బియన్"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4057,7 +4057,7 @@ msgstr "సైన్ అప్ చేస్తున్నారు..."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a magenta left border accent; compact and efficient for entry-level or internship applications."
-msgstr "ఒకే-కాలమ్, ఎడమ వైపు గులాబీ రంగు సరిహద్దుతో; ఎంట్రీ-లెవల్ లేదా ఇంటర్న్‌షిప్ అప్లికేషన్‌లకు కాంపాక్ట్ మరియు సమర్థవంతమైనది."
+msgstr "ఒకే-కాలమ్, ఎడమ వైపు గులాబీ రంగు సరిహద్దుతో; ఎంట్రీ-లెవల్ లేదా ఇంటర్న్‌షిప్ దరఖాస్తులకు కాంపాక్ట్ మరియు సమర్థవంతమైనది."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a minimal top header and lots of whitespace; clean and modern for designers or content creators."
@@ -4098,11 +4098,11 @@ msgstr "ప్రధాన విషయానికి దాటండి"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "స్లోవాక్"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "స్లోవేనియన్"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "స్పేసింగ్ (నిలువుగా)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "స్పానిష్"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "మీకు వీలైనంత చేసి యాప్‌కు �
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "స్వీడిష్"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,7 +4323,7 @@ msgstr "అనుకూలీకరణ విఫలమైంది."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "తమిళ్"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
@@ -4364,7 +4364,7 @@ msgstr "టెక్స్ట్ కలర్"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "థాయ్"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4647,7 +4647,7 @@ msgstr "మళ్ళీ ప్రయత్నించండి"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "టర్కిష్"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4683,7 +4683,7 @@ msgstr "రెండు-కాలమ్, క్లీన్ మరియు ప�
 
 #: src/dialogs/resume/template/data.ts
 msgid "Two-column, minimal and text-dense with no decorative elements; perfect for traditional industries or ATS-heavy applications."
-msgstr "రెండు-కాలమ్, మినిమల్, ఎక్కువ వచనంతో, అలంకారపు అంశాలు లేవు; సాంప్రదాయ రంగాలు లేదా ATS-పై ఆధారత ఎక్కువ అప్లికేషన్‌లకు ఆదర్శంగా."
+msgstr "రెండు-కాలమ్, మినిమల్, ఎక్కువ వచనంతో, అలంకారపు అంశాలు లేవు; సాంప్రదాయ రంగాలు లేదా ATS-పై ఆధారపడే దరఖాస్తులకు ఆదర్శంగా."
 
 #: src/dialogs/resume/template/data.ts
 msgid "Two-column, minimal with light gray sidebar and subtle icons; professional and understated for legal, finance, or executive roles."
@@ -4728,7 +4728,7 @@ msgstr "టైపోగ్రఫీ"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "యుక్రేనియన్"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "వినియోగదారులు"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "ఉజ్‌బెక్"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "వెర్షన్ చరిత్ర"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "వియత్నామీస్"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "జూమ్ అవుట్ చేయండి"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "జులు"
+msgstr "isiZulu"
 

--- a/apps/web/locales/th-TH.po
+++ b/apps/web/locales/th-TH.po
@@ -315,7 +315,7 @@ msgstr "ขั้นสูง"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "อาฟรีกานส์"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -364,7 +364,7 @@ msgstr "ผู้ให้บริการ AI ต้องการให้�
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "แอลเบเนีย"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "มีบัญชีอยู่แล้ว? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "อัมฮาริค"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "ลบใบสมัครแล้ว"
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "สถิติของแอปพลิเคชัน"
+msgstr "สถิติของใบสมัคร"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "ใช้งานโดยมีคำเตือน"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "อารบิก"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "รางวัล"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "อาเซอร์ไบจาน"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "แม่แบบที่สวยงามให้เลือก �
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "เบงกาลี"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "แผงคำสั่งของตัวสร้าง"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "บัลแกเรีย"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "ไม่สามารถกู้คืนได้ เนื่อ�
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "คาตาลัน"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "ตรวจสอบร่าง"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "จีน (ตัวย่อ)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "จีน (ตัวเต็ม)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "เลือกเรซูเม่"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "เลือกบทสนทนาที่มีอยู่แล้วจากแถบด้านข้าง หรือเริ่มหัวข้อสนทนาใหม่ที่เน้นการแก้ไขร่างข้อความ"
+msgstr "เลือกบทสนทนาที่มีอยู่แล้วจากแถบด้านข้าง หรือเริ่มเธรดใหม่ที่เน้นการแก้ไขร่างข้อความ"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "วงกลม"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "ชัดเจน"
+msgstr "ล้าง"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "สไตล์ที่กำหนดเอง"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "เช็ก"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "เขตอันตราย"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "เดนมาร์ก"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "ลบผู้ให้บริการ"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "ลบกระทู้ตัวแทนนี้เลยไหม?"
+msgstr "ลบเธรดตัวแทนนี้เลยไหม?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1548,7 +1548,7 @@ msgstr "กำลังคัดลอกเรซูเม่ของคุณ
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "ดัตช์"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "การเปิดใช้งานการตรวจสอบส
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "ภาษาอังกฤษ"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "อังกฤษ (สหราชอาณาจักร)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "ไม่สามารถวิเคราะห์ประวัต
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "ไม่สามารถเก็บถาวรกระทู้ได้"
+msgstr "ไม่สามารถเก็บถาวรเธรดได้"
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "ไม่สามารถลบคีย์ API ได้ กรุณ
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "ไม่สามารถลบกระทู้ได้"
+msgstr "ไม่สามารถลบเธรดได้"
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1963,7 +1963,7 @@ msgstr "ค้นหาประเด็นสำคัญที่อ่อน
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "ฟินแลนด์"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "เหมาะสำหรับรับชม"
+msgstr "ปรับให้พอดีกับมุมมอง"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "รูปแบบอิสระ"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "ฝรั่งเศส"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "สร้างชื่อแบบสุ่ม"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "ภาษาเยอรมัน"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "ย้อนกลับ"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "กลับบ้าน"
+msgstr "กลับไปหน้าแรก"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "เกรด"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "กรีก"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "พาดหัว"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "ฮิบรู"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "สีไฮไลท์"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "ฮินดี"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "ฮังการี"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "เพิ่มกำลังซูม"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "อินโดนีเซีย"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "ออกโดย"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "อิตาลี"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "ตัวเอียง"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "ญี่ปุ่น"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "จัดแนวชิดขอบทั้งสองด้าน"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "กันนาดา"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "อยู่ด้วยกันต่อไป"
+msgstr "เก็บไว้ด้วยกัน"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "คีย์เวิร์ด"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "เขมร"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "เกาหลี"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "ดูครั้งล่าสุดเมื่อ {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "ลัตเวีย"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "รายการ"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "ลิทัวเนีย"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "กำลังโหลดผู้ให้บริการ AI โ�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "กำลังโหลดแอปพลิเคชัน…"
+msgstr "กำลังโหลดใบสมัคร…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "ปรับปรุงส่วนประสบการณ์ให
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "มาเลย์"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "มาลายาลัม"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "มราฐี"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "ชื่อ"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "เนปาลี"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2889,12 +2889,12 @@ msgstr "แท็กใหม่…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "กระทู้ใหม่"
+msgstr "เธรดใหม่"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "กระทู้ใหม่"
+msgstr "เธรดใหม่"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2956,11 +2956,11 @@ msgstr "ไม่มีผู้ให้บริการที่ผ่าน
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "ยังไม่มีกระทู้ใดๆ"
+msgstr "ยังไม่มีเธรด"
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "นอร์เวย์"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "โน้ต"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "โอเดีย"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "เปิด"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "เอเจนต์ AI แบบเปิด"
+msgstr "เปิดเอเจนต์ AI"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "เข้ากันได้กับ OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "เปอร์เซีย"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "โปรดรอสักครู่ในระหว่างที
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "โปแลนด์"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "แนวตั้ง"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "โปรตุเกส (บราซิล)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "โปรตุเกส (โปรตุเกส)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - ไปที่หน้าแรก"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "เรกติก รีซูเม (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reactive Resume v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "เรแอคทีฟ เรซูเม่ v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "ความก้าวหน้าในตำแหน่ง"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "โรมาเนีย"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "ดำเนินการวิเคราะห์ครั้งแ
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "รัสเซีย"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3846,7 +3846,7 @@ msgstr "เลือกประวัติย่อ"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "เลือกหัวข้อ"
+msgstr "เลือกเธรด"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "ตัวคั่น"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "เซอร์เบีย"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "ตั้งค่าผู้ให้บริการ AI"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "ตั้งค่าผู้ให้บริการ AI ก่อนเริ่มการสนทนา"
+msgstr "ตั้งค่าผู้ให้บริการ AI ก่อนเริ่มเธรด"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "ข้ามไปยังเนื้อหาหลัก"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "สโลวัก"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "ภาษาสโลวีเนีย"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "ระยะห่าง (แนวตั้ง)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "สเปน"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "กดดาวที่ GitHub ของเรา ขณะนี้ม
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "เริ่มกระทู้ใหม่"
+msgstr "เริ่มเธรดใหม่"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "เริ่มกระทู้ใหม่"
+msgstr "เริ่มเธรดใหม่"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "เริ่มสร้างเรซูเม่ตั้งแต่
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "เริ่มกระทู้ใหม่"
+msgstr "เริ่มเธรดใหม่"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "เริ่มที่หน้าใหม่"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "เริ่มกระทู้"
+msgstr "เริ่มเธรด"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "สนับสนุนแอปด้วยวิธีใดก็ไ
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "สวีเดน"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "ปรับแต่งไม่สำเร็จ"
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "ทมิฬ"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "เตลูกู"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4419,7 +4419,7 @@ msgstr "URL ที่คุณกรอกไม่ถูกต้อง"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "ประวัติการทำงานถูกลบไปแล้ว กระทู้นี้เป็นแบบอ่านอย่างเดียว"
+msgstr "ประวัติการทำงานถูกลบไปแล้ว เธรดนี้เป็นแบบอ่านอย่างเดียว"
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4464,11 +4464,11 @@ msgstr "การกระทำนี้ไม่สามารถยกเล
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
-msgstr "การกระทำนี้ไม่สามารถยกเลิกได้ ข้อความและไฟล์แนบในกระทู้จะถูกลบออก"
+msgstr "การกระทำนี้ไม่สามารถยกเลิกได้ ข้อความและไฟล์แนบในเธรดจะถูกลบออก"
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "ไม่สามารถเปิดกระทู้ตัวแทนนี้ได้"
+msgstr "ไม่สามารถเปิดเธรดตัวแทนนี้ได้"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "ขั้นตอนนี้ไม่บังคับ แต่แ�
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "กระทู้นี้ถูกเก็บถาวรแล้ว ไม่สามารถส่งข้อความใหม่ได้"
+msgstr "เธรดนี้ถูกเก็บถาวรแล้ว ไม่สามารถส่งข้อความใหม่ได้"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "กระทู้นี้อ่านได้อย่างเดียว"
+msgstr "เธรดนี้อ่านได้อย่างเดียว"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "กระทู้นี้อยู่ในโหมดอ่านอย่างเดียว เนื่องจากระบบสร้างเรซูเม่หรือผู้ให้บริการ AI ที่ใช้งานได้ไม่พร้อมใช้งาน"
+msgstr "เธรดนี้อยู่ในโหมดอ่านอย่างเดียว เนื่องจากระบบสร้างเรซูเม่หรือผู้ให้บริการ AI ที่ใช้งานได้ไม่พร้อมใช้งาน"
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4549,18 +4549,18 @@ msgstr "การดำเนินการเธรด"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "กระทู้ถูกเก็บถาวรแล้ว"
+msgstr "เธรดถูกเก็บถาวรแล้ว"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "กระทู้ถูกลบแล้ว"
+msgstr "เธรดถูกลบแล้ว"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "ด้าย"
+msgstr "เธรด"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4647,7 +4647,7 @@ msgstr "ลองอีกครั้ง"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "ตุรกี"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "แบบอักษร"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "ยูเครน"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "ผู้ใช้"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "อุซเบก"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "ประวัติเวอร์ชัน"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "เวียดนาม"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "ซูมออก"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "ซูลู"
+msgstr "isiZulu"
 

--- a/apps/web/locales/th-TH.po
+++ b/apps/web/locales/th-TH.po
@@ -401,7 +401,7 @@ msgstr "และอีกมากมาย..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "แอนโธรปิก โคล้ด"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "จัดกึ่งกลาง"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "เซเรบราส"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "ปิดผู้ช่วย AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "โคฮีร์"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "ลดระดับการซูม"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "ดีพซีค"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "ฟินแลนด์"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "ดอกไม้ไฟ"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2162,7 +2162,7 @@ msgstr "ตาราง"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "โกรค"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "ประวัติการทำงานไม่ครบถ้ว
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "มิสทรัล AI"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "โอเดีย"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "โอลาม่าคลาวด์"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "โอเพนซอร์ส"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "โอเพ่นเอไอ"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "เข้ากันได้กับ OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "โอเพ่นรูเตอร์"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "ช่วงเวลา"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "ความสับสน"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "ในการลบบัญชีของคุณ กรุณา�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "ทูธตี้.ไอ"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "URL ที่ถูกต้องต้องขึ้นต้นด�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "เกตเวย์ AI ของ Vercel"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/th-TH.po
+++ b/apps/web/locales/th-TH.po
@@ -2377,7 +2377,7 @@ msgstr "เพิ่มกำลังซูม"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2692,7 +2692,7 @@ msgstr "กำลังโหลดผู้ให้บริการ…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Loading resumes…"
-msgstr "กำลังโหลดต่อ…"
+msgstr "กำลังโหลดเรซูเม่…"
 
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx

--- a/apps/web/locales/tr-TR.po
+++ b/apps/web/locales/tr-TR.po
@@ -401,7 +401,7 @@ msgstr "Ve daha fazlası..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropik Claude"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Ortala"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Beyinler"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Yapay zeka asistanını kapat"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Uyum"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1967,7 +1967,7 @@ msgstr "Fince"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Havai fişekler"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2797,7 +2797,7 @@ msgstr "Eksik iş özgeçmişi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Mistral Yapay Zeka"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odiya"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Ollama Bulutu"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Dönem"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Şaşkınlık"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Hesabınızı silmek için onay metnini girmeniz ve aşağıdaki butona 
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Birlikte.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "Geçerli URL'ler http:// veya https:// ile başlamalıdır."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Vercel AI Ağ Geçidi"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/tr-TR.po
+++ b/apps/web/locales/tr-TR.po
@@ -260,7 +260,7 @@ msgstr "Bir etiket ekleyin ve Enter'a basın…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Aracı iş parçacığını başlatmadan önce bir sağlayıcı ekleyin ve test edin."
+msgstr "Ajan konuşmasını başlatmadan önce bir sağlayıcı ekleyin ve test edin."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -364,7 +364,7 @@ msgstr "Yapay zeka sağlayıcılarının REDIS_URL ve ENCRYPTION_SECRET'in yapı
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Arnavutça"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Zaten hesabınız var mı? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amharca"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Başvuru silindi."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Uygulama İstatistikleri"
+msgstr "Başvuru İstatistikleri"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Uyarılarla birlikte uygulandı."
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arapça"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Ödüller"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Azerice"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Seçebileceğiniz güzel şablonlar, daha fazlası yolda."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengalce"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Oluşturucu Komut Paleti"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bulgarca"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Geri yüklenemiyor; bu düzenleme uygulandıktan sonra özgeçmiş deği
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalanca"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Taslağı kontrol etme"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Çince (Basitleştirilmiş)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Çince (Geleneksel)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Bir özgeçmiş seçin"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Yan menüden mevcut bir konuşmayı seçin veya taslak odaklı yeni bir konu başlatın."
+msgstr "Yan menüden mevcut bir konuşmayı seçin veya taslak odaklı yeni bir konuşma başlatın."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -1278,7 +1278,7 @@ msgstr "Özel Stiller"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Çekçe"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Tehlikeli Bölge"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Danca"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Sağlayıcıyı sil"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Bu temsilci ileti dizisini silmek ister misiniz?"
+msgstr "Bu ajan konuşmasını silmek ister misiniz?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1548,7 +1548,7 @@ msgstr "Özgeçmişiniz çoğaltılıyor..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Felemenkçe"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "İki faktörlü kimlik doğrulamayı etkinleştirme…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "İngilizce"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "İngilizce (Birleşik Krallık)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Özgeçmiş analiz edilemedi."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Konu arşivlenemedi."
+msgstr "Konuşma arşivlenemedi."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "API anahtarı silinemedi. Lütfen tekrar deneyin."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Konu silinemedi."
+msgstr "Konuşma silinemedi."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Çıkış yapılamadı. Lütfen tekrar deneyin."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Aracı iş parçacığı başlatılamadı."
+msgstr "Ajan konuşması başlatılamadı."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Zayıf madde işaretlerini bulun ve daha güçlü sonuçlar, sayılar, k
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Fince"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Görüntülemeye uygun"
+msgstr "Görünüme sığdır"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Serbest biçimli"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Fransızca"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Rastgele bir isim oluştur"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Almanca"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,13 +2116,13 @@ msgstr "Geri Dön"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Eve git"
+msgstr "Ana sayfaya git"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Gösterge Paneline Git"
+msgstr "Kontrol Paneline Git"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "Not"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Yunanca"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2199,11 +2199,11 @@ msgstr "Başlık 6"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
 msgid "Headline"
-msgstr "Başlık"
+msgstr "Özet başlık"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "İbranice"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Vurgu Rengi"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hintçe"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Macarca"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "Yakınlaştırmayı artırın"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Endonezce"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Veren"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "İtalyanca"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "İtalik"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Japonca"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Yasla"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kanada Dili"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Bir arada kalın"
+msgstr "Bir arada tut"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Anahtar Kelimeler"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Khmerce"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Korece"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "{0} tarihinde son görüntülendi"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Letonca"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Liste"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litvanca"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Yapay zeka sağlayıcıları yükleniyor. Lütfen bir süre sonra tekrar
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Uygulamalar yükleniyor…"
+msgstr "Başvurular yükleniyor…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Özgeçmişler yükleniyor…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "İş parçacıkları yükleniyor…"
+msgstr "Konuşmalar yükleniyor…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Deneyim bölümünü daha sonuç odaklı hale getirin ve belirsiz soruml
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malayca"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalamca"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "İsim"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepalce"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2889,12 +2889,12 @@ msgstr "Yeni etiket…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Yeni konu"
+msgstr "Yeni konuşma"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Yeni Konu"
+msgstr "Yeni Konuşma"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2956,11 +2956,11 @@ msgstr "Test edilmiş sağlayıcı yok."
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Henüz hiçbir konu açılmadı."
+msgstr "Henüz hiçbir konuşma yok."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norveççe"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Notlar"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odiya"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Aç"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Açık yapay zeka ajanı"
+msgstr "Yapay zeka ajanını aç"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI uyumlu"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Farsça"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "PDF dosyanız oluşturulurken lütfen bekleyin…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Lehçe"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portre"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portekizce (Brezilya)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portekizce (Portekiz)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Özgeçmiş - Ana sayfaya git"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktif Özgeçmiş (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktif Özgeçmiş v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktif Özgeçmiş v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Rol İlerlemesi"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumence"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Bir puan kartı, güçlü yönler ve önceliklendirilmiş öneriler elde
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Rusça"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3846,7 +3846,7 @@ msgstr "Bir özgeçmiş seçin"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "Bir konu seçin"
+msgstr "Bir konuşma seçin"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "Ayırıcı"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Sırpça"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Bir yapay zeka sağlayıcısı kurun."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Konu açmadan önce bir yapay zeka sağlayıcısı ayarlayın."
+msgstr "Konuşma başlatmadan önce bir yapay zeka sağlayıcısı ayarlayın."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Ana içeriğe atla"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovakça"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Slovence"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Boşluk (Dikey)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "İspanyolca"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "GitHub'da bize yıldız verin, şu anda {0} yıldız (yeni sekmede açı
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Yeni bir konu başlatın"
+msgstr "Yeni bir konuşma başlatın"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Bir konu başlatın"
+msgstr "Bir konuşma başlatın"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Özgeçmişinizi sıfırdan oluşturmaya başlayın"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Yeni konu başlat"
+msgstr "Yeni konuşma başlat"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Yeni sayfada başlayın"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Konuyu Başlat"
+msgstr "Konuşmayı Başlat"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Uygulamayı gücünüz yettiğince destekleyin!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "İsveççe"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Uyarlama başarısız oldu."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamilce"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Teluguca"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Metin Rengi"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Tayca"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "Girdiğiniz URL geçerli değil."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Çalışma özgeçmişi silindi. Bu konu yalnızca okunabilir durumdadır."
+msgstr "Çalışma özgeçmişi silindi. Bu konuşma yalnızca okunabilir durumdadır."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4464,11 +4464,11 @@ msgstr "Bu işlem geri alınamaz. Konuşma mesajları ve yüklenen ekler silinec
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
-msgstr "Bu işlem geri alınamaz. Mesajlar ve ekler silinecektir."
+msgstr "Bu işlem geri alınamaz. Mesajlar ve konuşma ekleri silinecektir."
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Bu temsilci başlığı açılamadı."
+msgstr "Bu ajan konuşması açılamadı."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "Bu adım isteğe bağlıdır, ancak önerilir."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Bu konu arşivlendi. Yeni mesaj gönderilemez."
+msgstr "Bu konuşma arşivlendi. Yeni mesaj gönderilemez."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Bu konu başlığı salt okunur."
+msgstr "Bu konuşma salt okunur."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Bu konu başlığı salt okunur durumdadır çünkü çalışan özgeçmiş veya yapay zeka sağlayıcısı mevcut değildir."
+msgstr "Bu konuşma salt okunur durumdadır çünkü çalışan özgeçmiş veya yapay zeka sağlayıcısı mevcut değildir."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,22 +4545,22 @@ msgstr "Bu, bu bölümdeki tüm öğeleri kaldıracaktır."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "İş parçacığı işlemleri"
+msgstr "Konuşma işlemleri"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Konu arşivlendi."
+msgstr "Konuşma arşivlendi."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Konu silindi."
+msgstr "Konuşma silindi."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Konular"
+msgstr "Konuşmalar"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "Sağ kenar çubuğunu aç / kapat"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Konuları açıp kapat"
+msgstr "Konuşmaları açıp kapat"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4728,7 +4728,7 @@ msgstr "Tipografi"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukraynaca"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Kullanıcılar"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Özbekçe"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Sürüm geçmişi"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vietnamca"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5190,5 +5190,5 @@ msgstr "Uzaklaştır"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/tr-TR.po
+++ b/apps/web/locales/tr-TR.po
@@ -2377,7 +2377,7 @@ msgstr "Yakınlaştırmayı artırın"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/uk-UA.po
+++ b/apps/web/locales/uk-UA.po
@@ -260,7 +260,7 @@ msgstr "Додайте тег і натисніть Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Додайте та перевірте постачальника перед запуском потоку агента."
+msgstr "Додайте та перевірте постачальника перед початком теми агента."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -315,7 +315,7 @@ msgstr "Розширений"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Африканська"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -344,7 +344,7 @@ msgstr "Налаштування агента штучного інтелект�
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "Асистент зі штучним інтелектом"
+msgstr "Асистент ШІ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "Постачальники штучного інтелекту вима�
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Албанська"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Вже маєте обліковий запис? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Амхарська"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -504,7 +504,7 @@ msgstr "Застосовується з попередженнями"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Арабська"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Нагороди"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Азербайджанська"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Гарні шаблони на вибір, і ще більше буде
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Бенгальська"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Палітра команд Конструктора"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Болгарська"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Неможливо відновити; резюме змінилося �
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Каталонська"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Перевірка чернетки"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Китайська (спрощена)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Китайська (традиційна)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -856,7 +856,7 @@ msgstr "Кругле"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Чисто"
+msgstr "Очистити"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Власні стилі"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Чеська"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Небезпечна зона"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Данська"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1548,7 +1548,7 @@ msgstr "Дублювання резюме..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Голландська"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Увімкнення двофакторної автентифікаці
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Англійська"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Англійська (Велика Британія)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Не вдалося проаналізувати резюме."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Не вдалося архівувати ланцюжок повідомлень."
+msgstr "Не вдалося архівувати тему."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Не вдалося видалити ключ API. Будь ласка, 
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Не вдалося видалити ланцюжок повідомлень."
+msgstr "Не вдалося видалити тему."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Не вдалося вийти. Спробуйте ще раз."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Не вдалося розпочати ланцюжок агента."
+msgstr "Не вдалося розпочати тему агента."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Знайдіть слабкі пункти та перепишіть ї�
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Фінська"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Пристосувати до перегляду"
+msgstr "Вписати у вікно"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Вільна форма"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Французька"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Згенерувати випадкове ім'я"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Німецька"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Отримайте відгук на своє резюме із зага
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Отримайте поглиблений аналіз вашого резюме за допомогою штучного інтелекту із загальною оцінкою, ключовими сильними сторонами та практичними порадами. Щоб активувати цю функцію, оновіть налаштування ШІ."
+msgstr "Отримайте поглиблений аналіз вашого резюме за допомогою ШІ із загальною оцінкою, ключовими сильними сторонами та практичними порадами. Щоб активувати цю функцію, оновіть налаштування ШІ."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,18 +2116,18 @@ msgstr "Назад"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Іди додому"
+msgstr "На головну"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Перейти до дашборду"
+msgstr "Перейти до інформаційної панелі"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Перейти до панелі резюме"
+msgstr "Перейти до інформаційної панелі резюме"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Оцінка"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Грецька"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2203,7 +2203,7 @@ msgstr "Заголовна інформація"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Іврит"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Колір виділення"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Гінді"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Угорська"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2353,7 +2353,7 @@ msgstr "Імпортовано {0} заявок."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "Для імпорту з PDF або Word потрібен підключений постачальник штучного інтелекту."
+msgstr "Для імпорту з PDF або Word потрібен підключений постачальник ШІ."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Збільшити масштаб"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Індонезійська"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Ким видано"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Італійська"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Курсив"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Японська"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Вирівняти за шириною"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Каннада"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Тримайтеся разом"
+msgstr "Тримати разом"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Ключові слова"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Кхмерська"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Корейська"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Востаннє переглянуто {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Латвійська"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Список"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Литовська"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Завантаження постачальників ШІ. Будь л�
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Завантаження програм…"
+msgstr "Завантаження заявок…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2754,15 +2754,15 @@ msgstr "Зробіть розділ про досвід більш орієнт�
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Малайська"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Малаялам"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Маратхі"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Назва"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Непальська"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2960,7 +2960,7 @@ msgstr "Поки що немає тем."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Норвезька"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Нотатки"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Одія"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Відкрити"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Відкритий агент штучного інтелекту"
+msgstr "Відкрити агента штучного інтелекту"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Сумісний з OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Перська"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Будь ласка, зачекайте, поки генерується
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Польська"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Портрет"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Португальська (Бразилія)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Португальська (Португалія)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume – перейти на головну сторінку"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Реактивне резюме (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Реактивне резюме v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Реактивне резюме v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Кар'єрне зростання"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Румунська"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Проведіть перший аналіз, щоб отримати о
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Російська"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3846,7 +3846,7 @@ msgstr "Виберіть резюме"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "Виберіть ланцюжок"
+msgstr "Виберіть тему"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "Роздільник"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Сербська"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4098,11 +4098,11 @@ msgstr "Перейти до основного контенту"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Словацька"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Словенська"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Відступи (вертикальні)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Іспанська"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4276,7 +4276,7 @@ msgstr "Підтримайте застосунок будь-яким досту
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Шведська"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Адаптація не вдалася."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Тамільська"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Телугу"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Колір тексту"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Тайська"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "Вказана вами URL-адреса недійсна."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Робоче резюме видалено. Цей потік обговорень доступний лише для читання."
+msgstr "Робоче резюме видалено. Ця тема доступна лише для читання."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4464,11 +4464,11 @@ msgstr "Цю дію не можна скасувати. Повідомлення
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
-msgstr "Цю дію не можна скасувати. Повідомлення та вкладення до ланцюжків повідомлень будуть видалені."
+msgstr "Цю дію не можна скасувати. Повідомлення та вкладення теми будуть видалені."
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Не вдалося відкрити цей потік агента."
+msgstr "Не вдалося відкрити цю тему агента."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "Цей крок необов'язковий, але рекомендов
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Цей потік обговорень архівовано. Нові повідомлення надсилати не можна."
+msgstr "Цю тему архівовано. Нові повідомлення надсилати не можна."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Цей потік доступний лише для читання"
+msgstr "Ця тема доступна лише для читання"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Цей потік доступний лише для читання, оскільки робоче резюме або постачальник штучного інтелекту недоступні."
+msgstr "Ця тема доступна лише для читання, оскільки робоче резюме або постачальник штучного інтелекту недоступні."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4553,7 +4553,7 @@ msgstr "Тему заархівовано."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Гілку видалено."
+msgstr "Тему видалено."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -4647,7 +4647,7 @@ msgstr "Спробуйте ще раз"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Турецька"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4929,7 +4929,7 @@ msgstr "Користувачі"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Узбецька"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Історія версій"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Вʼєтнамська"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5173,7 +5173,7 @@ msgstr "Ваша підтримка гарантує, що проєкт зали
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Zoom"
-msgstr "Збільшити"
+msgstr "Масштаб"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom in"
@@ -5190,5 +5190,5 @@ msgstr "Зменшити"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Зулу"
+msgstr "isiZulu"
 

--- a/apps/web/locales/uk-UA.po
+++ b/apps/web/locales/uk-UA.po
@@ -401,7 +401,7 @@ msgstr "Та багато іншого..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Антропік Клод"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Вирівняти по центру"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Церебрас"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Закрити помічника зі штучним інтелекто
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Зв'язати"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Зменшити масштаб"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Глибокий пошук"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Фінська"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Феєрверки"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "Google"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "Google Близнюки"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "Сітка"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "Грок"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "Відсутнє робоче резюме"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Містраль ШІ"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Одія"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Хмара Оллама"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Період"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Збентеження"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4595,7 +4595,7 @@ msgstr "Щоб видалити акаунт, введіть підтвердж�
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Together.ai"
-msgstr "Разом.ai"
+msgstr "Together.ai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-base.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/shared/section-base.tsx
@@ -4937,7 +4937,7 @@ msgstr "Дійсні URL-адреси мають починатися з http://
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Шлюз штучного інтелекту Vercel"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"
@@ -5063,7 +5063,7 @@ msgstr "Х (Твіттер)"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "xAI Grok"
-msgstr "xAI Грок"
+msgstr "xAI Grok"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Yes, Reactive Resume is available in multiple languages. You can choose your preferred language in the settings page, or using the language switcher in the top right corner. If you don't see your language, or you would like to improve the existing translations, you can <0>contribute to the translations on Crowdin<1> (opens in new tab)</1></0>."

--- a/apps/web/locales/uk-UA.po
+++ b/apps/web/locales/uk-UA.po
@@ -2377,7 +2377,7 @@ msgstr "Збільшити масштаб"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/uz-UZ.po
+++ b/apps/web/locales/uz-UZ.po
@@ -401,7 +401,7 @@ msgstr "Va yana ko‘pgina..."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "Antropik Klod"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "Markazda tekislash"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Miya"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -1967,7 +1967,7 @@ msgstr "Fin tili"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Mushakbozlik"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2981,7 +2981,7 @@ msgstr "Odiya tili"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Ollama buluti"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3038,7 +3038,7 @@ msgstr "Ochiq kodli"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI"
-msgstr "Ochiq AI"
+msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
@@ -3046,7 +3046,7 @@ msgstr "OpenAI bilan mos keladi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "Ochiq marshrutizator"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "Davr"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Sarosimaga tushish"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"

--- a/apps/web/locales/uz-UZ.po
+++ b/apps/web/locales/uz-UZ.po
@@ -344,11 +344,11 @@ msgstr "REDIS_URL va ENCRYPTION_SECRET sozlanmaguncha AI agentini sozlash imkoni
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "AI yordamchisi"
+msgstr "Sun'iy intellekt yordamchisi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
-msgstr "REDIS_URL va ENCRYPTION_SECRET sozlanmaguncha, AI provayderini boshqarish imkonsiz bo'ladi."
+msgstr "REDIS_URL va ENCRYPTION_SECRET sozlanmaguncha, Sun'iy intellekt provayderini boshqarish imkonsiz bo'ladi."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable. Please try again."
@@ -1028,7 +1028,7 @@ msgstr "URL-ni nusxalash"
 #: src/dialogs/resume/import.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Could not reach the AI provider. Please try again."
-msgstr "AI provayderiga ulanib bo'lmadi. Iltimos, yana urinib ko'ring."
+msgstr "Sun'iy intellekt provayderiga ulanib bo'lmadi. Iltimos, yana urinib ko'ring."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Could not restore this patch."
@@ -1532,7 +1532,7 @@ msgstr "Nusxalash"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Duplicate as AI Draft"
-msgstr "AI loyihasi sifatida nusxalash"
+msgstr "Sun'iy intellekt loyihasi sifatida nusxalash"
 
 #: src/dialogs/resume/index.tsx
 msgid "Duplicate Resume"
@@ -1861,7 +1861,7 @@ msgstr "Parolingizni qayta tiklash muvaffaqiyatsiz bo'ldi. Iltimos, yana urinib 
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "AI provayderini saqlab bo'lmadi."
+msgstr "Sun'iy intellekt provayderini saqlab bo'lmadi."
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -2377,7 +2377,7 @@ msgstr "Masshtabni oshirish"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2595,7 +2595,7 @@ msgstr "Chapga tekislash"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Let AI read the posting and fill the fields below."
-msgstr "AI e'lonni o'qib, quyidagi maydonlarni to'ldirsin."
+msgstr "Sun'iy intellekt e'lonni o'qib, quyidagi maydonlarni to'ldirsin."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Letter"
@@ -2911,7 +2911,7 @@ msgstr "Hali arizalar yo'q — funnel va javob foizlarini ko'rish uchun bir nech
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
 msgid "No data was returned from the AI provider."
-msgstr "AI provayderidan hech qanday ma'lumot qaytarilmadi."
+msgstr "Sun'iy intellekt provayderidan hech qanday ma'lumot qaytarilmadi."
 
 #: src/features/settings/authentication/components/passkeys.tsx
 msgid "No passkeys registered yet."
@@ -3009,7 +3009,7 @@ msgstr "Ochiq"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "AI agentini oching"
+msgstr "Sun'iy intellekt agentini oching"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"

--- a/apps/web/locales/uz-UZ.po
+++ b/apps/web/locales/uz-UZ.po
@@ -260,7 +260,7 @@ msgstr "Teg qo‘shing va Enter tugmasini bosing…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Agent mavzusini boshlashdan oldin provayderni qo'shing va sinab ko'ring."
+msgstr "Agent suhbatini boshlashdan oldin provayderni qo'shing va sinab ko'ring."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -344,7 +344,7 @@ msgstr "REDIS_URL va ENCRYPTION_SECRET sozlanmaguncha AI agentini sozlash imkoni
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "Sun'iy intellekt yordamchisi"
+msgstr "AI yordamchisi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "Sun'iy intellekt provayderlari REDIS_URL va ENCRYPTION_SECRET ni sozlash
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Alban tili"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Hisobingiz bormi? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Amxar tili"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Ariza o'chirildi."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Ilova statistikasi"
+msgstr "Ariza statistikasi"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Ogohlantirishlar bilan qo'llanildi"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Arab tili"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Mukofotlar"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Ozarbayjon tili"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Goʻzal shablonlar tanlang, yana koʻplari yoʻlda."
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Bengal tili"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Yasash buyruq paneli"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Bolgar tili"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Qayta tiklab bo'lmadi; ushbu tahrir qo'llanilganidan beri rezyume o'zgar
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Katalan tili"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Qoralama tekshirilmoqda"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Xitoy (Soddalashtirilgan)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Xitoy (An’anaviy)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Rezyumeni tanlang"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Yon paneldan mavjud suhbatni tanlang yoki qoralamaga yo'naltirilgan yangi mavzuni boshlang."
+msgstr "Yon paneldan mavjud suhbatni tanlang yoki qoralamaga yo'naltirilgan yangi suhbatni boshlang."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "Doira"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "Tiniq"
+msgstr "Tozalash"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -1278,7 +1278,7 @@ msgstr "Maxsus uslublar"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Chex tili"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Xavfli Hudud"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Daniya tili"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Provayderni o'chirish"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Ushbu agent mavzusi oʻchirib tashlansinmi?"
+msgstr "Ushbu agent suhbati oʻchirib tashlansinmi?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1548,7 +1548,7 @@ msgstr "Rezyume nusxalanmoqda..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Golland tili"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Ikki faktorli autentifikatsiyani yoqish…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Inglizcha"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Inglizcha (Birlashgan Qirollik)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Rezyumeni tahlil qilish muvaffaqiyatsiz bo'ldi."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Mavzu arxivlanmadi."
+msgstr "Suhbat arxivlanmadi."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "API kalitini o'chirib tashlash muvaffaqiyatsiz tugadi. Iltimos, yana uri
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Mavzuni o'chirib bo'lmadi."
+msgstr "Suhbatni o'chirib bo'lmadi."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1861,7 +1861,7 @@ msgstr "Parolingizni qayta tiklash muvaffaqiyatsiz bo'ldi. Iltimos, yana urinib 
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "Sun'iy intellekt provayderini saqlab bo'lmadi."
+msgstr "AI provayderini saqlab bo'lmadi."
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -1886,7 +1886,7 @@ msgstr "Chiqish muvaffaqiyatsiz bo'ldi. Iltimos, yana urinib ko'ring."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Agent mavzusini ishga tushirib bo'lmadi."
+msgstr "Agent suhbatini boshlab bo'lmadi."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Zaif o'qlarni toping va ularni kuchliroq natijalar, raqamlar, ko'lam va 
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Fin tili"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2053,7 +2053,7 @@ msgstr "Erkin shakl"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Fransuz tili"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "Tasodifiy ism yaratish"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Nemischa"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "Rezyumeingizni umumiy ball, kuchli tomonlar va amaliy tavsiyalar bilan k
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "Rezyumeingizni sun'iy intellekt yordamida chuqur tahlil qiling: umumiy ball, asosiy kuchli tomonlar va amaliy tavsiyalar bilan. Ushbu funksiyani yoqish uchun iltimos, sun'iy intellekt sozlamalaringizni yangilang."
+msgstr "Rezyumeingizni AI yordamida chuqur tahlil qiling: umumiy ball, asosiy kuchli tomonlar va amaliy tavsiyalar bilan. Ushbu funksiyani yoqish uchun iltimos, AI sozlamalaringizni yangilang."
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,13 +2116,13 @@ msgstr "Orqaga qaytish"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Uyga ket"
+msgstr "Bosh sahifaga o'tish"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "Dashboardga o'tish"
+msgstr "Boshqaruv paneliga o'tish"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "Baholar"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Yunon tili"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2199,11 +2199,11 @@ msgstr "Sarlavha 6"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
 msgid "Headline"
-msgstr "Sarlavha"
+msgstr "Qisqa sarlavha"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Ibroniy tili"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Belgilash rangi"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Hind tili"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Venger tili"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2353,7 +2353,7 @@ msgstr "{0} ta ariza import qilindi."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "PDF yoki Word’dan import qilish uchun ulangan AI provayderi talab qilinadi."
+msgstr "PDF yoki Word'dan import qilish uchun ulangan AI provayderi talab qilinadi."
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2377,7 +2377,7 @@ msgstr "Masshtabni oshirish"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonez tili"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Beruvchi"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Italyan tili"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "Kursiv"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Yapon tili"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Harflarni kengaytirib tekislash"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Kannada tili"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Birgalikda bo'ling"
+msgstr "Birgalikda saqlang"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Kalit soʻzlar"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Xmer tili"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Koreys tili"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Oxirgi ko‘rilgan sana: {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Latish tili"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Roʻyxat"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Litva tili"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Sun'iy intellekt provayderlari yuklanmoqda. Iltimos, bir zumda qayta uri
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Ilovalar yuklanmoqda…"
+msgstr "Arizalar yuklanmoqda…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Rezyumelar yuklanmoqda…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Mavzular yuklanmoqda…"
+msgstr "Suhbatlar yuklanmoqda…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Tajriba bo'limini natijaga yo'naltirilgan qiling va noaniq mas'uliyatlar
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Malay tili"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Malayalam tili"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Maratxi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Ism"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepal tili"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Tarmoq"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Yangi ilova"
+msgstr "Yangi ariza"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "Yangi teg…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Yangi mavzu"
+msgstr "Yangi suhbat"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Yangi mavzu"
+msgstr "Yangi suhbat"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2956,11 +2956,11 @@ msgstr "Sinovdan o'tgan provayder yo'q"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Hali hech qanday mavzu yo'q."
+msgstr "Hali hech qanday suhbat yo'q."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Norveg tili"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Eslatmalar"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odiya tili"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Ochiq"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Ochiq AI agenti"
+msgstr "AI agentini oching"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "OpenAI bilan mos keladi"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Fors tili"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "PDF faylingiz yaratilguncha kuting…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Polyak tili"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Portret"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Portugalcha (Braziliya)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Portugalcha (Portugaliya)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - Bosh sahifaga o'tish"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Reaktiv Rezume (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reaktiv rezyume v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Reaktiv Rezume v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Rol rivojlanishi"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumin tili"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Birinchi tahlilingizni ishga tushiring va ballar jadvali, kuchli tomonla
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Rus tili"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3846,7 +3846,7 @@ msgstr "Rezyumeni tanlang"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "Mavzuni tanlang"
+msgstr "Suhbatni tanlang"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "Ajratgich"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serb tili"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Sun'iy intellekt provayderini sozlang"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Mavzuni boshlashdan oldin AI provayderini sozlang."
+msgstr "Suhbatni boshlashdan oldin AI provayderini sozlang."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Asosiy tarkibga o'tish"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovak tili"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Sloven"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Bo'shliq (vertikal)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Ispan tili"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "GitHubda bizni yulduzlang, hozirda {0} ta yulduz (yangi tabda ochiladi)"
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Yangi mavzuni boshlang"
+msgstr "Yangi suhbatni boshlang"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Mavzuni boshlang"
+msgstr "Suhbatni boshlang"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Rezyumeni nolldan boshlang va yarating"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Yangi mavzuni boshlash"
+msgstr "Yangi suhbatni boshlash"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Yangi sahifadan boshlang"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Mavzuni boshlash"
+msgstr "Suhbatni boshlash"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4223,7 +4223,7 @@ msgstr "Statistika"
 
 #: src/hooks/use-form-blocker.tsx
 msgid "Stay"
-msgstr "Qolish"
+msgstr "Qoling"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Stop generation"
@@ -4276,7 +4276,7 @@ msgstr "Ilovani imkon qadar qoʻllab-quvvatlang!"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Shved tili"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Moslash amalga oshmadi."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil tili"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Telugu tili"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Matn rangi"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Tay tili"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4419,7 +4419,7 @@ msgstr "Kiritilgan URL haqiqiy emas."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Ishchi rezyume o'chirildi. Bu mavzu faqat o'qish uchun."
+msgstr "Ishchi rezyume o'chirildi. Bu suhbat faqat o'qish uchun."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4464,11 +4464,11 @@ msgstr "Bu amalni bekor qilib bo'lmaydi. Suhbat xabarlari va yuklangan qo'shimch
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
-msgstr "Bu amalni bekor qilib bo'lmaydi. Xabarlar va mavzu qo'shimchalari olib tashlanadi."
+msgstr "Bu amalni bekor qilib bo'lmaydi. Xabarlar va suhbat qo'shimchalari olib tashlanadi."
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Bu agent mavzusini ochib bo'lmadi."
+msgstr "Bu agent suhbatini ochib bo'lmadi."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "Bu bosqich ixtiyoriy, ammo tavsiya etiladi."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Bu mavzu arxivlangan. Yangi xabarlarni yuborib bo'lmaydi."
+msgstr "Bu suhbat arxivlangan. Yangi xabarlarni yuborib bo'lmaydi."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Bu mavzu faqat o'qish uchun"
+msgstr "Bu suhbat faqat o'qish uchun"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Ushbu mavzu faqat o'qish uchun mo'ljallangan, chunki ishlaydigan rezyume yoki AI provayderi mavjud emas."
+msgstr "Ushbu suhbat faqat o'qish uchun mo'ljallangan, chunki ishlaydigan rezyume yoki AI provayderi mavjud emas."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,22 +4545,22 @@ msgstr "Bu bo'limdagi barcha elementlarni o'chirib tashlaydi."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "Mavzu harakatlari"
+msgstr "Suhbat harakatlari"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Mavzu arxivlandi."
+msgstr "Suhbat arxivlandi."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Mavzu o'chirildi."
+msgstr "Suhbat o'chirildi."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Mavzular"
+msgstr "Suhbatlar"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "O'ng yon panelni yoqish/o'chirish"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Mavzularni ochish/o'chirish"
+msgstr "Suhbatlarni ochish/o'chirish"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4647,7 +4647,7 @@ msgstr "Qayta urinib ko'ring"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Turk tili"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Tipografiya"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukrain tili"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Foydalanuvchilar"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "O'zbek tili"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "Versiya tarixi"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "Vyetnam tili"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5173,7 +5173,7 @@ msgstr "Sizning yordamingiz loyihaning har doim bepul bo‘lishi va har kim uchu
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Zoom"
-msgstr "Kattalashtirish"
+msgstr "Masshtab"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom in"
@@ -5190,5 +5190,5 @@ msgstr "Kichraytirish"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/vi-VN.po
+++ b/apps/web/locales/vi-VN.po
@@ -260,7 +260,7 @@ msgstr "Thêm thẻ và nhấn Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "Thêm và kiểm tra nhà cung cấp trước khi bắt đầu luồng tác vụ."
+msgstr "Thêm và kiểm tra nhà cung cấp trước khi bắt đầu cuộc trò chuyện của tác nhân."
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -311,24 +311,24 @@ msgstr "Hãy điều chỉnh sơ yếu lý lịch cho phù hợp với vị trí
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "Trình độ cao"
+msgstr "Nâng cao"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "Tiếng Afrikaans"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Agent"
-msgstr "Đại lý"
+msgstr "Tác nhân"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Agent ready"
-msgstr "Đại lý sẵn sàng"
+msgstr "Tác nhân sẵn sàng"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Agents"
-msgstr "Đại lý"
+msgstr "Tác nhân"
 
 #: src/dialogs/resume/import.tsx
 msgid "AI"
@@ -364,7 +364,7 @@ msgstr "Các nhà cung cấp AI yêu cầu cấu hình REDIS_URL và ENCRYPTION_
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "Tiếng Albania"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "Đã có tài khoản? <0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "Tiếng Amharic"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -464,7 +464,7 @@ msgstr "Đã xóa hồ sơ ứng tuyển."
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "Thống kê ứng dụng"
+msgstr "Thống kê hồ sơ ứng tuyển"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -504,7 +504,7 @@ msgstr "Được áp dụng kèm theo cảnh báo"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "Tiếng Ả Rập"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -628,7 +628,7 @@ msgstr "Giải thưởng"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "Tiếng Azerbaijan"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -661,7 +661,7 @@ msgstr "Các mẫu đẹp để lựa chọn, sẽ còn cập nhật thêm trong
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "Tiếng Bengal"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "Bảng lệnh Builder"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "Tiếng Bulgaria"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "Không thể khôi phục; sơ yếu lý lịch đã thay đổi kể t�
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "Tiếng Catalan"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,11 +819,11 @@ msgstr "Kiểm tra bản nháp"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "Tiếng Trung (Giản thể)"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "Tiếng Trung (Phồn thể)"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "Chọn một bản sơ yếu lý lịch"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "Chọn một cuộc hội thoại hiện có từ thanh bên hoặc bắt đầu một chủ đề mới tập trung vào bản nháp."
+msgstr "Chọn một cuộc hội thoại hiện có từ thanh bên hoặc bắt đầu một cuộc trò chuyện mới tập trung vào bản nháp."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -1278,7 +1278,7 @@ msgstr "Kiểu dáng tùy chỉnh"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "Tiếng Séc"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "Vùng nguy hiểm"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "Tiếng Đan Mạch"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1374,7 +1374,7 @@ msgstr "Xóa nhà cung cấp"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "Xóa chủ đề thảo luận về tác vụ này?"
+msgstr "Xóa cuộc trò chuyện của tác nhân này?"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -1548,7 +1548,7 @@ msgstr "Đang tạo bản sao bản lý lịch của bạn..."
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "Tiếng Hà Lan"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "Kích hoạt xác thực hai yếu tố…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "Tiếng Anh"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "Tiếng Anh (Vương quốc Anh)"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "Không thể phân tích sơ yếu lý lịch."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "Không thể lưu trữ chủ đề."
+msgstr "Không thể lưu trữ cuộc trò chuyện."
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "Không thể xóa khóa API. Vui lòng thử lại."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "Không thể xóa chủ đề."
+msgstr "Không thể xóa cuộc trò chuyện."
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1886,7 +1886,7 @@ msgstr "Không thể đăng xuất. Vui lòng thử lại."
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "Không thể khởi động luồng tác vụ."
+msgstr "Không thể bắt đầu cuộc trò chuyện của tác nhân."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "Hãy tìm những gạch đầu dòng yếu và viết lại chúng vớ
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "Tiếng Phần Lan"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "Phù hợp để xem"
+msgstr "Vừa với khung nhìn"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "Hình thức tự do"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "Tiếng Pháp"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2079,7 +2079,7 @@ msgstr "Trình chỉnh sửa toàn màn hình"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Gaps:"
-msgstr "Khoảng trống:"
+msgstr "Thiếu sót:"
 
 #: src/dialogs/resume/index.tsx
 msgid "Generate a random name"
@@ -2087,7 +2087,7 @@ msgstr "Tạo tên ngẫu nhiên"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "Tiếng Đức"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2116,7 +2116,7 @@ msgstr "Quay lại"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "Về nhà"
+msgstr "Về trang chủ"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2127,7 +2127,7 @@ msgstr "Đi đến bảng điều khiển"
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Go to resumes dashboard"
-msgstr "Truy cập trang tổng quan hồ sơ"
+msgstr "Truy cập bảng điều khiển hồ sơ"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Go to…"
@@ -2154,7 +2154,7 @@ msgstr "Điểm số"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "Tiếng Hy Lạp"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2199,11 +2199,11 @@ msgstr "Tiêu đề 6"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
 msgid "Headline"
-msgstr "Tiêu đề"
+msgstr "Chức danh"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "Tiếng Do Thái"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "Màu nổi bật"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "Tiếng Hindi"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "Tiếng Hungary"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2377,7 +2377,7 @@ msgstr "Tăng độ phóng to"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Tiếng Indonesia"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "Bên phát hành"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "Tiếng Ý"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "In nghiêng"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "Tiếng Nhật"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "Căn đều hai bên"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "Tiếng Kannada"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "Hãy giữ vững sự đoàn kết"
+msgstr "Giữ liền khối"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "Từ khóa"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "Tiếng Khmer"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "Tiếng Hàn"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "Xem lần cuối vào {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "Tiếng Latvia"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2674,7 +2674,7 @@ msgstr "Danh sách"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "Tiếng Litva"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "Đang tải các nhà cung cấp AI. Vui lòng thử lại sau một lá
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "Đang tải ứng dụng…"
+msgstr "Đang tải hồ sơ ứng tuyển…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "Đang tải tiếp tục…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "Đang tải luồng…"
+msgstr "Đang tải cuộc trò chuyện…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "Hãy tập trung vào kết quả hơn trong phần mô tả kinh nghi�
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "Tiếng Mã Lai"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "Tiếng Malayalam"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "Marathi"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2848,7 +2848,7 @@ msgstr "Tên"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "Nepali"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "Mạng"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "Ứng dụng mới"
+msgstr "Hồ sơ ứng tuyển mới"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "Thẻ mới…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "Chủ đề mới"
+msgstr "Cuộc trò chuyện mới"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "Chủ đề mới"
+msgstr "Cuộc trò chuyện mới"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2956,11 +2956,11 @@ msgstr "Không có nhà cung cấp nào được kiểm thử"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "Chưa có chủ đề nào."
+msgstr "Chưa có cuộc trò chuyện nào."
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "Na Uy"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "Ghi chú"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "Odia"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "Mở"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "Đại lý AI mở"
+msgstr "Mở tác nhân AI"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "Tương thích với OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,7 +3211,7 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "Ba Tư"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3272,7 +3272,7 @@ msgstr "Vui lòng chờ trong khi tệp PDF của bạn đang được tạo…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "Ba Lan"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "Chân dung"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "Bồ Đào Nha (Brazil)"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "Bồ Đào Nha (Bồ Đào Nha)"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3399,7 +3399,7 @@ msgstr "Resume Phản Ứng - Về trang chủ"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "Sơ yếu lý lịch động (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "Reactive Resume v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "Sơ yếu lý lịch phản hồi phiên bản 4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "Tiến trình vai trò"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "Rumani"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "Hãy thực hiện phân tích đầu tiên để nhận được bảng
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "Nga"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3846,7 +3846,7 @@ msgstr "Chọn một bản sơ yếu lý lịch"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "Chọn một chủ đề"
+msgstr "Chọn một cuộc trò chuyện"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3899,7 +3899,7 @@ msgstr "Dấu phân cách"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "Serbia"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "Thiết lập một nhà cung cấp AI"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "Hãy thiết lập một nhà cung cấp AI trước khi bắt đầu một chủ đề."
+msgstr "Hãy thiết lập một nhà cung cấp AI trước khi bắt đầu một cuộc trò chuyện."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "Chuyển đến nội dung chính"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "Slovak"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "Tiếng Slovenia"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "Khoảng cách (Dọc)"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "Tây Ban Nha"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "Nhấn sao cho chúng tôi trên GitHub, hiện tại có {0} lượt sa
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "Bắt đầu một chủ đề mới"
+msgstr "Bắt đầu một cuộc trò chuyện mới"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "Bắt đầu một chủ đề"
+msgstr "Bắt đầu một cuộc trò chuyện"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "Bắt đầu xây dựng hồ sơ từ đầu"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "Bắt đầu chủ đề mới"
+msgstr "Bắt đầu cuộc trò chuyện mới"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "Bắt đầu trên trang mới"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "Bắt đầu chủ đề"
+msgstr "Bắt đầu cuộc trò chuyện"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4276,7 +4276,7 @@ msgstr "Hãy ủng hộ ứng dụng bằng cách làm bất cứ điều gì b�
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "Thụy Điển"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "Tinh chỉnh thất bại."
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "Tamil"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "Tiếng Telugu"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "Màu chữ"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "Thái"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4372,7 +4372,7 @@ msgstr "Cảm ơn các nhà tài trợ của chúng tôi."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "The agent needs your input."
-msgstr "Nhân viên cần thông tin đầu vào từ bạn."
+msgstr "Tác nhân cần thông tin đầu vào từ bạn."
 
 #. Error description when AI returns invalid resume analysis format
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
@@ -4419,7 +4419,7 @@ msgstr "URL bạn đã nhập không hợp lệ."
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "Hồ sơ xin việc đã bị xóa. Chủ đề này chỉ có thể đọc."
+msgstr "Hồ sơ xin việc đã bị xóa. Cuộc trò chuyện này chỉ có thể đọc."
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4460,7 +4460,7 @@ msgstr "Hành động này không thể hoàn tác. Tất cả dữ liệu của
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "Thao tác này không thể hoàn tác. Tin nhắn hội thoại và tệp đính kèm đã tải lên sẽ bị xóa. Hồ sơ công việc vẫn hiển thị trên trang tổng quan của bạn và có thể được xóa riêng."
+msgstr "Thao tác này không thể hoàn tác. Tin nhắn hội thoại và tệp đính kèm đã tải lên sẽ bị xóa. Hồ sơ công việc vẫn hiển thị trên bảng điều khiển của bạn và có thể được xóa riêng."
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
@@ -4468,7 +4468,7 @@ msgstr "Thao tác này không thể hoàn tác. Tin nhắn và tệp đính kèm
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "Không thể mở luồng thảo luận về tác vụ này."
+msgstr "Không thể mở cuộc trò chuyện của tác nhân này."
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4520,15 +4520,15 @@ msgstr "Bước này là không bắt buộc, nhưng được khuyến nghị."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "Chủ đề này đã được lưu trữ. Không thể gửi tin nhắn mới."
+msgstr "Cuộc trò chuyện này đã được lưu trữ. Không thể gửi tin nhắn mới."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "Chủ đề này chỉ có thể đọc."
+msgstr "Cuộc trò chuyện này chỉ có thể đọc."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "Chủ đề này chỉ có thể đọc vì sơ yếu lý lịch đang làm việc hoặc nhà cung cấp AI hiện không khả dụng."
+msgstr "Cuộc trò chuyện này chỉ có thể đọc vì sơ yếu lý lịch đang làm việc hoặc nhà cung cấp AI hiện không khả dụng."
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,22 +4545,22 @@ msgstr "Thao tác này sẽ xóa tất cả các mục trong phần này."
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "Hành động luồng"
+msgstr "Hành động cuộc trò chuyện"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "Chủ đề đã được lưu trữ."
+msgstr "Cuộc trò chuyện đã được lưu trữ."
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "Bài viết đã bị xóa."
+msgstr "Cuộc trò chuyện đã bị xóa."
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "Các sợi chỉ"
+msgstr "Các cuộc trò chuyện"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
@@ -4622,7 +4622,7 @@ msgstr "Bật/tắt thanh bên phải"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "Luồng chuyển đổi"
+msgstr "Chuyển đổi cuộc trò chuyện"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4647,7 +4647,7 @@ msgstr "Hãy thử lại"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "Thổ Nhĩ Kỳ"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "Kiểu chữ"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "Ukraina"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4929,7 +4929,7 @@ msgstr "Người dùng"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "Uzbek"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -5190,5 +5190,5 @@ msgstr "Thu nhỏ"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "Zulu"
+msgstr "isiZulu"
 

--- a/apps/web/locales/vi-VN.po
+++ b/apps/web/locales/vi-VN.po
@@ -768,7 +768,7 @@ msgstr "Căn giữa"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "Não bộ"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "Trợ lý AI gần gũi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "Liên kết"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "Giảm độ phóng to"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "Tìm kiếm sâu"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "Tiếng Phần Lan"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "Pháo hoa"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2797,7 +2797,7 @@ msgstr "Hồ sơ xin việc bị thiếu"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "Trí tuệ nhân tạo Mistral"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "Odia"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "Đám mây Ollama"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "Thời gian"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "Sự bối rối"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "URL hợp lệ phải bắt đầu với http:// hoặc https://."
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Cổng AI Vercel"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/vi-VN.po
+++ b/apps/web/locales/vi-VN.po
@@ -2377,7 +2377,7 @@ msgstr "Tăng độ phóng to"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/zh-CN.po
+++ b/apps/web/locales/zh-CN.po
@@ -2377,7 +2377,7 @@ msgstr "增大缩放"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/zh-CN.po
+++ b/apps/web/locales/zh-CN.po
@@ -45,7 +45,7 @@ msgstr "{0, plural, other {# 个职位}}"
 #. placeholder {0}: insights.total
 #: src/features/applications/components/insights-view.tsx
 msgid "{0} applications tracked"
-msgstr "已跟踪 {0} 个申请"
+msgstr "已跟踪 {0} 个求职申请"
 
 #. Character count readout for the rich-text editor
 #. placeholder {0}: state.characterCount
@@ -260,13 +260,13 @@ msgstr "添加标签并按 Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "在启动代理线程之前，添加并测试提供程序。"
+msgstr "在启动智能体会话之前，添加并测试提供程序。"
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Add application"
-msgstr "添加申请"
+msgstr "添加求职申请"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Add contact"
@@ -311,40 +311,40 @@ msgstr "调整简历，使其更适合远程优先、重视异步沟通和自主
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "先进的"
+msgstr "高级"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "南非语"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Agent"
-msgstr "代理人"
+msgstr "智能体"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Agent ready"
-msgstr "代理已准备就绪"
+msgstr "智能体就绪"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Agents"
-msgstr "代理人"
+msgstr "智能体"
 
 #: src/dialogs/resume/import.tsx
 msgid "AI"
-msgstr "AI（人工智能）"
+msgstr "AI"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "AI agent setup is unavailable right now. Please try again in a moment."
-msgstr "目前无法设置人工智能代理，请稍后再试。"
+msgstr "目前无法设置 AI 智能体，请稍后再试。"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "AI agent setup is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
-msgstr "在配置 REDIS_URL 和 ENCRYPTION_SECRET 之前，AI 代理设置不可用。"
+msgstr "在配置 REDIS_URL 和 ENCRYPTION_SECRET 之前，AI 智能体设置不可用。"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "人工智能助手"
+msgstr "AI 助手"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "AI 提供商需要配置 REDIS_URL 和 ENCRYPTION_SECRET。"
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "阿尔巴尼亚语"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "已有账户？<0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "阿姆哈拉语"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,43 +447,43 @@ msgstr "应用"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "申请操作"
+msgstr "求职申请操作"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
-msgstr "申请已添加到你的流程。"
+msgstr "求职申请已添加到你的流程。"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "申请 Copilot"
+msgstr "求职申请 Copilot"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
-msgstr "申请已删除。"
+msgstr "求职申请已删除。"
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "应用统计数据"
+msgstr "求职申请统计"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
-msgstr "申请已更新。"
+msgstr "求职申请已更新。"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
 #: src/routes/dashboard/applications/index.tsx
 msgid "Applications"
-msgstr "申请"
+msgstr "求职申请"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
-msgstr "申请随时间变化"
+msgstr "求职申请随时间变化"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
-msgstr "每周发送的申请（最近 8 周）"
+msgstr "每周发送的求职申请（最近 8 周）"
 
 #: src/features/applications/components/table-view.tsx
 #: src/features/resume/stylesheet/status.tsx
@@ -504,7 +504,7 @@ msgstr "附带警告"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "阿拉伯语"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -591,7 +591,7 @@ msgstr "附加文件"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment"
-msgstr "依恋"
+msgstr "附件"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment uploaded."
@@ -628,7 +628,7 @@ msgstr "奖项"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "阿塞拜疆语"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -649,7 +649,7 @@ msgstr "备份码已复制到剪贴板。"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Base URL"
-msgstr "基本 URL"
+msgstr "Base URL"
 
 #: src/libs/resume/section.tsx
 msgid "Basics"
@@ -657,15 +657,15 @@ msgstr "基础"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Beautiful templates to choose from, with more on the way."
-msgstr "提供多款精美模板供你选择，并且还会不断增加。"
+msgstr "精美模板任你挑选，更多模板持续上新。"
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "孟加拉语"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
-msgstr "最适合申请、分享和打印。"
+msgstr "最适合职位申请、分享和打印。"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Blank draft"
@@ -694,7 +694,7 @@ msgstr "边框宽度"
 
 #: src/features/resume/public/public-resume.tsx
 msgid "Build your own resume"
-msgstr "打造你自己的简历"
+msgstr "打造你的个人简历"
 
 #. Screen-reader dialog title for the command palette in the resume builder
 #: src/features/command-palette/index.tsx
@@ -703,7 +703,7 @@ msgstr "编辑器命令面板"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "保加利亚语"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -722,7 +722,7 @@ msgstr "项目符号列表"
 #: src/routes/_home/-sections/features.tsx
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "By the community, for the community."
-msgstr "由社群贡献，为社群服务。"
+msgstr "来自社区，服务社区。"
 
 #: src/routes/_home/-sections/faq.tsx
 msgid "Can I export my resume to PDF?"
@@ -760,7 +760,7 @@ msgstr "无法恢复；简历自此编辑后已发生更改。"
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "加泰罗尼亚语"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -823,7 +823,7 @@ msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr "中文（繁体）"
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -841,7 +841,7 @@ msgstr "选择一份简历"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "从侧边栏选择现有对话，或发起新的以草稿为中心的讨论串。"
+msgstr "从侧边栏选择现有对话，或开启新的以草稿为中心的会话。"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -856,7 +856,7 @@ msgstr "圆形"
 #: src/components/input/rich-input.tsx
 #: src/features/applications/components/table-view.tsx
 msgid "Clear"
-msgstr "清晰"
+msgstr "清除"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Clear filters"
@@ -969,7 +969,7 @@ msgstr "从上次中断的地方继续"
 
 #: src/dialogs/resume/import.tsx
 msgid "Continue where you left off by importing an existing resume you created using Reactive Resume or any another resume builder. Supported formats include PDF, Microsoft Word, as well as JSON files from Reactive Resume."
-msgstr "通过导入你使用 Reactive Resume 或其他简历生成器创建的现有简历，从上次中断的地方继续。支持的格式包括 PDF、Microsoft Word 以及来自 Reactive Resume 的 JSON 文件。"
+msgstr "导入你用 Reactive Resume 或其他简历工具创建过的简历，即可从上次中断的地方继续。支持 PDF、Microsoft Word 以及 Reactive Resume 导出的 JSON 文件。"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Contributions fund bug fixes, security updates, and continuous improvements to keep the app running smoothly."
@@ -1044,12 +1044,12 @@ msgstr "连接验证失败。请检查 API 密钥、模型和基本 URL。"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Couldn't add the application. Please try again."
-msgstr "无法添加申请。请重试。"
+msgstr "无法添加求职申请，请重试。"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the application."
-msgstr "无法删除申请。"
+msgstr "无法删除求职申请。"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Couldn't delete the timeline entry."
@@ -1057,7 +1057,7 @@ msgstr "无法删除时间线条目。"
 
 #: src/features/applications/components/board.tsx
 msgid "Couldn't move the application. Please try again."
-msgstr "无法移动申请。请重试。"
+msgstr "无法移动求职申请，请重试。"
 
 #: src/routes/builder/$resumeId/-components/header.tsx
 msgid "Couldn't save"
@@ -1179,11 +1179,11 @@ msgstr "创建新项目"
 
 #: src/dialogs/resume/sections/publication.tsx
 msgid "Create a new publication"
-msgstr "创建新出版物"
+msgstr "新增出版物"
 
 #: src/dialogs/resume/sections/reference.tsx
 msgid "Create a new reference"
-msgstr "创建新推荐人"
+msgstr "新增推荐人"
 
 #: src/dialogs/resume/index.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -1233,7 +1233,7 @@ msgstr "创建时间"
 #. placeholder {0}: result.name
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Created \"{0}\" and linked it to this application."
-msgstr "已创建“{0}”并关联到此申请。"
+msgstr "已创建“{0}”并关联到此求职申请。"
 
 #: src/dialogs/api-key/create.tsx
 msgid "Creating your API key..."
@@ -1278,7 +1278,7 @@ msgstr "自定义样式"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "捷克语"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "危险操作区"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "丹麦语"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1320,11 +1320,11 @@ msgstr "申请日期"
 
 #: src/components/input/rich-input.tsx
 msgid "Decrease indent"
-msgstr "减少缩进"
+msgstr "减小缩进"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "Decrease zoom"
-msgstr "降低缩放比例"
+msgstr "减小缩放"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
@@ -1374,12 +1374,12 @@ msgstr "删除提供商"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "删除此代理主题帖？"
+msgstr "删除此智能体会话？"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Delete this application?"
-msgstr "删除此申请？"
+msgstr "删除此求职申请？"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Delete this timeline entry?"
@@ -1392,7 +1392,7 @@ msgstr "删除时间线条目"
 #. placeholder {0}: result.deleted
 #: src/features/applications/components/table-view.tsx
 msgid "Deleted {0} application(s)."
-msgstr "已删除 {0} 个申请。"
+msgstr "已删除 {0} 个求职申请。"
 
 #: src/features/settings/pages/danger-zone.tsx
 msgid "Deleting your account..."
@@ -1548,7 +1548,7 @@ msgstr "正在复制你的简历…"
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "荷兰语"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1568,7 +1568,7 @@ msgstr "编辑 {chip}"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Edit application"
-msgstr "编辑申请"
+msgstr "编辑求职申请"
 
 #. placeholder {0}: selectedColor.token.value
 #: src/features/resume/stylesheet/editor.tsx
@@ -1666,11 +1666,11 @@ msgstr "启用双因素身份验证…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "英语"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "英语（英国）"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "简历分析失败。"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "帖子归档失败。"
+msgstr "会话归档失败。"
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "删除 API 密钥失败。请重试。"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "删除线程失败。"
+msgstr "会话删除失败。"
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1861,7 +1861,7 @@ msgstr "重置密码失败。请重试。"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "保存人工智能提供商失败。"
+msgstr "保存 AI 提供商失败。"
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -1886,7 +1886,7 @@ msgstr "退出登录失败。请重试。"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "启动代理线程失败。"
+msgstr "启动智能体会话失败。"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "找出薄弱的要点，用更强有力的结果、数字、范围和更
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "芬兰语"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "适合观看"
+msgstr "适应视图"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "自由形式"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "法语"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2079,7 +2079,7 @@ msgstr "全屏编辑器"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Gaps:"
-msgstr "差距："
+msgstr "缺口："
 
 #: src/dialogs/resume/index.tsx
 msgid "Generate a random name"
@@ -2087,7 +2087,7 @@ msgstr "生成一个随机名称"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "德语"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "对您的简历进行审核，并给出总分、优势和可行建议。
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "人工智能将对您的简历进行深入审核，并给出总分、主要优势和实用建议。要激活此功能，请更新您的人工智能设置。"
+msgstr "AI 将对你的简历进行深入评估，并给出总分、核心优势与实用建议。要启用此功能，请更新你的 AI 设置。"
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,13 +2116,13 @@ msgstr "返回"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "回家"
+msgstr "回到首页"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
 #: src/routes/_home/-sections/header.tsx
 msgid "Go to dashboard"
-msgstr "转到控制面板"
+msgstr "转到仪表板"
 
 #. Accessible label for button navigating from builder to resumes dashboard
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2154,7 +2154,7 @@ msgstr "成绩"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "希腊语"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2171,7 +2171,7 @@ msgstr "扩充团队"
 #: src/routes/builder/$resumeId/-sidebar/right/sections/typography.tsx
 msgctxt "Headings or Titles (H1, H2, H3, H4, H5, H6)"
 msgid "Heading"
-msgstr "标题文字"
+msgstr "标题"
 
 #: src/components/input/rich-input.tsx
 msgid "Heading 1"
@@ -2199,11 +2199,11 @@ msgstr "标题 6"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
 msgid "Headline"
-msgstr "标题"
+msgstr "职业头衔"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "希伯来语"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "高亮颜色"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "印地语"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "匈牙利语"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2349,11 +2349,11 @@ msgstr "从 CSV 导入"
 #. placeholder {0}: result.imported
 #: src/features/applications/components/import-applications-sheet.tsx
 msgid "Imported {0} application(s)."
-msgstr "已导入 {0} 个申请。"
+msgstr "已导入 {0} 个求职申请。"
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "从 PDF 或 Word 导入需要连接 AI 提供商。"
+msgstr "从 PDF 或 Word 导入需要接入 AI 提供商。"
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2373,11 +2373,11 @@ msgstr "增加缩进"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "Increase zoom"
-msgstr "放大"
+msgstr "增大缩放"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "印尼语"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "签发机构"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "意大利语"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "斜体"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "日语"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "两端对齐"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "卡纳达语"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "保持团结"
+msgstr "保持同页"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "关键词"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "高棉语"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "韩语"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "上次查看于 {0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "拉脱维亚语"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2587,7 +2587,7 @@ msgstr "离开"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
 msgid "Leave empty to reset the title to the original."
-msgstr "留空则将标题重置为原始值。"
+msgstr "留空可恢复为原始标题。"
 
 #: src/components/input/rich-input.tsx
 msgid "Left Align"
@@ -2674,7 +2674,7 @@ msgstr "列表"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "立陶宛语"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "正在加载人工智能提供商。请稍后再试。"
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "正在加载应用程序…"
+msgstr "正在加载求职申请…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "正在恢复加载…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "正在加载线程…"
+msgstr "正在加载会话…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "让工作经历部分更注重结果导向，并删除模糊的职责描
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "马来语"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "马拉雅拉姆语"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "马拉地语"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2829,7 +2829,7 @@ msgstr "多语言"
 #. Placeholder text for custom link URL field in resume builder
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom-fields.tsx
 msgid "Must start with https://"
-msgstr "必须从 https:// 开始"
+msgstr "必须以 https:// 开头"
 
 #. Label for full name input on registration form
 #: src/dialogs/api-key/create.tsx
@@ -2848,7 +2848,7 @@ msgstr "姓名"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "尼泊尔语"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "网络"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "新申请"
+msgstr "新建求职申请"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "新标签…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "新帖"
+msgstr "新会话"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "新帖"
+msgstr "新会话"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2902,11 +2902,11 @@ msgstr "无广告，无跟踪"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "No applications match your filters."
-msgstr "没有符合筛选条件的申请。"
+msgstr "没有符合筛选条件的求职申请。"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "No applications yet — add a few to see your funnel and reply rates."
-msgstr "还没有申请，添加几个即可查看漏斗和回复率。"
+msgstr "还没有求职申请，添加几个即可查看漏斗和回复率。"
 
 #. Error shown when AI import endpoint returns no parsed resume data
 #: src/dialogs/resume/import.tsx
@@ -2956,11 +2956,11 @@ msgstr "没有经过测试的提供商"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "暂无主题。"
+msgstr "暂无会话。"
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "挪威语"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "注释"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "奥里亚语"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "打开"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "OpenAI代理"
+msgstr "打开 AI 智能体"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "兼容 OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,11 +3211,11 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "波斯语"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
-msgstr "使用任意颜色、字体或设计来个性化你的简历，让它真正属于你。"
+msgstr "用任意颜色、字体或设计个性化你的简历，打造出独一无二的专属版本。"
 
 #: src/dialogs/resume/sections/reference.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
@@ -3236,7 +3236,7 @@ msgstr "流程流向"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Pipeline health across all applications"
-msgstr "所有申请的流程健康状况"
+msgstr "所有求职申请的流程健康状况"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Plain text, ideal for AI tools and quick edits."
@@ -3272,7 +3272,7 @@ msgstr "请稍候，您的PDF文件正在生成中…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "波兰语"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "纵向"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "葡萄牙语（巴西）"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "葡萄牙语（葡萄牙）"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3301,7 +3301,7 @@ msgstr "偏好设置"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Prepare a conservative patch that improves clarity without changing my career narrative."
-msgstr "准备一个保守的补丁，在不改变我的职业发展轨迹的前提下，提高清晰度。"
+msgstr "在不改动职业经历的前提下，准备一份保守的润色补丁，提升表述清晰度。"
 
 #: src/features/resume/export/use-resume-export.ts
 msgid "Preparing your resume for printing..."
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - 返回首页"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "反应式简历（JSON）"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "响应式恢复 v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "反应式简历 v4（JSON）"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "职位晋升"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "罗马尼亚语"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "进行首次分析，以获得记分卡、优势和优先建议。"
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "俄语"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3788,7 +3788,7 @@ msgstr "搜索"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Search applications…"
-msgstr "搜索申请…"
+msgstr "搜索求职申请…"
 
 #. Accessible label for command palette search input
 #: src/features/command-palette/index.tsx
@@ -3846,7 +3846,7 @@ msgstr "选择一份简历"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "选择一个线程"
+msgstr "选择会话"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3854,7 +3854,7 @@ msgstr "全选"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Select an agent model"
-msgstr "选择代理模型"
+msgstr "选择智能体模型"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Select an AI provider"
@@ -3899,7 +3899,7 @@ msgstr "分隔线"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "塞尔维亚语"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "建立人工智能提供商"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "在发起讨论之前，请先设置好人工智能提供商。"
+msgstr "在开启会话之前，请先设置好人工智能提供商。"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4057,7 +4057,7 @@ msgstr "正在注册…"
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a magenta left border accent; compact and efficient for entry-level or internship applications."
-msgstr "单栏布局，左侧为洋红色边框点缀；紧凑高效，适合入门级或实习申请。"
+msgstr "单栏布局，左侧为洋红色边框点缀；紧凑高效，适合入门级或实习职位申请。"
 
 #: src/dialogs/resume/template/data.ts
 msgid "Single-column with a minimal top header and lots of whitespace; clean and modern for designers or content creators."
@@ -4098,11 +4098,11 @@ msgstr "跳到主要内容"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "斯洛伐克语"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "斯洛文尼亚语"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "间距（垂直）"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "西班牙语"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "在 GitHub 上为我们加星，目前有 {0} 颗星（在新标签页�
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "另开一个帖子"
+msgstr "开启新会话"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "发起一个话题"
+msgstr "开启会话"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "从头开始构建你的简历"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "另开新帖"
+msgstr "开启新会话"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "在新页面开始"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "发起讨论"
+msgstr "开启会话"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4223,7 +4223,7 @@ msgstr "统计数据"
 
 #: src/hooks/use-form-blocker.tsx
 msgid "Stay"
-msgstr "留下"
+msgstr "留在本页"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Stop generation"
@@ -4276,7 +4276,7 @@ msgstr "尽你所能支持这个应用！"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "瑞典语"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "定制失败。"
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "泰米尔语"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "泰卢固语"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "文本颜色"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "泰语"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4372,7 +4372,7 @@ msgstr "感谢我们的赞助商"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "The agent needs your input."
-msgstr "经纪人需要您的意见。"
+msgstr "智能体需要你的输入。"
 
 #. Error description when AI returns invalid resume analysis format
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
@@ -4419,7 +4419,7 @@ msgstr "你输入的 URL 无效。"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "工作简历已被删除。此帖为只读模式。"
+msgstr "工作简历已被删除。此会话为只读。"
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4460,15 +4460,15 @@ msgstr "此操作不可撤销。你的所有数据都将被永久删除。"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "此操作无法撤销。对话消息和上传的附件将被删除。正在编辑的简历仍保留在您的控制面板中，您可以单独将其删除。"
+msgstr "此操作无法撤销。会话消息和上传的附件将被删除。工作简历仍保留在你的仪表板中，可单独删除。"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
-msgstr "此操作无法撤销。消息和对话附件将被删除。"
+msgstr "此操作无法撤销。消息和会话附件将被删除。"
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "此代理线程无法打开。"
+msgstr "无法打开此智能体会话。"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4504,7 +4504,7 @@ msgstr "这份简历已被锁定，无法更新。"
 
 #: src/features/resume/builder/draft.ts
 msgid "This resume was updated by an AI agent."
-msgstr "这份简历由人工智能代理更新。"
+msgstr "此简历由 AI 智能体更新。"
 
 #: src/features/resume/builder/draft.ts
 msgid "This resume's sharing settings changed elsewhere."
@@ -4520,15 +4520,15 @@ msgstr "此步骤可选，但推荐完成。"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "此帖已存档，无法发送新消息。"
+msgstr "此会话已存档，无法发送新消息。"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "此帖为只读帖。"
+msgstr "此会话为只读。"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "由于简历撰写或人工智能服务提供商不可用，此帖为只读模式。"
+msgstr "由于简历撰写或人工智能服务提供商不可用，此会话为只读。"
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,26 +4545,26 @@ msgstr "这将删除该部分的所有项目。"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "线程操作"
+msgstr "会话操作"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "帖子已存档。"
+msgstr "会话已存档。"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "帖子已删除。"
+msgstr "会话已删除。"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "线程"
+msgstr "会话"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
-msgstr "精简技能部分，使其能够支持目标职位，而不是像关键词堆砌一样。"
+msgstr "精简技能板块，让技能真正支撑目标职位，而不是关键词堆砌。"
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Timelapse demonstration of building a resume with Reactive Resume"
@@ -4622,7 +4622,7 @@ msgstr "切换右侧边栏"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "切换线程"
+msgstr "切换会话"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4630,7 +4630,7 @@ msgstr "跟踪你正在申请的职位并关联已发送的简历。"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Track your first application"
-msgstr "跟踪你的第一个申请"
+msgstr "跟踪你的第一份求职申请"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Track your resume's views and downloads"
@@ -4647,7 +4647,7 @@ msgstr "再试一次"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "土耳其语"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "排版"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "乌克兰语"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4750,7 +4750,7 @@ msgstr "撤销样式表编辑"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Unlimited Resumes"
-msgstr "无限简历"
+msgstr "简历份数不限"
 
 #: src/features/settings/authentication/components/hooks.tsx
 msgid "Unlinking your {providerName} account..."
@@ -4859,7 +4859,7 @@ msgstr "更新此时间线条目的日历日期。"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Update this application's details."
-msgstr "更新此申请的详细信息。"
+msgstr "更新此求职申请的详细信息。"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Update this timeline note."
@@ -4929,7 +4929,7 @@ msgstr "用户数"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "乌兹别克语"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "版本历史记录"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "越南语"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5039,11 +5039,11 @@ msgstr "简历一旦被锁定，就无法更新或删除。"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where applications come from"
-msgstr "申请来源"
+msgstr "求职申请来源"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Where your applications went"
-msgstr "你的申请去向"
+msgstr "你的求职申请去向"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Work OpenAI"
@@ -5173,7 +5173,7 @@ msgstr "你的支持可以确保这个项目在现在和未来都保持免费且
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Zoom"
-msgstr "飞涨"
+msgstr "缩放"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom in"
@@ -5190,5 +5190,5 @@ msgstr "缩小"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "祖鲁语"
+msgstr "isiZulu"
 

--- a/apps/web/locales/zh-CN.po
+++ b/apps/web/locales/zh-CN.po
@@ -79,7 +79,7 @@ msgstr "{label} 在过去 30 天内"
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "<0>Finally,</0><1>A free and open-source resume builder</1>"
-msgstr "<0>终于，</0><1>一款免费、开源的简历生成器</1>"
+msgstr "<0>久等了，</0><1>一款免费、开源的简历生成器</1>"
 
 #: src/routes/_home/-sections/faq.tsx
 msgctxt "Home page FAQ section heading with each word visually separated into individual spans"
@@ -401,7 +401,7 @@ msgstr "还有更多…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "克劳德人类学"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "居中对齐"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "大脑"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "近距离人工智能助手"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "凝聚"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "降低缩放比例"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "深潜"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "芬兰语"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "烟花"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "谷歌"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "谷歌双子座"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "网格"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "格罗克"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "缺少工作简历"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "米斯特拉尔人工智能"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "奥里亚语"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "奥拉玛云"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3046,7 +3046,7 @@ msgstr "兼容 OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
-msgstr "开放路由器"
+msgstr "OpenRouter"
 
 #: src/features/resume/stylesheet/editor.tsx
 #: src/routes/_home/-sections/donate.tsx
@@ -3207,7 +3207,7 @@ msgstr "起止时间"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "困惑"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
@@ -4937,7 +4937,7 @@ msgstr "有效的 URL 必须以 http:// 或 https:// 开头。"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Vercel AI Gateway"
-msgstr "Vercel 人工智能网关"
+msgstr "Vercel AI Gateway"
 
 #: src/features/settings/pages/profile.tsx
 msgid "Verified"

--- a/apps/web/locales/zh-TW.po
+++ b/apps/web/locales/zh-TW.po
@@ -2377,7 +2377,7 @@ msgstr "增大縮放"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/locales/zh-TW.po
+++ b/apps/web/locales/zh-TW.po
@@ -401,7 +401,7 @@ msgstr "還有很多……"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Anthropic Claude"
-msgstr "克勞德人類"
+msgstr "Anthropic Claude"
 
 #: src/routes/dashboard/applications/index.tsx
 msgid "Any tag"
@@ -768,7 +768,7 @@ msgstr "置中對齊"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cerebras"
-msgstr "大腦"
+msgstr "Cerebras"
 
 #: src/dialogs/resume/sections/custom.tsx
 #: src/libs/resume/section-title.ts
@@ -876,7 +876,7 @@ msgstr "近距離人工智慧助手"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Cohere"
-msgstr "凝聚"
+msgstr "Cohere"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -1328,7 +1328,7 @@ msgstr "降低縮放比例"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
-msgstr "深潛"
+msgstr "DeepSeek"
 
 #: src/dialogs/resume/sections/education.tsx
 msgid "Degree"
@@ -1967,7 +1967,7 @@ msgstr "芬蘭語"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
-msgstr "煙火"
+msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
@@ -2142,7 +2142,7 @@ msgstr "Google"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Google Gemini"
-msgstr "Google 雙子星"
+msgstr "Google Gemini"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "gpt-4.1"
@@ -2162,7 +2162,7 @@ msgstr "網格"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Groq"
-msgstr "格羅克"
+msgstr "Groq"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Grow the Team"
@@ -2797,7 +2797,7 @@ msgstr "缺少工作履歷"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Mistral AI"
-msgstr "米斯特拉爾人工智慧"
+msgstr "Mistral AI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Model"
@@ -2981,7 +2981,7 @@ msgstr "歐利亞語"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
-msgstr "奧拉瑪雲"
+msgstr "Ollama Cloud"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "One-Click Sign-In"
@@ -3207,7 +3207,7 @@ msgstr "期間"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Perplexity"
-msgstr "困惑"
+msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"

--- a/apps/web/locales/zh-TW.po
+++ b/apps/web/locales/zh-TW.po
@@ -45,7 +45,7 @@ msgstr "{0, plural, other {# 個職位}}"
 #. placeholder {0}: insights.total
 #: src/features/applications/components/insights-view.tsx
 msgid "{0} applications tracked"
-msgstr "已追蹤 {0} 份申請"
+msgstr "已追蹤 {0} 個應徵紀錄"
 
 #. Character count readout for the rich-text editor
 #. placeholder {0}: state.characterCount
@@ -260,7 +260,7 @@ msgstr "新增標籤並按 Enter…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Add and test a provider before starting an agent thread."
-msgstr "在啟動代理線程之前，請新增並測試提供者。"
+msgstr "在啟動智慧代理對話之前，請新增並測試提供者。"
 
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/command-palette/pages/navigation.tsx
@@ -311,24 +311,24 @@ msgstr "調整履歷，使其更適合遠端優先、重視非同步溝通和自
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Advanced"
-msgstr "先進的"
+msgstr "進階"
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr "南非荷蘭語"
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Agent"
-msgstr "代理人"
+msgstr "智慧代理"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Agent ready"
-msgstr "代理已準備就緒"
+msgstr "智慧代理就緒"
 
 #: src/routes/dashboard/-components/sidebar.tsx
 msgid "Agents"
-msgstr "代理人"
+msgstr "智慧代理"
 
 #: src/dialogs/resume/import.tsx
 msgid "AI"
@@ -336,15 +336,15 @@ msgstr "AI"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "AI agent setup is unavailable right now. Please try again in a moment."
-msgstr "目前無法設定人工智慧代理，請稍後再試。"
+msgstr "目前無法設定 AI 智慧代理，請稍後再試。"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "AI agent setup is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
-msgstr "在配置 REDIS_URL 和 ENCRYPTION_SECRET 之前，AI 代理設定不可用。"
+msgstr "在配置 REDIS_URL 和 ENCRYPTION_SECRET 之前，AI 智慧代理設定不可用。"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "AI assistant"
-msgstr "人工智慧助手"
+msgstr "AI 助手"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "AI provider management is unavailable until REDIS_URL and ENCRYPTION_SECRET are configured."
@@ -364,7 +364,7 @@ msgstr "AI 供應商需要配置 REDIS_URL 和 ENCRYPTION_SECRET。"
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr "阿爾巴尼亞語"
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -376,7 +376,7 @@ msgstr "已有帳戶？<0/>"
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr "阿姆哈拉語"
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -447,7 +447,7 @@ msgstr "應用程式"
 
 #: src/features/applications/components/application-actions-menu.tsx
 msgid "Application actions"
-msgstr "應徵操作"
+msgstr "應徵紀錄操作"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application added to your pipeline."
@@ -455,7 +455,7 @@ msgstr "應徵紀錄已加入你的流程。"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "Application Copilot"
-msgstr "應徵 Copilot"
+msgstr "應徵紀錄 Copilot"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -464,7 +464,7 @@ msgstr "應徵紀錄已刪除。"
 
 #: src/routes/_home/-sections/statistics.tsx
 msgid "Application Statistics"
-msgstr "應用程式統計資料"
+msgstr "應徵紀錄統計資料"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Application updated."
@@ -479,11 +479,11 @@ msgstr "應徵紀錄"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications over time"
-msgstr "申請隨時間變化"
+msgstr "應徵紀錄隨時間變化"
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
-msgstr "每週送出的申請（最近 8 週）"
+msgstr "每週送出的應徵紀錄（最近 8 週）"
 
 #: src/features/applications/components/table-view.tsx
 #: src/features/resume/stylesheet/status.tsx
@@ -504,7 +504,7 @@ msgstr "附帶警告"
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr "阿拉伯文"
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -591,7 +591,7 @@ msgstr "附加文件"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment"
-msgstr "依戀"
+msgstr "附件"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Attachment uploaded."
@@ -628,7 +628,7 @@ msgstr "獎項"
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr "亞塞拜然語"
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -649,7 +649,7 @@ msgstr "備份代碼已複製到剪貼簿。"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Base URL"
-msgstr "基本 URL"
+msgstr "Base URL"
 
 #: src/libs/resume/section.tsx
 msgid "Basics"
@@ -657,11 +657,11 @@ msgstr "基本資料"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Beautiful templates to choose from, with more on the way."
-msgstr "提供多款精美範本供您選擇，並持續增加中。"
+msgstr "精美範本任您挑選，更多範本持續上新。"
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr "孟加拉語"
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -703,7 +703,7 @@ msgstr "編輯器指令選單"
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr "保加利亞語"
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -760,7 +760,7 @@ msgstr "無法恢復；簡歷自此編輯後已發生更改。"
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr "加泰隆尼亞語"
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -819,7 +819,7 @@ msgstr "檢查草稿"
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr "中文（簡體）"
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
@@ -841,7 +841,7 @@ msgstr "選擇一份履歷"
 
 #: src/routes/agent/index.tsx
 msgid "Choose an existing conversation from the sidebar, or start a new draft-focused thread."
-msgstr "從側邊欄選擇現有對話，或發起新的以草稿為中心的討論串。"
+msgstr "從側邊欄選擇現有對話，或開啟新的以草稿為中心的對話。"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/export.tsx
 msgid "Choose PDF, DOCX, Markdown, or JSON. Export your resume and cover letter separately when available."
@@ -969,7 +969,7 @@ msgstr "從上次中斷的地方繼續"
 
 #: src/dialogs/resume/import.tsx
 msgid "Continue where you left off by importing an existing resume you created using Reactive Resume or any another resume builder. Supported formats include PDF, Microsoft Word, as well as JSON files from Reactive Resume."
-msgstr "透過匯入您使用 Reactive Resume 或其他履歷建立工具建立的既有履歷，從上次中斷的地方繼續。支援的格式包括 PDF、Microsoft Word，以及來自 Reactive Resume 的 JSON 檔案。"
+msgstr "匯入您以 Reactive Resume 或其他履歷工具建立的既有履歷，即可從上次中斷的地方繼續。支援 PDF、Microsoft Word，以及 Reactive Resume 匯出的 JSON 檔案。"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Contributions fund bug fixes, security updates, and continuous improvements to keep the app running smoothly."
@@ -1179,11 +1179,11 @@ msgstr "建立新的專案"
 
 #: src/dialogs/resume/sections/publication.tsx
 msgid "Create a new publication"
-msgstr "建立新的出版品"
+msgstr "新增出版品"
 
 #: src/dialogs/resume/sections/reference.tsx
 msgid "Create a new reference"
-msgstr "建立新的推薦人"
+msgstr "新增推薦人"
 
 #: src/dialogs/resume/index.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -1278,7 +1278,7 @@ msgstr "自訂樣式"
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr "捷克語"
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1288,7 +1288,7 @@ msgstr "危險操作"
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr "丹麥語"
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1320,11 +1320,11 @@ msgstr "申請日期"
 
 #: src/components/input/rich-input.tsx
 msgid "Decrease indent"
-msgstr "減少縮排"
+msgstr "減小縮排"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "Decrease zoom"
-msgstr "降低縮放比例"
+msgstr "減小縮放"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "DeepSeek"
@@ -1374,12 +1374,12 @@ msgstr "刪除提供者"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Delete this agent thread?"
-msgstr "刪除此代理主題貼文？"
+msgstr "刪除此智慧代理對話？"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Delete this application?"
-msgstr "刪除此申請？"
+msgstr "刪除此應徵紀錄？"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Delete this timeline entry?"
@@ -1548,7 +1548,7 @@ msgstr "正在複製您的履歷…"
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr "荷蘭語"
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1666,11 +1666,11 @@ msgstr "啟用雙重認證…"
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr "英文"
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr "英語（英國）"
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1778,7 +1778,7 @@ msgstr "分析履歷失敗。"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to archive thread."
-msgstr "貼文歸檔失敗。"
+msgstr "對話歸檔失敗。"
 
 #. Fallback toast when creating an API key fails
 #: src/dialogs/api-key/create.tsx
@@ -1807,7 +1807,7 @@ msgstr "刪除 API 金鑰失敗。請再試一次。"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Failed to delete thread."
-msgstr "刪除線程失敗。"
+msgstr "對話刪除失敗。"
 
 #. Fallback toast when account deletion fails
 #: src/features/settings/pages/danger-zone.tsx
@@ -1861,7 +1861,7 @@ msgstr "重設密碼失敗。請再試一次。"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Failed to save AI provider."
-msgstr "保存人工智慧提供者失敗。"
+msgstr "儲存 AI 提供者失敗。"
 
 #. Fallback toast when requesting password reset email fails without backend message
 #: src/features/auth/pages/forgot-password.tsx
@@ -1886,7 +1886,7 @@ msgstr "登出失敗。請再試一次。"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Failed to start agent thread."
-msgstr "啟動代理線程失敗。"
+msgstr "啟動智慧代理對話失敗。"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Failed to start the AI assistant."
@@ -1963,7 +1963,7 @@ msgstr "找出薄弱的要點，用更強有力的結果、數字、範圍和更
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr "芬蘭語"
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -1971,7 +1971,7 @@ msgstr "Fireworks"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Fit to view"
-msgstr "適合觀看"
+msgstr "適應視圖"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Flexibility"
@@ -2053,7 +2053,7 @@ msgstr "自由形式"
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr "法文"
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2087,7 +2087,7 @@ msgstr "產生隨機名稱"
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr "德文"
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2095,7 +2095,7 @@ msgstr "獲得一份包含整體評分、優勢和可行建議的履歷檢閱。
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get an in-depth AI-powered review of your resume with an overall score, key strengths, and practical suggestions. To activate this feature, please update your AI settings."
-msgstr "獲得由 AI 驅動的深入履歷檢閱，包括整體評分、關鍵優勢和實用建議。若要啟動此功能，請更新您的 AI 設定。"
+msgstr "讓 AI 深入檢閱您的履歷，提供整體評分、核心優勢與實用建議。若要啟用此功能，請更新您的 AI 設定。"
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Get Started"
@@ -2116,7 +2116,7 @@ msgstr "返回"
 
 #: src/components/layout/not-found-screen.tsx
 msgid "Go home"
-msgstr "回家"
+msgstr "回到首頁"
 
 #: src/components/layout/error-screen.tsx
 #: src/components/layout/not-found-screen.tsx
@@ -2154,7 +2154,7 @@ msgstr "成績"
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr "希臘語"
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2171,7 +2171,7 @@ msgstr "擴大團隊"
 #: src/routes/builder/$resumeId/-sidebar/right/sections/typography.tsx
 msgctxt "Headings or Titles (H1, H2, H3, H4, H5, H6)"
 msgid "Heading"
-msgstr "標題文字"
+msgstr "標題"
 
 #: src/components/input/rich-input.tsx
 msgid "Heading 1"
@@ -2199,11 +2199,11 @@ msgstr "標題 6"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
 msgid "Headline"
-msgstr "標題"
+msgstr "職業頭銜"
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr "希伯來語"
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2282,7 +2282,7 @@ msgstr "高亮顏色"
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr "印地語"
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2306,7 +2306,7 @@ msgstr "https://gateway.example.com/v1"
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr "匈牙利語"
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2353,7 +2353,7 @@ msgstr "已匯入 {0} 個應徵紀錄。"
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing from PDF or Word requires a connected AI provider."
-msgstr "從 PDF 或 Word 匯入需要連接 AI 提供者。"
+msgstr "從 PDF 或 Word 匯入需要串接 AI 提供者。"
 
 #: src/dialogs/resume/import.tsx
 msgid "Importing your resume..."
@@ -2373,11 +2373,11 @@ msgstr "增加縮排"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "Increase zoom"
-msgstr "放大"
+msgstr "增大縮放"
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "印尼語"
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2425,7 +2425,7 @@ msgstr "發行者"
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr "義大利語"
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2433,7 +2433,7 @@ msgstr "斜體"
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr "日文"
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2491,12 +2491,12 @@ msgstr "左右對齊"
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr "卡納達語"
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
 msgid "Keep together"
-msgstr "保持團結"
+msgstr "保持同頁"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Key"
@@ -2509,11 +2509,11 @@ msgstr "關鍵詞"
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr "高棉語"
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr "韓文"
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2571,7 +2571,7 @@ msgstr "上次檢視日期：{0}"
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr "拉脫維亞語"
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2587,7 +2587,7 @@ msgstr "離開"
 
 #: src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
 msgid "Leave empty to reset the title to the original."
-msgstr "留空則會將標題重設為原始值。"
+msgstr "留空可恢復為原始標題。"
 
 #: src/components/input/rich-input.tsx
 msgid "Left Align"
@@ -2674,7 +2674,7 @@ msgstr "列表"
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr "立陶宛語"
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2682,7 +2682,7 @@ msgstr "正在加載人工智慧提供者。請稍後再試。"
 
 #: src/features/command-palette/pages/resumes.tsx
 msgid "Loading applications…"
-msgstr "正在載入應用程式…"
+msgstr "正在載入應徵紀錄…"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/routes/agent/-components/new-thread-setup.tsx
@@ -2697,7 +2697,7 @@ msgstr "正在恢復載入…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Loading threads…"
-msgstr "正在載入線程…"
+msgstr "正在載入對話…"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Loading…"
@@ -2754,15 +2754,15 @@ msgstr "讓工作經歷部分更注重結果導向，並刪除模糊的職責說
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr "馬來語"
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr "馬拉雅拉姆語"
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr "馬拉提語"
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2829,7 +2829,7 @@ msgstr "多語系"
 #. Placeholder text for custom link URL field in resume builder
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom-fields.tsx
 msgid "Must start with https://"
-msgstr "必須從 https:// 開始"
+msgstr "必須以 https:// 開頭"
 
 #. Label for full name input on registration form
 #: src/dialogs/api-key/create.tsx
@@ -2848,7 +2848,7 @@ msgstr "名稱"
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr "尼泊爾語"
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2857,7 +2857,7 @@ msgstr "網路"
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Application"
-msgstr "新申請"
+msgstr "新增應徵紀錄"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "New features are constantly being added and improved, so be sure to check back often."
@@ -2889,12 +2889,12 @@ msgstr "新標籤…"
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "New thread"
-msgstr "新帖"
+msgstr "新對話"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 msgid "New Thread"
-msgstr "新帖"
+msgstr "新對話"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "No Advertising, No Tracking"
@@ -2956,11 +2956,11 @@ msgstr "沒有經過測試的提供者"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "No threads yet."
-msgstr "暫無主題。"
+msgstr "暫無對話。"
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr "挪威語"
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2977,7 +2977,7 @@ msgstr "注意事項"
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr "歐利亞語"
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3009,7 +3009,7 @@ msgstr "開啟"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Open AI agent"
-msgstr "OpenAI代理"
+msgstr "開啟 AI 智慧代理"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Open AI assistant"
@@ -3042,7 +3042,7 @@ msgstr "OpenAI"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenAI-compatible"
-msgstr "相容 OpenAI"
+msgstr "OpenAI-compatible"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "OpenRouter"
@@ -3211,11 +3211,11 @@ msgstr "Perplexity"
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr "波斯語"
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
-msgstr "利用顏色、字體或設計來個人化您的履歷，打造獨一無二的風格。"
+msgstr "用任何顏色、字體或設計個人化您的履歷，打造出專屬於您的版本。"
 
 #: src/dialogs/resume/sections/reference.tsx
 #: src/routes/builder/$resumeId/-sidebar/left/sections/basics.tsx
@@ -3272,7 +3272,7 @@ msgstr "請稍候，您的PDF檔案正在產生中…"
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr "波蘭語"
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3281,11 +3281,11 @@ msgstr "直向"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr "葡萄牙語（巴西）"
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr "葡萄牙語（葡萄牙）"
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3301,7 +3301,7 @@ msgstr "偏好設定"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Prepare a conservative patch that improves clarity without changing my career narrative."
-msgstr "準備一個保守的補丁，在不改變我的職業發展軌蹟的前提下，提高清晰度。"
+msgstr "在不改動職涯經歷的前提下，準備一份保守的潤色補丁，以提升表述清晰度。"
 
 #: src/features/resume/export/use-resume-export.ts
 msgid "Preparing your resume for printing..."
@@ -3399,7 +3399,7 @@ msgstr "Reactive Resume - 前往首頁"
 #. Import source option for current Reactive Resume JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume (JSON)"
-msgstr "反應式履歷 (JSON)"
+msgstr "Reactive Resume (JSON)"
 
 #: src/routes/_home/-sections/prefooter.tsx
 msgid "Reactive Resume continues to grow thanks to its vibrant community. This project owes its progress to numerous individuals who've dedicated their time and skills to make it better. We celebrate the coders who've enhanced its features on GitHub, the linguists whose translations on Crowdin have made it accessible to a broader audience, and the people who've donated to support its continued development."
@@ -3433,7 +3433,7 @@ msgstr "響應式恢復 v<0>{__APP_VERSION__}</0>"
 #. Import source option for legacy Reactive Resume v4 JSON format
 #: src/dialogs/resume/import.tsx
 msgid "Reactive Resume v4 (JSON)"
-msgstr "反應式履歷 v4 (JSON)"
+msgstr "Reactive Resume v4 (JSON)"
 
 #: src/features/resume/stylesheet/editor.tsx
 msgid "Read the Applying Custom Styles guide."
@@ -3681,7 +3681,7 @@ msgstr "職位晉升"
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr "羅馬尼亞語"
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3701,7 +3701,7 @@ msgstr "執行您的第一次分析，以獲得計分卡、優勢和優先建議
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr "俄文"
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3846,7 +3846,7 @@ msgstr "選擇一份履歷"
 
 #: src/routes/agent/index.tsx
 msgid "Select a thread"
-msgstr "選擇一個線程"
+msgstr "選擇對話"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Select all"
@@ -3854,7 +3854,7 @@ msgstr "全選"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Select an agent model"
-msgstr "選擇代理模型"
+msgstr "選擇智慧代理模型"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Select an AI provider"
@@ -3899,7 +3899,7 @@ msgstr "分隔線"
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr "塞爾維亞語"
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3916,7 +3916,7 @@ msgstr "建立人工智慧提供者"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Set up an AI provider before starting a thread."
-msgstr "在發起討論之前，請先設定好人工智慧提供者。"
+msgstr "在開啟對話之前，請先設定好人工智慧提供者。"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "Set up an AI provider to chat about this resume and apply edits automatically."
@@ -4098,11 +4098,11 @@ msgstr "跳至主要內容"
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr "斯洛伐克語"
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr "斯洛維尼亞語"
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4153,7 +4153,7 @@ msgstr "間距（垂直）"
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr "西班牙語"
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4189,11 +4189,11 @@ msgstr "在 GitHub 上為我們加星，目前有 {0} 顆星（在新分頁中�
 
 #: src/routes/agent/$threadId.tsx
 msgid "Start a new thread"
-msgstr "另開一個帖子"
+msgstr "開啟新對話"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start a thread"
-msgstr "發起一個話題"
+msgstr "開啟對話"
 
 #: src/dialogs/resume/index.tsx
 msgid "Start building your resume by giving it a name."
@@ -4206,7 +4206,7 @@ msgstr "從零開始建立您的履歷"
 
 #: src/routes/agent/index.tsx
 msgid "Start new thread"
-msgstr "另開新帖"
+msgstr "開啟新對話"
 
 #. Layout editor toggle that forces a section to begin on a new page
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -4215,7 +4215,7 @@ msgstr "在新頁面開始"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Start Thread"
-msgstr "發起討論"
+msgstr "開啟對話"
 
 #: src/libs/resume/section.tsx
 msgid "Statistics"
@@ -4223,7 +4223,7 @@ msgstr "統計資料"
 
 #: src/hooks/use-form-blocker.tsx
 msgid "Stay"
-msgstr "留下"
+msgstr "留在本頁"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Stop generation"
@@ -4276,7 +4276,7 @@ msgstr "盡您所能支持此應用程式！"
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr "瑞典語"
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4323,11 +4323,11 @@ msgstr "調整失敗。"
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr "泰米爾語"
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr "泰盧固語"
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4364,7 +4364,7 @@ msgstr "字型色彩"
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr "泰文"
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4372,7 +4372,7 @@ msgstr "感謝我們的贊助商"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "The agent needs your input."
-msgstr "經紀人需要您的意見。"
+msgstr "智慧代理需要你的輸入。"
 
 #. Error description when AI returns invalid resume analysis format
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
@@ -4419,7 +4419,7 @@ msgstr "您輸入的 URL 無效。"
 
 #: src/routes/agent/-components/resume-pane.tsx
 msgid "The working resume was deleted. This thread is read-only."
-msgstr "工作簡歷已被刪除。此帖為唯讀模式。"
+msgstr "工作簡歷已被刪除。此對話為唯讀。"
 
 #. Menu item that opens appearance theme selection submenu
 #: src/features/command-palette/pages/preferences/theme.tsx
@@ -4460,7 +4460,7 @@ msgstr "此動作無法復原。您的所有資料都將被永久刪除。"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This action cannot be undone. Conversation messages and uploaded attachments will be removed. The working resume remains in your dashboard and can be deleted separately."
-msgstr "此操作無法撤銷。對話訊息和上傳的附件將被刪除。正在編輯的簡歷仍保留在您的控制面板中，您可以單獨將其刪除。"
+msgstr "此操作無法撤銷。對話訊息和上傳的附件將被刪除。工作履歷仍保留在您的儀表板中，可單獨刪除。"
 
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "This action cannot be undone. Messages and thread attachments will be removed."
@@ -4468,7 +4468,7 @@ msgstr "此操作無法撤銷。訊息和對話附件將被刪除。"
 
 #: src/routes/agent/$threadId.tsx
 msgid "This agent thread could not be opened."
-msgstr "此代理線程無法開啟。"
+msgstr "無法開啟此智慧代理對話。"
 
 #: src/routes/builder/$resumeId/-components/ai-assistant.tsx
 msgid "This assistant could not be opened."
@@ -4504,7 +4504,7 @@ msgstr "這份履歷已被鎖定，無法更新。"
 
 #: src/features/resume/builder/draft.ts
 msgid "This resume was updated by an AI agent."
-msgstr "這份履歷由人工智慧代理更新。"
+msgstr "此履歷已由 AI 智慧代理更新。"
 
 #: src/features/resume/builder/draft.ts
 msgid "This resume's sharing settings changed elsewhere."
@@ -4520,15 +4520,15 @@ msgstr "此步驟為選填，但建議您完成。"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is archived. New messages cannot be sent."
-msgstr "此貼文已存檔，無法傳送新訊息。"
+msgstr "此對話已存檔，無法傳送新訊息。"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only"
-msgstr "此帖為唯讀帖。"
+msgstr "此對話為唯讀"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "This thread is read-only because the working resume or AI provider is unavailable."
-msgstr "由於履歷撰寫或人工智慧服務提供者無法使用，此貼文為唯讀模式。"
+msgstr "由於履歷撰寫或人工智慧服務提供者無法使用，此對話為唯讀。"
 
 #: src/dialogs/api-key/create.tsx
 msgid "This will generate a new API key to access the Reactive Resume API to allow machines to interact with your resume data."
@@ -4545,26 +4545,26 @@ msgstr "這將移除此區中的所有項目。"
 #: src/routes/agent/-components/agent-chat.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 msgid "Thread actions"
-msgstr "執行緒操作"
+msgstr "對話操作"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread archived."
-msgstr "貼文已存檔。"
+msgstr "對話已存檔。"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Thread deleted."
-msgstr "帖子已刪除。"
+msgstr "對話已刪除。"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
 #: src/routes/agent/-components/thread-sidebar.tsx
 #: src/routes/agent/$threadId.tsx
 msgid "Threads"
-msgstr "執行緒"
+msgstr "對話"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Tighten the skills section so it supports the target role instead of reading like a keyword dump."
-msgstr "精簡技能部分，使其能夠支援目標職位，而不是像關鍵字堆砌一樣。"
+msgstr "精簡技能區塊，讓技能真正支撐目標職位，而不是關鍵字堆砌。"
 
 #: src/routes/_home/-sections/hero.tsx
 msgid "Timelapse demonstration of building a resume with Reactive Resume"
@@ -4622,7 +4622,7 @@ msgstr "切換右側邊欄"
 
 #: src/routes/agent/-components/agent-chat.tsx
 msgid "Toggle threads"
-msgstr "切換線程"
+msgstr "切換對話"
 
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Track a job you're applying to and link the resume you sent."
@@ -4647,7 +4647,7 @@ msgstr "再試一次"
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr "土耳其語"
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4728,7 +4728,7 @@ msgstr "字體樣式"
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr "烏克蘭語"
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4750,7 +4750,7 @@ msgstr "撤銷樣式表編輯"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Unlimited Resumes"
-msgstr "無限履歷"
+msgstr "履歷份數不限"
 
 #: src/features/settings/authentication/components/hooks.tsx
 msgid "Unlinking your {providerName} account..."
@@ -4929,7 +4929,7 @@ msgstr "使用者"
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr "烏茲別克語"
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4979,7 +4979,7 @@ msgstr "版本歷史記錄"
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr "越南語"
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5173,7 +5173,7 @@ msgstr "您的支持能確保此專案現在與未來都能持續免費、並讓
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Zoom"
-msgstr "飛漲"
+msgstr "縮放"
 
 #: src/routes/builder/$resumeId/-components/dock.tsx
 msgid "Zoom in"
@@ -5190,5 +5190,5 @@ msgstr "縮小"
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr "祖魯語"
+msgstr "isiZulu"
 

--- a/apps/web/locales/zu-ZA.po
+++ b/apps/web/locales/zu-ZA.po
@@ -310,7 +310,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Afrikaans"
-msgstr ""
+msgstr "Afrikaans"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/features/command-palette/pages/resumes.tsx
@@ -359,7 +359,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Albanian"
-msgstr ""
+msgstr "Shqip"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
@@ -371,7 +371,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Amharic"
-msgstr ""
+msgstr "አማርኛ"
 
 #: src/components/layout/error-screen.tsx
 msgid "An unexpected error stopped this page from loading. You can try again or head back."
@@ -499,7 +499,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Arabic"
-msgstr ""
+msgstr "العربية"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -623,7 +623,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Azerbaijani"
-msgstr ""
+msgstr "Azərbaycanca"
 
 #. Secondary navigation button on 2FA verification screen
 #: src/features/auth/pages/verify-2fa.tsx
@@ -656,7 +656,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Bengali"
-msgstr ""
+msgstr "বাংলা"
 
 #: src/features/resume/export/download-dialog.tsx
 msgid "Best for applications, sharing, and printing."
@@ -698,7 +698,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Bulgarian"
-msgstr ""
+msgstr "Български"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Bulk delete failed. Please try again."
@@ -755,7 +755,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Catalan"
-msgstr ""
+msgstr "Català"
 
 #: src/components/input/rich-input.tsx
 msgid "Center Align"
@@ -814,11 +814,11 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Chinese (Simplified)"
-msgstr ""
+msgstr "中文（简体）"
 
 #: src/libs/locale.ts
 msgid "Chinese (Traditional)"
-msgstr ""
+msgstr "中文（繁體）"
 
 #: src/routes/agent/-components/new-thread-setup.tsx
 msgid "Choose a model and resume draft."
@@ -1273,7 +1273,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Czech"
-msgstr ""
+msgstr "Čeština"
 
 #: src/features/command-palette/pages/navigation.tsx
 #: src/routes/dashboard/-components/sidebar.tsx
@@ -1283,7 +1283,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Danish"
-msgstr ""
+msgstr "Dansk"
 
 #. Appearance theme option for dark mode
 #: src/features/user/dropdown-menu.tsx
@@ -1543,7 +1543,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Dutch"
-msgstr ""
+msgstr "Nederlands"
 
 #: src/routes/builder/$resumeId/-components/version-history.tsx
 msgid "Earlier versions are kept; the builder's undo history is reset."
@@ -1661,11 +1661,11 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "English"
-msgstr ""
+msgstr "English"
 
 #: src/libs/locale.ts
 msgid "English (United Kingdom)"
-msgstr ""
+msgstr "English (UK)"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Enhance the security of your account with additional layers of protection."
@@ -1958,7 +1958,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Finnish"
-msgstr ""
+msgstr "Suomi"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Fireworks"
@@ -2048,7 +2048,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "French"
-msgstr ""
+msgstr "Français"
 
 #: src/features/applications/components/application-ai-copilot.tsx
 msgid "From your resume and the posting"
@@ -2082,7 +2082,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "German"
-msgstr ""
+msgstr "Deutsch"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/resume-analysis.tsx
 msgid "Get a review of your resume with an overall score, strengths, and actionable suggestions."
@@ -2149,7 +2149,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Greek"
-msgstr ""
+msgstr "Ελληνικά"
 
 #: src/routes/dashboard/resumes/index.tsx
 msgid "Grid"
@@ -2198,7 +2198,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Hebrew"
-msgstr ""
+msgstr "עברית"
 
 #: src/routes/_home/-sections/donate.tsx
 msgid "Help me bring more experienced contributors on board, reducing the burden on a single maintainer and accelerating development."
@@ -2277,7 +2277,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Hindi"
-msgstr ""
+msgstr "हिन्दी"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Home"
@@ -2301,7 +2301,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Hungarian"
-msgstr ""
+msgstr "Magyar"
 
 #: src/components/level/combobox.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx
@@ -2372,7 +2372,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr ""
+msgstr "Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"
@@ -2420,7 +2420,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Italian"
-msgstr ""
+msgstr "Italiano"
 
 #: src/components/input/rich-input.tsx
 msgid "Italic"
@@ -2428,7 +2428,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Japanese"
-msgstr ""
+msgstr "日本語"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Job"
@@ -2486,7 +2486,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Kannada"
-msgstr ""
+msgstr "ಕನ್ನಡ"
 
 #. Layout editor toggle that prevents a section from splitting across pages
 #: src/routes/builder/$resumeId/-sidebar/right/sections/layout/pages.tsx
@@ -2504,11 +2504,11 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Khmer"
-msgstr ""
+msgstr "ខ្មែរ"
 
 #: src/libs/locale.ts
 msgid "Korean"
-msgstr ""
+msgstr "한국어"
 
 #. Short field label for custom display text associated with a URL
 #: src/components/input/url-input.tsx
@@ -2566,7 +2566,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Latvian"
-msgstr ""
+msgstr "Latviešu"
 
 #: src/libs/resume/section.tsx
 msgid "Layout"
@@ -2669,7 +2669,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Lithuanian"
-msgstr ""
+msgstr "Lietuvių"
 
 #: src/dialogs/resume/import.tsx
 msgid "Loading AI providers. Please try again in a moment."
@@ -2749,15 +2749,15 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Malay"
-msgstr ""
+msgstr "Bahasa Melayu"
 
 #: src/libs/locale.ts
 msgid "Malayalam"
-msgstr ""
+msgstr "മലയാളം"
 
 #: src/libs/locale.ts
 msgid "Marathi"
-msgstr ""
+msgstr "मराठी"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/page.tsx
 msgid "Margin (Horizontal)"
@@ -2843,7 +2843,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Nepali"
-msgstr ""
+msgstr "नेपाली"
 
 #: src/dialogs/resume/sections/profile.tsx
 msgid "Network"
@@ -2955,7 +2955,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Norwegian"
-msgstr ""
+msgstr "Norsk"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Not connected"
@@ -2972,7 +2972,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Odia"
-msgstr ""
+msgstr "ଓଡ଼ିଆ"
 
 #: src/features/settings/integrations/components/ai-section.tsx
 msgid "Ollama Cloud"
@@ -3206,7 +3206,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Persian"
-msgstr ""
+msgstr "فارسی"
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Personalize your resume with any colors, fonts or designs, and make it your own."
@@ -3267,7 +3267,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Polish"
-msgstr ""
+msgstr "Polski"
 
 #. Preset button for setting picture aspect ratio to portrait orientation
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -3276,11 +3276,11 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Portuguese (Brazil)"
-msgstr ""
+msgstr "Português (Brasil)"
 
 #: src/libs/locale.ts
 msgid "Portuguese (Portugal)"
-msgstr ""
+msgstr "Português (Portugal)"
 
 #: src/dialogs/resume/sections/experience.tsx
 #: src/dialogs/resume/sections/reference.tsx
@@ -3676,7 +3676,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Romanian"
-msgstr ""
+msgstr "Română"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Rotation"
@@ -3696,7 +3696,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Russian"
-msgstr ""
+msgstr "Русский"
 
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/table-view.tsx
@@ -3894,7 +3894,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Serbian"
-msgstr ""
+msgstr "Српски"
 
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -4093,11 +4093,11 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Slovak"
-msgstr ""
+msgstr "Slovenčina"
 
 #: src/libs/locale.ts
 msgid "Slovenian"
-msgstr ""
+msgstr "Slovenščina"
 
 #: src/dialogs/resume/index.tsx
 msgid "Slug"
@@ -4148,7 +4148,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Spanish"
-msgstr ""
+msgstr "Español"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/information.tsx
 msgid "Sponsors"
@@ -4271,7 +4271,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Swedish"
-msgstr ""
+msgstr "Svenska"
 
 #: src/features/theme/toggle-button.tsx
 msgid "Switch to dark theme"
@@ -4318,11 +4318,11 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Tamil"
-msgstr ""
+msgstr "தமிழ்"
 
 #: src/libs/locale.ts
 msgid "Telugu"
-msgstr ""
+msgstr "తెలుగు"
 
 #: src/libs/resume/section.tsx
 msgid "Template"
@@ -4359,7 +4359,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Thai"
-msgstr ""
+msgstr "ไทย"
 
 #: src/routes/_home/-sections/sponsors.tsx
 msgid "Thank you to our sponsors"
@@ -4642,7 +4642,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Turkish"
-msgstr ""
+msgstr "Türkçe"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Turn on public sharing to track how many times your resume has been viewed or downloaded. Only you can see your resume's statistics."
@@ -4723,7 +4723,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Ukrainian"
-msgstr ""
+msgstr "Українська"
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
@@ -4924,7 +4924,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Uzbek"
-msgstr ""
+msgstr "Oʻzbekcha"
 
 #: src/components/input/rich-input.tsx
 msgid "Valid URLs must start with http:// or https://."
@@ -4974,7 +4974,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Vietnamese"
-msgstr ""
+msgstr "Tiếng Việt"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/statistics.tsx
 msgid "Views"
@@ -5185,4 +5185,4 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Zulu"
-msgstr ""
+msgstr "isiZulu"

--- a/apps/web/locales/zu-ZA.po
+++ b/apps/web/locales/zu-ZA.po
@@ -2372,7 +2372,7 @@ msgstr ""
 
 #: src/libs/locale.ts
 msgid "Indonesian"
-msgstr "Indonesia"
+msgstr "Bahasa Indonesia"
 
 #: src/libs/resume/section.tsx
 msgid "Information"

--- a/apps/web/src/libs/locale.test.ts
+++ b/apps/web/src/libs/locale.test.ts
@@ -2,10 +2,18 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import Cookies from "js-cookie";
-import { changeLocale, formatRelativeTime, isLocale, resolveLocale } from "./locale";
+import {
+	applyAutoDetectedLocale,
+	changeLocale,
+	formatRelativeTime,
+	getBrowserLocale,
+	isLocale,
+	resolveLocale,
+} from "./locale";
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
 	vi.useRealTimers();
 	Cookies.remove("locale");
 });
@@ -76,6 +84,84 @@ describe("changeLocale", () => {
 		const reload = vi.spyOn(window.location, "reload").mockImplementation(() => undefined);
 
 		changeLocale("de-DE");
+
+		expect(Cookies.get("locale")).toBe("de-DE");
+		expect(reload).toHaveBeenCalledOnce();
+	});
+});
+
+describe("getBrowserLocale", () => {
+	it("returns the exact supported locale when the tag matches", () => {
+		expect(getBrowserLocale(["zh-CN"])).toBe("zh-CN");
+		expect(getBrowserLocale(["en-GB"])).toBe("en-GB");
+		expect(getBrowserLocale(["pt-BR"])).toBe("pt-BR");
+	});
+
+	it("matches case-insensitively and normalizes underscores", () => {
+		expect(getBrowserLocale(["zh-cn"])).toBe("zh-CN");
+		expect(getBrowserLocale(["ZH_CN"])).toBe("zh-CN");
+	});
+
+	it("resolves a bare language subtag to its regional variant", () => {
+		expect(getBrowserLocale(["de"])).toBe("de-DE");
+		expect(getBrowserLocale(["ja"])).toBe("ja-JP");
+		expect(getBrowserLocale(["fr"])).toBe("fr-FR");
+	});
+
+	it("prefers the canonical regional variant for ambiguous subtags", () => {
+		expect(getBrowserLocale(["en"])).toBe("en-US");
+		expect(getBrowserLocale(["zh"])).toBe("zh-CN");
+		expect(getBrowserLocale(["pt"])).toBe("pt-BR");
+	});
+
+	it("honors the first matching entry in the preference order", () => {
+		expect(getBrowserLocale(["xx-YY", "fr-FR", "de"])).toBe("fr-FR");
+		expect(getBrowserLocale(["en", "de-DE"])).toBe("en-US");
+	});
+
+	it("falls back to English for unsupported or empty languages", () => {
+		expect(getBrowserLocale(["xx-YY"])).toBe("en-US");
+		expect(getBrowserLocale([""])).toBe("en-US");
+		expect(getBrowserLocale([])).toBe("en-US");
+	});
+});
+
+describe("applyAutoDetectedLocale", () => {
+	it("respects an existing stored locale preference", () => {
+		Cookies.set("locale", "de-DE");
+		const reload = vi.spyOn(window.location, "reload").mockImplementation(() => undefined);
+
+		applyAutoDetectedLocale();
+
+		expect(Cookies.get("locale")).toBe("de-DE");
+		expect(reload).not.toHaveBeenCalled();
+	});
+
+	it("persists the detected locale and reloads when it differs from the default", () => {
+		vi.stubGlobal("navigator", { language: "zh-CN", languages: ["zh-CN"] });
+		const reload = vi.spyOn(window.location, "reload").mockImplementation(() => undefined);
+
+		applyAutoDetectedLocale();
+
+		expect(Cookies.get("locale")).toBe("zh-CN");
+		expect(reload).toHaveBeenCalledOnce();
+	});
+
+	it("skips reloading when the detected locale is the English default", () => {
+		vi.stubGlobal("navigator", { language: "en-US", languages: ["en-US"] });
+		const reload = vi.spyOn(window.location, "reload").mockImplementation(() => undefined);
+
+		applyAutoDetectedLocale();
+
+		expect(Cookies.get("locale")).toBeUndefined();
+		expect(reload).not.toHaveBeenCalled();
+	});
+
+	it("falls back to navigator.language when the languages list is empty", () => {
+		vi.stubGlobal("navigator", { language: "de", languages: [] });
+		const reload = vi.spyOn(window.location, "reload").mockImplementation(() => undefined);
+
+		applyAutoDetectedLocale();
 
 		expect(Cookies.get("locale")).toBe("de-DE");
 		expect(reload).toHaveBeenCalledOnce();

--- a/apps/web/src/libs/locale.ts
+++ b/apps/web/src/libs/locale.ts
@@ -93,9 +93,12 @@ const regionalDefaultLocale: Partial<Record<string, Locale>> = {
 
 const localeBySubtag = new Map<string, Locale>();
 
+// First declaration wins so a bare subtag resolves to the first-listed regional
+// variant ("en" → "en-US", "pt" → "pt-BR", "zh" → "zh-CN"), consistent with
+// regionalDefaultLocale; a later duplicate never silently overrides it.
 for (const locale of localeSchema.options) {
 	const subtag = locale.split("-")[0];
-	if (subtag) localeBySubtag.set(subtag.toLowerCase(), locale);
+	if (subtag && !localeBySubtag.has(subtag.toLowerCase())) localeBySubtag.set(subtag.toLowerCase(), locale);
 }
 
 // Resolves the first supported locale from a browser language list, falling back

--- a/apps/web/src/libs/locale.ts
+++ b/apps/web/src/libs/locale.ts
@@ -85,6 +85,43 @@ export const resolveLocale = (locale: string): Locale => {
 	return isLocale(locale) ? locale : defaultLocale;
 };
 
+const regionalDefaultLocale: Partial<Record<string, Locale>> = {
+	en: "en-US",
+	pt: "pt-BR",
+	zh: "zh-CN",
+};
+
+const localeBySubtag = new Map<string, Locale>();
+
+for (const locale of localeSchema.options) {
+	const subtag = locale.split("-")[0];
+	if (subtag) localeBySubtag.set(subtag.toLowerCase(), locale);
+}
+
+// Resolves the first supported locale from a browser language list, falling back
+// to the default when nothing matches. Exact tags win; bare subtags map to their
+// canonical regional variant (e.g. "de" → "de-DE", "zh" → "zh-CN").
+export const getBrowserLocale = (languages: readonly string[]): Locale => {
+	for (const language of languages) {
+		const normalized = language.trim().replaceAll("_", "-");
+		if (!normalized) continue;
+
+		const exactMatch = localeSchema.options.find((candidate) => candidate.toLowerCase() === normalized.toLowerCase());
+		if (exactMatch) return exactMatch;
+
+		const subtag = normalized.split("-")[0]?.toLowerCase();
+		if (!subtag) continue;
+
+		const regionalDefault = regionalDefaultLocale[subtag];
+		if (regionalDefault) return regionalDefault;
+
+		const subtagMatch = localeBySubtag.get(subtag);
+		if (subtagMatch) return subtagMatch;
+	}
+
+	return defaultLocale;
+};
+
 export function formatRelativeTime(value: Date | string, formatter: Intl.RelativeTimeFormat, invalidFallback?: string) {
 	const date = value instanceof Date ? value : new Date(value);
 	const diffMs = date.getTime() - Date.now();
@@ -134,4 +171,17 @@ export const changeLocale = (value: string | null) => {
 	if (!value || !isLocale(value)) return;
 	Cookies.set(storageKey, value);
 	window.location.reload();
+};
+
+// Applies the browser-detected language once when no preference is stored, so
+// returning visitors keep their manual choice. Mirrors changeLocale by persisting
+// the cookie and reloading; skipped when detection yields the English default.
+export const applyAutoDetectedLocale = () => {
+	if (typeof navigator === "undefined") return;
+	if (Cookies.get(storageKey)) return;
+
+	const languages = navigator.languages.length > 0 ? navigator.languages : [navigator.language];
+	const detectedLocale = getBrowserLocale(languages);
+
+	if (detectedLocale !== defaultLocale) changeLocale(detectedLocale);
 };

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -27,7 +27,7 @@ import { ThemeProvider } from "@/features/theme/provider";
 import { ConfirmDialogProvider } from "@/hooks/use-confirm";
 import { PromptDialogProvider } from "@/hooks/use-prompt";
 import { getSession } from "@/libs/auth/session";
-import { getLocale, isRTL, loadLocale } from "@/libs/locale";
+import { applyAutoDetectedLocale, getLocale, isRTL, loadLocale } from "@/libs/locale";
 import { client } from "@/libs/orpc/client";
 import { getTheme } from "@/libs/theme";
 
@@ -113,6 +113,11 @@ function RootComponent() {
 		document.documentElement.dir = dir;
 		document.documentElement.classList.toggle("dark", theme === "dark");
 	}, [dir, locale, theme]);
+
+	// Detect the browser language once on first visit; changeLocale persists the choice and reloads.
+	useEffect(() => {
+		applyAutoDetectedLocale();
+	}, []);
 
 	return (
 		<>


### PR DESCRIPTION
## Summary

Two related improvements: a better first-visit experience, and a translation-quality overhaul across all 55 locale catalogs.

### 1. Auto-detect browser locale on first visit

- When no stored preference exists, the app now picks the user's browser language instead of defaulting to English. Exact tags win; bare subtags map to their canonical regional variant (`de` → `de-DE`, `zh` → `zh-CN`). The choice is persisted, so returning visitors keep their manual selection.

### 2. Keep AI provider names untranslated

- Provider option labels are product proper nouns and were machine-translated in up to 52 locales ("Anthropic Claude" → 克劳德人类学, "Cohere" → 凝聚, "Fireworks" → 烟花, "Google Gemini" → 谷歌双子座…). All catalogs now show the original English names.

### 3. Professional terms and proper nouns

- **AI-domain terminology**: `agent` → 智能体 / 智慧代理 / 에이전트 (was 代理人, 经纪人, 대리인, 상담원…); `thread` → 会话 / 對話 / 스레드 (was 线程, 帖子, 실, 게시글 — OS-thread / forum-post / yarn mistranslations); `Advanced` → 高级 / 進階 / 고급; `application` (job tracker) → 求职申请 / 應徵紀錄 / 지원, consistently.
- **Brand / technical terms left untranslated**: "Reactive Resume (JSON)" / "Reactive Resume v4 (JSON)" (was 反应式简历, Reaktiver Lebenslauf, Currículo reativo…), "OpenAI-compatible", "Base URL" (zh), "AI" (zh 人工智能 → AI).
- **Per-language vocabulary consistency**: one dashboard term per language (zh 控制面板 → 仪表板, ko 계기반 → 대시보드, de Armaturenbrett → Dashboard, it/pl/tr/hu unified); unified zoom vocabulary (缩放 / 放大 / 缩小 / 增大缩放 / 减小缩放); `Headline` now distinct from `Heading` in CJK.

### 4. Localization (natural phrasing)

- **Homepage hero "Finally,"**: zh-CN `终于` → `久等了`, ko-KR `마침내` → `드디어` (ja-JP already idiomatic, kept).
- **Absurd literal translations fixed in every affected language**: `Zoom` (飞涨 "skyrocket" → 缩放), `Keep together` (保持团结 "stay united" → 保持同页), `Go home` (回家 → 回到首页), `Fit to view` (适合观看 → 适应视图), `Stay` (留下 → 留在本页), `Clear` (清晰 → 清除), `Attachment` (依恋 → 附件), `By the community, for the community.` (由社群贡献 → 来自社区，服务社区).
- **Natural rewrites of long marketing / AI-assistant strings** in zh-CN, zh-TW, ko-KR, ja-JP, and the other 48 locales (import flow copy, feature descriptions, AI copilot prompts…).

### 5. Endonym language names

- The locale switcher now shows each language in its own name (English, Deutsch, Français, 中文（简体）, 한국어…) in every UI language, instead of translated names (英语, 德语, 南非语…), so the switcher stays readable regardless of UI language.

## Verification

- All 55 catalogs parse with the project's own formatter (`@lingui/format-po`).
- 69 agent/thread/application/Advanced msgids plus 51 additionally flagged msgids are present and correct in every catalog.
- Provider brand labels and the two API-key strings whose "applications" means developer software were intentionally left untouched.
- `git diff --check` clean; only catalog files (and the locale-detection feature's web source) changed.

## Notes

- **Not applied on Crowdin**: the account used for the sync attempt (`excnies`) has translator-level access to the Reactive Resume project, and Crowdin restricts translation uploads to project managers/owners (API returned `403 Forbidden`; the translator web UI exposes no upload entry either). The corrections have not been pushed to Crowdin. If desired, a project manager (e.g. AmruthPillai) or an account with upload permission can apply them on Crowdin — especially the language-name endonyms, which should not be translated.
- Note: `zu-ZA` exists in the repo catalogs but is not among the Crowdin project's target languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects the visitor’s browser language and selects the closest supported locale.
  * Remembers the automatically selected language for future visits.
  * Falls back to English when no suitable language is available.

* **Localization**
  * Refined translations across supported languages for application, AI, navigation, import/export, resume, error, and conversation terminology.
  * Updated language and provider names to use native or official forms.
  * Added missing isiZulu language-name translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two independent improvements: a browser-locale auto-detection feature for first-time visitors (`locale.ts` / `__root.tsx`), and a broad translation quality overhaul across all 55 `.po` catalogs.

- **Auto-detect feature**: `getBrowserLocale` resolves the browser's `navigator.languages` list against supported locales (exact match → regional default → first-listed subtag match → `en-US`). `applyAutoDetectedLocale` runs once on mount via `useEffect`, skips if a cookie already exists, and calls the existing `changeLocale` (cookie + reload) only when a non-English locale is detected.
- **Translation corrections**: Provider brand names, AI/thread terminology, and language endonyms have been corrected across all catalogs; `localeMap` strings now use native/endonym forms in every `.po` file.
- **Tests**: New `getBrowserLocale` and `applyAutoDetectedLocale` suites cover exact match, case-insensitive normalization, bare-subtag resolution, preference ordering, and edge cases (empty list, unsupported tag).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The auto-detection logic is well-guarded, well-tested, and non-destructive — it only fires once on first visit and never overwrites a stored preference.

The locale auto-detection is additive: a cookie guard and SSR guard prevent any double-firing or server-side execution. The `localeBySubtag` first-declaration-wins fix addresses the ordering fragility noted in the previous review thread. Tests cover all meaningful code paths. The translation-only `.po` changes carry no runtime risk beyond display text.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/libs/locale.ts | Adds `getBrowserLocale` and `applyAutoDetectedLocale`. Logic is correct: first-declaration-wins for `localeBySubtag`, `regionalDefaultLocale` overrides for ambiguous subtags, SSR guard, and cookie-presence early-return all work as intended. |
| apps/web/src/libs/locale.test.ts | Comprehensive test coverage added for `getBrowserLocale` (exact match, case normalization, bare subtag, preference ordering, empty/unsupported fallback) and `applyAutoDetectedLocale` (existing cookie, non-English detection, English-default skip, languages-list fallback). |
| apps/web/src/routes/__root.tsx | Adds a single `useEffect(applyAutoDetectedLocale, [])` in `RootComponent`. Runs once on client mount; the cookie guard in `applyAutoDetectedLocale` prevents re-detection on subsequent renders. No other changes to route logic. |
| apps/web/locales/zh-CN.po | Translation corrections: AI-provider brand names left untranslated, AI/thread/dashboard terminology corrected, homepage hero phrase and absurd literal translations fixed. |
| apps/web/locales/ko-KR.po | Terminology corrections: AI agent/thread/dashboard terms updated to natural Korean equivalents, provider names left in English. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(i18n): address pt-BR review findings..."](https://github.com/amruthpillai/reactive-resume/commit/969c09f28d6b30109584862a83c23dcd0f07fb7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49730799)</sub>

<!-- /greptile_comment -->