### PR TITLE
fix(stylesheet): skip parity on explicit activation

### DIFF
--- a/docs/spec.json
+++ b/docs/spec.json
@@ -10925,46 +10925,6 @@
 											"type": "object",
 											"properties": {
 												"defined": {
-													"const": true
-												},
-												"code": {
-													"const": "STYLESHEET_PARITY_FAILED"
-												},
-												"status": {
-													"const": 400
-												},
-												"message": {
-													"type": "string",
-													"default": "The converted stylesheet does not preserve legacy PDF presentation."
-												},
-												"data": {
-													"type": "object",
-													"properties": {
-														"mismatches": {
-															"type": "array",
-															"items": {
-																"type": "string"
-															}
-														}
-													},
-													"required": [
-														"mismatches"
-													],
-													"additionalProperties": false
-												}
-											},
-											"required": [
-												"defined",
-												"code",
-												"status",
-												"message",
-												"data"
-											]
-										},
-										{
-											"type": "object",
-											"properties": {
-												"defined": {
 													"const": false
 												},
 												"code": {

--- a/packages/api/src/dto/resume.ts
+++ b/packages/api/src/dto/resume.ts
@@ -202,9 +202,6 @@ export const resumeDto = {
 			validation: z.strictObject({
 				diagnostics: z.array(stylesheetDiagnosticSchema),
 			}),
-			parity: z.strictObject({
-				mismatches: z.array(z.string()),
-			}),
 			revisionConflict: z.strictObject({
 				state: stylesheetStateSchema,
 			}),

--- a/packages/api/src/features/resume/stylesheet-observability.ts
+++ b/packages/api/src/features/resume/stylesheet-observability.ts
@@ -5,7 +5,6 @@ type SemanticCssEventName =
 	| "semantic_css.compile"
 	| "semantic_css.preflight"
 	| "semantic_css.convert_legacy"
-	| "semantic_css.parity_check"
 	| "semantic_css.activate";
 
 export type SemanticCssEventInput = {

--- a/packages/api/src/features/resume/stylesheet-preflight.test.ts
+++ b/packages/api/src/features/resume/stylesheet-preflight.test.ts
@@ -3,17 +3,7 @@ import type { ResumeData } from "@reactive-resume/schema/resume/data";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultResumeData } from "@reactive-resume/schema/resume/default";
 import { EMPTY_SEMANTIC_CSS_SOURCE } from "@reactive-resume/schema/resume/stylesheet";
-import {
-	checkLegacyStylesheetParity,
-	prepareImportedResumeData,
-	validateHistoricalStylesheet,
-} from "./stylesheet-preflight";
-
-const semanticPdfMocks = vi.hoisted(() => ({
-	compareLegacySemanticPresentation: vi.fn(),
-}));
-
-vi.mock("@reactive-resume/pdf/semantic", () => semanticPdfMocks);
+import { prepareImportedResumeData, validateHistoricalStylesheet } from "./stylesheet-preflight";
 
 const validSource = {
 	languageVersion: 1,
@@ -47,7 +37,6 @@ const createRunner = () => {
 describe("stylesheet persistence preparation", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
-		semanticPdfMocks.compareLegacySemanticPresentation.mockReset();
 	});
 
 	it("uses a valid imported source as applied only after PDF preflight", async () => {
@@ -170,33 +159,5 @@ describe("stylesheet persistence preparation", () => {
 		]);
 		expect(serialized).not.toContain(validSource.text);
 		expect(serialized).not.toContain("import-observed");
-	});
-
-	it("records a sanitized parity failure metric when the comparator throws", async () => {
-		const privateText = "private parity failure john.doe@example.com";
-		const log = vi.spyOn(console, "info").mockImplementation(() => undefined);
-		semanticPdfMocks.compareLegacySemanticPresentation.mockRejectedValueOnce(new Error(privateText));
-
-		await expect(
-			checkLegacyStylesheetParity({
-				data: resumeData(),
-				stylesheet: validSource,
-				resumeId: "parity-observed",
-				revision: 5,
-			}),
-		).rejects.toThrow(privateText);
-
-		expect(log.mock.calls.map(([event]) => event)).toContainEqual(
-			expect.objectContaining({
-				name: "semantic_css.parity_check",
-				durationMs: expect.any(Number),
-				diagnosticCodes: [],
-				success: false,
-			}),
-		);
-		const serialized = JSON.stringify(log.mock.calls);
-		expect(serialized).not.toContain(privateText);
-		expect(serialized).not.toContain(validSource.text);
-		expect(serialized).not.toContain("parity-observed");
 	});
 });

--- a/packages/api/src/features/resume/stylesheet-preflight.ts
+++ b/packages/api/src/features/resume/stylesheet-preflight.ts
@@ -6,7 +6,6 @@ import type { StylesheetSnapshot } from "./stylesheet-service";
 import { ORPCError } from "@orpc/client";
 import { compileStylesheet } from "@reactive-resume/resume/stylesheet";
 import { EMPTY_SEMANTIC_CSS_SOURCE } from "@reactive-resume/schema/resume/stylesheet";
-import { templateSchema } from "@reactive-resume/schema/templates";
 import { recordSemanticCssEvent } from "./stylesheet-observability";
 
 type PrepareImportedResumeDataInput = {
@@ -186,50 +185,6 @@ export async function convertLegacyStylesheet(snapshot: StylesheetSnapshot): Pro
 			diagnosticCodes: [],
 			pageCount: null,
 			revision: snapshot.stylesheetRevision,
-			success: false,
-		});
-		throw error;
-	}
-}
-
-export async function checkLegacyStylesheetParity(input: {
-	data: ResumeData;
-	stylesheet: StylesheetSource;
-	resumeId: string;
-	revision: number;
-}): Promise<{ mismatches: readonly string[] }> {
-	const startedAt = performance.now();
-	try {
-		const { compareLegacySemanticPresentation } = await import("@reactive-resume/pdf/semantic");
-		const result = await compareLegacySemanticPresentation({
-			data: input.data,
-			convertedSource: input.stylesheet,
-			templates: templateSchema.options,
-		});
-		recordSemanticCssEvent({
-			name: "semantic_css.parity_check",
-			resumeId: input.resumeId,
-			durationMs: performance.now() - startedAt,
-			languageVersion: input.stylesheet.languageVersion,
-			sourceBytes: byteCount(input.stylesheet),
-			template: input.data.metadata.template,
-			diagnosticCodes: [],
-			pageCount: null,
-			revision: input.revision,
-			success: result.mismatches.length === 0,
-		});
-		return result;
-	} catch (error) {
-		recordSemanticCssEvent({
-			name: "semantic_css.parity_check",
-			resumeId: input.resumeId,
-			durationMs: performance.now() - startedAt,
-			languageVersion: input.stylesheet.languageVersion,
-			sourceBytes: byteCount(input.stylesheet),
-			template: input.data.metadata.template,
-			diagnosticCodes: [],
-			pageCount: null,
-			revision: input.revision,
 			success: false,
 		});
 		throw error;

--- a/packages/api/src/features/resume/stylesheet-route.test.ts
+++ b/packages/api/src/features/resume/stylesheet-route.test.ts
@@ -56,14 +56,6 @@ describe("resume stylesheet route error contract", () => {
 		}>();
 	});
 
-	it("exposes strict parity mismatch data at runtime and in the inferred client error", () => {
-		const schema = dataSchema("STYLESHEET_PARITY_FAILED");
-
-		expect(schema.safeParse({ mismatches: ["onyx: page 1"] }).success).toBe(true);
-		expect(schema.safeParse({ mismatches: ["onyx: page 1"], source }).success).toBe(false);
-		expectTypeOf<ErrorData<"STYLESHEET_PARITY_FAILED">>().toEqualTypeOf<{ mismatches: string[] }>();
-	});
-
 	it("exposes strict canonical conflict state for type-safe client rebasing", () => {
 		const schema = dataSchema("STYLESHEET_REVISION_CONFLICT");
 

--- a/packages/api/src/features/resume/stylesheet-service.test.ts
+++ b/packages/api/src/features/resume/stylesheet-service.test.ts
@@ -88,8 +88,6 @@ type HarnessOptions = {
 	initial?: StylesheetSnapshot;
 	compile?: (source: StylesheetSource) => CompileStylesheetResult;
 	preflight?: ((input: { data: ResumeData; stylesheet: StylesheetSource }) => Promise<PdfPreflightResult>) | undefined;
-	parityMismatches?: readonly string[];
-	parity?: () => Promise<{ mismatches: readonly string[] }>;
 	locked?: StylesheetSnapshot;
 	useDefaultObserver?: boolean;
 };
@@ -108,10 +106,6 @@ const createHarness = (options: HarnessOptions = {}) => {
 				callOrder.push("preflight");
 				return Promise.resolve(successfulPreflight);
 			});
-	const parity = vi.fn(() => {
-		callOrder.push("parity");
-		return options.parity?.() ?? Promise.resolve({ mismatches: options.parityMismatches ?? [] });
-	});
 	const publish = vi.fn(() => {
 		callOrder.push("publish");
 		return Promise.resolve();
@@ -134,7 +128,6 @@ const createHarness = (options: HarnessOptions = {}) => {
 						callOrder.push("preflight");
 						return preflight(input);
 					},
-		parity,
 		transaction: async (run) => {
 			callOrder.push("begin");
 			try {
@@ -171,7 +164,7 @@ const createHarness = (options: HarnessOptions = {}) => {
 		...(options.useDefaultObserver ? {} : { observe: (event: SemanticCssEventInput) => events.push(event) }),
 	});
 
-	return { callOrder, compile, events, parity, persisted: () => persisted, preflight, publish, service };
+	return { callOrder, compile, events, persisted: () => persisted, preflight, publish, service };
 };
 
 describe("stylesheet service", () => {
@@ -262,7 +255,7 @@ describe("stylesheet service", () => {
 		]);
 	});
 
-	it("requires parity and preflight before explicit activation", async () => {
+	it("activates an explicitly requested mode transition without checking legacy parity", async () => {
 		const initial = snapshot({ ...previousStylesheet, mode: "legacy" });
 		const harness = createHarness({ initial });
 
@@ -273,7 +266,6 @@ describe("stylesheet service", () => {
 		});
 
 		expect(result.stylesheet).toEqual({ mode: "semantic", source: validSource, applied: validSource });
-		expect(harness.parity).toHaveBeenCalledOnce();
 		expect(harness.preflight).toHaveBeenCalledOnce();
 		expect(result.revision).toBe(4);
 		expect(result.renderDataVersion).toBe(8);
@@ -342,35 +334,6 @@ describe("stylesheet service", () => {
 		expect(serialized).not.toContain("resume-1");
 	});
 
-	it("records a sanitized activation failure metric when parity throws", async () => {
-		const privateText = "private parity failure john.doe@example.com";
-		const log = vi.spyOn(console, "info").mockImplementation(() => undefined);
-		const harness = createHarness({
-			initial: snapshot({ ...previousStylesheet, mode: "legacy" }),
-			parity: () => Promise.reject(new Error(privateText)),
-			useDefaultObserver: true,
-		});
-
-		await expect(
-			harness.service.mutate({ ...commonMutationInput, transition: "activate", source: validSource }),
-		).rejects.toThrow(privateText);
-
-		expect(log.mock.calls.map(([event]) => event)).toContainEqual(
-			expect.objectContaining({
-				name: "semantic_css.activate",
-				durationMs: expect.any(Number),
-				diagnosticCodes: [],
-				pageCount: null,
-				revision: 3,
-				success: false,
-			}),
-		);
-		const serialized = JSON.stringify(log.mock.calls);
-		expect(serialized).not.toContain(privateText);
-		expect(serialized).not.toContain(validSource.text);
-		expect(serialized).not.toContain("resume-1");
-	});
-
 	it("deactivates without compiling or deleting either source", async () => {
 		const harness = createHarness();
 
@@ -378,7 +341,6 @@ describe("stylesheet service", () => {
 
 		expect(result.stylesheet).toEqual({ ...previousStylesheet, mode: "legacy" });
 		expect(harness.compile).not.toHaveBeenCalled();
-		expect(harness.parity).not.toHaveBeenCalled();
 		expect(harness.preflight).not.toHaveBeenCalled();
 	});
 

--- a/packages/api/src/features/resume/stylesheet-service.ts
+++ b/packages/api/src/features/resume/stylesheet-service.ts
@@ -12,7 +12,7 @@ import { EMPTY_SEMANTIC_CSS_SOURCE } from "@reactive-resume/schema/resume/styles
 import { publishResumeUpdated } from "./events";
 import { parseStoredResumeData } from "./resume-data-validation";
 import { recordSemanticCssEvent } from "./stylesheet-observability";
-import { checkLegacyStylesheetParity, convertLegacyStylesheet } from "./stylesheet-preflight";
+import { convertLegacyStylesheet } from "./stylesheet-preflight";
 
 export type StylesheetSnapshot = {
 	id: string;
@@ -68,12 +68,6 @@ type StylesheetServiceDependencies = {
 	convertLegacy(snapshot: StylesheetSnapshot): StylesheetSource | Promise<StylesheetSource>;
 	compile(source: StylesheetSource): CompileStylesheetResult;
 	preflight?(input: { data: ResumeData; stylesheet: StylesheetSource }): Promise<PdfPreflightResult>;
-	parity(input: {
-		data: ResumeData;
-		stylesheet: StylesheetSource;
-		resumeId: string;
-		revision: number;
-	}): Promise<{ mismatches: readonly string[] }>;
 	transaction<T>(run: (transaction: StylesheetTransaction) => Promise<T>): Promise<T>;
 	compare(snapshot: StylesheetSnapshot, input: StylesheetMutationCommon): boolean | Promise<boolean>;
 	publish(snapshot: StylesheetSnapshot): Promise<void>;
@@ -262,20 +256,6 @@ export function createStylesheetService(dependencies: StylesheetServiceDependenc
 						throw validationError("The stylesheet cannot be activated because it is invalid.", compiled.diagnostics);
 					}
 
-					const parity = await dependencies.parity({
-						data: snapshot.data,
-						stylesheet: input.source,
-						resumeId: snapshot.id,
-						revision: snapshot.stylesheetRevision,
-					});
-					if (parity.mismatches.length > 0) {
-						throw new ORPCError("STYLESHEET_PARITY_FAILED", {
-							status: 400,
-							message: "The converted stylesheet does not preserve the legacy PDF presentation.",
-							data: { mismatches: parity.mismatches },
-						});
-					}
-
 					const preflight = await runPreflight(snapshot, input.source);
 					didPreflight = true;
 					activationPageCount = preflight.ok ? preflight.pageCount : null;
@@ -397,7 +377,6 @@ export function createDatabaseStylesheetService(options: DatabaseStylesheetServi
 						}),
 				}
 			: {}),
-		parity: checkLegacyStylesheetParity,
 		transaction: (run) =>
 			database.transaction((transaction) =>
 				run({

--- a/packages/api/src/features/resume/stylesheet.ts
+++ b/packages/api/src/features/resume/stylesheet.ts
@@ -13,11 +13,6 @@ const errors = {
 		status: 400,
 		data: resumeDto.stylesheet.errors.validation,
 	},
-	STYLESHEET_PARITY_FAILED: {
-		message: "The converted stylesheet does not preserve legacy PDF presentation.",
-		status: 400,
-		data: resumeDto.stylesheet.errors.parity,
-	},
 	STYLESHEET_REVISION_CONFLICT: {
 		message: "The resume or stylesheet changed while the candidate was being validated.",
 		status: 409,


### PR DESCRIPTION
## Summary

- skip legacy stylesheet parity checks for explicit Semantic CSS activation
- retain compilation and PDF preflight validation
- remove the unreachable parity error contract and observability code

## Root cause

Activation compared the requested Semantic CSS presentation against the legacy renderer. That rejected intentional style changes and harmless renderer-only structural differences even after compilation and PDF preflight succeeded.

## Validation

- 33 focused stylesheet API tests
- API and server typechecks
- OpenAPI generation tests
- Biome and package boundary checks

Closes #3293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed legacy stylesheet parity validation during stylesheet activation.
  * Removed the `STYLESHEET_PARITY_FAILED` error response and its mismatch details.
  * Removed related parity-check observability events.
* **Behavior Changes**
  * Stylesheet activation now relies on compilation and PDF preflight validation.
  * Existing validation and revision-conflict errors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes legacy-renderer parity validation from explicit Semantic CSS activation while preserving compilation and PDF preflight checks.
- Removes the parity check and dependency from the stylesheet service.
- Removes the now-unreachable parity error DTO, route contract, observability event, and tests.
- Regenerates the OpenAPI specification to match the reduced error contract.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because explicit activation still requires successful compilation and PDF preflight, and the removed parity error contract has no remaining repository producers or consumers.

The change deliberately stops enforcing equivalence with the legacy renderer for an explicit Semantic CSS activation, while the retained validation rejects invalid or unrenderable stylesheets and all associated contracts and generated documentation were removed consistently.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/api/src/features/resume/stylesheet-service.ts | Removes legacy presentation comparison from explicit activation while retaining compile, preflight, transaction, and publication behavior. |
| packages/api/src/features/resume/stylesheet-preflight.ts | Removes the unused parity wrapper and associated observability while preserving import validation, conversion, and PDF preflight preparation. |
| packages/api/src/features/resume/stylesheet.ts | Removes the unreachable parity error from the stylesheet route contract. |
| packages/api/src/dto/resume.ts | Removes the parity mismatch payload schema that no reachable API error uses. |
| docs/spec.json | Updates the generated OpenAPI contract consistently with removal of the parity error variant. |
| packages/api/src/features/resume/stylesheet-observability.ts | Removes the event name associated solely with the deleted parity operation. |
| packages/api/src/features/resume/stylesheet-service.test.ts | Updates activation coverage to assert the intended compile-and-preflight flow without legacy parity enforcement. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Explicit Semantic CSS activation] --> B[Compile stylesheet]
    B -->|Invalid| C[Return validation error]
    B -->|Valid| D[Run PDF preflight]
    D -->|Failed| E[Reject activation]
    D -->|Passed| F[Persist stylesheet]
    F --> G[Publish resume update]
    H[Legacy parity comparison] -. removed .-> D
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20amruthpillai%2Freactive-resume%20PR%20%233316%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=3316&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["fix(stylesheet): skip parity on explicit..."](https://github.com/amruthpillai/reactive-resume/commit/25410b4685f5e2a759072b0860657d007b9da457) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52966785)</sub>

<!-- /greptile_comment -->