### PR TITLE
fix(pdf,web): distinguish solid/outline states for level display icons

### DIFF
--- a/apps/web/src/components/level/display.test.tsx
+++ b/apps/web/src/components/level/display.test.tsx
@@ -46,12 +46,12 @@ describe("LevelDisplay", () => {
 		expect(wrapper.querySelector("i")?.className).toContain("ph-star");
 	});
 
-	it("dims inactive icons for icon type", () => {
+	it("fills active icons for icon type", () => {
 		const { container } = render(<LevelDisplay type="icon" icon="star" level={1} />);
 		const wrapper = container.firstChild as HTMLElement;
 		const icons = wrapper.querySelectorAll("i");
-		expect(icons[0]?.className).not.toContain("opacity-40");
-		expect(icons[4]?.className).toContain("opacity-40");
+		expect(icons[0]?.className).toContain("ph-fill");
+		expect(icons[4]?.className).not.toContain("ph-fill");
 	});
 
 	it("renders square segments for circle/rectangle/rectangle-full types", () => {

--- a/apps/web/src/components/level/display.tsx
+++ b/apps/web/src/components/level/display.tsx
@@ -69,7 +69,7 @@ export function LevelDisplay({ icon, type, level, className, decorationSizePx, i
 								"ph text-(--page-primary-color)",
 								resolvedIconSizePx === undefined && defaultDecorationClassName,
 								`ph-${icon}`,
-								!isActive && "opacity-40",
+								isActive && "ph-fill",
 							)}
 						/>
 					);

--- a/packages/pdf/src/templates/shared/level-display.tsx
+++ b/packages/pdf/src/templates/shared/level-display.tsx
@@ -11,7 +11,7 @@ import {
 	useSemanticNodeVisible,
 } from "../../semantic/context";
 import { semanticNodeKeys } from "../../semantic/node-keys";
-import { useSectionStyleRule, useTemplateIconSlot, useTemplateStyle } from "./context";
+import { useSectionStyleRule, useTemplateStyle } from "./context";
 import { resolveStyleFontSize } from "./icon-size";
 import { getTemplateMetrics } from "./metrics";
 import { Icon } from "./primitives";
@@ -32,7 +32,6 @@ export const LevelDisplay = ({ level }: LevelDisplayProps) => {
 	const { resolveNode, isNodeVisible } = useSemanticNodeBindings();
 	const levelDesign = data.metadata.design.level;
 	const metrics = getTemplateMetrics(data.metadata.page);
-	const iconProps = useTemplateIconSlot("icon");
 	const levelContainerStyle = useTemplateStyle("levelContainer");
 	const levelItemStyle = useTemplateStyle("levelItem");
 	const levelItemActiveStyle = useTemplateStyle("levelItemActive");
@@ -44,7 +43,10 @@ export const LevelDisplay = ({ level }: LevelDisplayProps) => {
 		iconFontSize: resolveStyleFontSize(iconRuleStyle),
 		levelFontSize: resolveStyleFontSize(levelRuleStyle, resolved.style),
 	});
-	const color = typeof iconProps.color === "string" ? iconProps.color : "#000000";
+	const color =
+		levelItemActiveStyle && "backgroundColor" in levelItemActiveStyle
+			? levelItemActiveStyle.backgroundColor
+			: "#000000";
 
 	if (level === 0 || !visible) return null;
 	if (levelDesign.type === "hidden") return null;
@@ -83,7 +85,8 @@ export const LevelDisplay = ({ level }: LevelDisplayProps) => {
 							nodeKey={decorationNodeKey}
 							{...(levelIconExplicitSize === undefined ? {} : { size: levelIconExplicitSize })}
 							name={levelDesign.icon as IconName}
-							style={{ opacity: isActive ? 1 : 0.35 }}
+							weight={isActive ? "fill" : "regular"}
+							color={color}
 						/>
 					);
 				}

--- a/packages/pdf/src/templates/shared/level-display.tsx
+++ b/packages/pdf/src/templates/shared/level-display.tsx
@@ -11,7 +11,7 @@ import {
 	useSemanticNodeVisible,
 } from "../../semantic/context";
 import { semanticNodeKeys } from "../../semantic/node-keys";
-import { useSectionStyleRule, useTemplateStyle } from "./context";
+import { useSectionStyleRule, useTemplateIconSlot, useTemplateStyle } from "./context";
 import { resolveStyleFontSize } from "./icon-size";
 import { getTemplateMetrics } from "./metrics";
 import { Icon } from "./primitives";
@@ -32,6 +32,7 @@ export const LevelDisplay = ({ level }: LevelDisplayProps) => {
 	const { resolveNode, isNodeVisible } = useSemanticNodeBindings();
 	const levelDesign = data.metadata.design.level;
 	const metrics = getTemplateMetrics(data.metadata.page);
+	const iconProps = useTemplateIconSlot("icon");
 	const levelContainerStyle = useTemplateStyle("levelContainer");
 	const levelItemStyle = useTemplateStyle("levelItem");
 	const levelItemActiveStyle = useTemplateStyle("levelItemActive");
@@ -46,7 +47,9 @@ export const LevelDisplay = ({ level }: LevelDisplayProps) => {
 	const color =
 		levelItemActiveStyle && "backgroundColor" in levelItemActiveStyle
 			? levelItemActiveStyle.backgroundColor
-			: "#000000";
+			: typeof iconProps.color === "string"
+				? iconProps.color
+				: "#000000";
 
 	if (level === 0 || !visible) return null;
 	if (levelDesign.type === "hidden") return null;

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -3,6 +3,7 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/ibm-plex-sans";
 @import "@phosphor-icons/web/regular/style.css";
+@import "@phosphor-icons/web/fill/style.css";
 
 @plugin "@tailwindcss/typography";
 


### PR DESCRIPTION
- Use the fill weight for active icons and the regular weight for inactive ones

- Align icon colors with shape fill color and theme primary color

- Remove the level opacity property, which had no visible effect

- Update LevelDisplay tests

<img width="1469" height="882" alt="PixPin_2026-08-11_12-00-34" src="https://github.com/user-attachments/assets/78e098a7-11a5-45ed-a839-447da0c8cd8a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated level indicators to use filled icons for active levels and regular icons for inactive levels.
  * Removed dimming from inactive icons for clearer visibility.
  * Improved icon color handling in generated documents.
  * Added support for filled icon styling across the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR distinguishes active and inactive level icons through filled and regular weights while aligning icon paint with template colors.
- Adds the filled Phosphor icon stylesheet to the web application.
- Updates web level indicators and their tests for weight-based states.
- Updates PDF level indicators to use explicit weights and resolved template colors.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported black PDF icon fallback is avoided because the affected templates now resolve a valid primary or accent color.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/level/display.tsx | Active level icons now use the filled Phosphor variant while inactive icons remain regular. |
| apps/web/src/components/level/display.test.tsx | Tests now verify filled active icons instead of opacity-based inactive states. |
| packages/pdf/src/templates/shared/level-display.tsx | PDF level icons now use fill/regular weights and resolve their color from the active level style before the icon slot fallback. |
| packages/ui/src/styles/globals.css | Imports the filled Phosphor icon font required by the new web icon classes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(pdf): use theme primary as fallback ..."](https://github.com/amruthpillai/reactive-resume/commit/88fc8848e81fdef15f60b54d04f4cca64a04f1a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52076453)</sub>

<!-- /greptile_comment -->