### PR TITLE
fix(lefthook): run the conflict-marker check on Windows

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,13 +9,12 @@ pre-commit:
       exclude:
         - "*.md"
         - "*.mdx"
+      # Single quotes only: on Windows the script is truncated at the first double quote, which
+      # leaves the shell with an unterminated command and fails the job on every commit.
       run: |
-        matches=$(grep -nEI '<{7} |>{7} |^={7}$' {staged_files} || true)
-        if [ -n "$matches" ]; then
-          echo "$matches"
-          echo "Error: merge conflict markers found in staged files"
-          exit 1
-        fi
+        grep -nEI '<{7} |>{7} |^={7}$' {staged_files} || exit 0
+        echo 'Error: merge conflict markers found in staged files'
+        exit 1
     - name: lint and format
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
       run: pnpm biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,8 +11,16 @@ pre-commit:
         - "*.mdx"
       # Single quotes only: on Windows the script is truncated at the first double quote, which
       # leaves the shell with an unterminated command and fails the job on every commit.
+      # grep exits 1 for a clean tree and 2 on error, so the statuses are handled separately —
+      # an unreadable path must fail the job rather than read as no markers found.
       run: |
-        grep -nEI '<{7} |>{7} |^={7}$' {staged_files} || exit 0
+        grep -nEI '<{7} |>{7} |^={7}$' {staged_files}
+        status=$?
+        if [ $status -eq 1 ]; then
+          exit 0
+        elif [ $status -ne 0 ]; then
+          exit $status
+        fi
         echo 'Error: merge conflict markers found in staged files'
         exit 1
     - name: lint and format


### PR DESCRIPTION
## Problem

The `check merge conflict markers` pre-commit job never runs on Windows. Lefthook truncates the script at the first double quote, leaving the shell with an unterminated command, so **every** commit in the repo fails the hook regardless of what is staged:

```
merge: -c: line 5: syntax error: unexpected end of file
┃  check merge conflict markers ❯
exit status 2
```

`merge` there is the word following `Error: ` in the truncated script, which is what gives the cause away — the shell received the script only up to that quote and treated the remaining words as arguments.

Reproduced on a clean checkout of `main` with lefthook 2.1.10 and Git Bash on Windows 11. The script itself is fine; running it by hand in the same shell works.

## Fix

Rewrite the check using single quotes only, letting `grep` print its own matches rather than round-tripping them through a quoted variable.

Behaviour is unchanged: matching lines are printed with line numbers and the job exits 1, otherwise it exits 0.

## Verification

- Clean tree: job passes.
- Staged a file containing all three marker types: job prints `2:<<<<<<< ours`, `4:=======`, `6:>>>>>>> theirs`, then the error message, and exits 1.
- The commit in this PR was made with the full hook set enabled and no exclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of unresolved merge-conflict markers.
  * Updated error handling to provide clearer success or failure results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes the merge-conflict marker pre-commit check work on Windows while preserving grep errors instead of treating them as a clean result.
- Rewrites the hook script to avoid problematic double quotes.
- Prints grep matches directly.
- Distinguishes no-match status 1 from actual grep errors.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lefthook.yml | The hook now handles grep statuses explicitly, resolving both Windows script truncation and the previously reported error-status bypass. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/lefthook-wi..."](https://github.com/amruthpillai/reactive-resume/commit/0bfc2a086c633441cee6a55eefd36ffd6f7642a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53571844)</sub>

<!-- /greptile_comment -->