### PR TITLE
chore(github): organize issue triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,68 +1,124 @@
 name: 🐞 Bug Report
 
-description: Create a bug report to help improve Reactive Resume
+description: Report a reproducible problem with Reactive Resume
 
-title: "[Bug] <title>"
-labels: [bug, v5, needs triage]
-assignees: "AmruthPillai"
+labels: ["bug", "status: needs triage"]
+assignees: []
 
 body:
   - type: checkboxes
     attributes:
-      label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the bug you encountered.
+      label: Existing issue
+      description: Search open and closed issues before submitting a new report.
       options:
-        - label: Yes, I have searched the existing issues and none of them match my problem.
+        - label: I searched the existing issues and could not find a matching report.
           required: true
 
   - type: dropdown
     id: variant
     attributes:
-      label: Product Variant
-      description: What variant of Reactive Resume are you using?
+      label: Product variant
+      description: Where does the problem occur?
       options:
-        - Cloud (https://rxresu.me)
-        - Self-Hosted
+        - Cloud
+        - Self-hosted
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Reactive Resume version
+      description: Find this in Settings or provide the container image tag or commit SHA.
+      placeholder: 5.2.6
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Choose the part of Reactive Resume most closely related to the problem.
+      options:
+        - Resume builder & data
+        - Templates, preview & export
+        - Accounts & sharing
+        - AI & Agent
+        - Language & localization
+        - Self-hosting
+        - API & integrations
+        - Applications & cover letters
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include your operating system and browser. For self-hosted installations, also include the deployment method.
+      placeholder: Firefox 143 on Ubuntu 26.04, deployed with Docker Compose
     validations:
       required: true
 
   - type: textarea
+    id: summary
     attributes:
-      label: Describe the bug you're experiencing
-      description: A detailed description of what you're experiencing. Please provide as much detail as possible as it will help me diagnose and fix the issue faster.
+      label: Summary
+      description: Briefly describe the problem and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reliable sequence that demonstrates the problem.
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
     validations:
       required: true
 
   - type: dropdown
     id: template
     attributes:
-      label: What template are you using?
-      description: Leave blank if the issue applies to all templates, or is not template-specific.
-      multiple: false
+      label: Template
+      description: Leave blank when the problem is not template-specific.
       options:
         - Azurill
         - Bronzor
         - Chikorita
-        - Ditto
         - Ditgar
+        - Ditto
         - Gengar
         - Glalie
         - Kakuna
         - Lapras
         - Leafish
+        - Meowth
         - Onyx
         - Pikachu
         - Rhyhorn
         - Scizor
-    validations:
-      required: false
 
   - type: textarea
+    id: logs
     attributes:
-      label: Anything else?
-      description: |
-        Links? References? Anything that will give us more context about the issue you are encountering!
-
-        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
-    validations:
-      required: false
+      label: Logs and screenshots
+      description: Add relevant logs, screenshots, or a minimal reproduction. Remove secrets and personal resume data first.

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,23 +1,82 @@
 name: ✨ Feature Request
 
-description: Suggest an feature or idea that you would like to see in Reactive Resume
+description: Propose an actionable improvement to Reactive Resume
 
-title: "[Feature] <title>"
-labels: [enhancement, v5, needs triage]
-assignees: "AmruthPillai"
+labels: ["enhancement", "status: needs triage"]
+assignees: []
 
 body:
   - type: checkboxes
     attributes:
-      label: Is there an existing issue for this feature?
-      description: Please search to see if an issue already exists for the feature you requested.
+      label: Existing issue
+      description: Search open and closed issues before submitting a new proposal.
       options:
-        - label: Yes, I have searched the existing issues and it doesn't exist.
+        - label: I searched the existing issues and could not find a matching proposal.
           required: true
 
-  - type: textarea
+  - type: dropdown
+    id: variant
     attributes:
-      label: Feature Description
-      description: A detailed description of the feature you would like to see in Reactive Resume. Please provide as much detail as possible as it will help me implement the feature faster.
+      label: Product variant
+      description: Choose the primary environment for this proposal.
+      options:
+        - Cloud
+        - Self-hosted
     validations:
       required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Choose the part of Reactive Resume most closely related to the proposal.
+      options:
+        - Resume builder & data
+        - Templates, preview & export
+        - Accounts & sharing
+        - AI & Agent
+        - Language & localization
+        - Self-hosting
+        - API & integrations
+        - Applications & cover letters
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem or limitation should Reactive Resume solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the behavior you want without prescribing an implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe current workarounds or alternatives. Write "None" if there are none.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope
+      description: Explain what should be included and what can remain out of scope.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add examples, mockups, or related issues when useful. Remove personal resume data first.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Questions and support
+    url: https://github.com/amruthpillai/reactive-resume/discussions/categories/q-a
+    about: Get help with setup, configuration, and using Reactive Resume.
+  - name: Security vulnerability
+    url: https://github.com/amruthpillai/reactive-resume/security/advisories/new
+    about: Report security vulnerabilities privately.

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,0 +1,30 @@
+name: Label New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Apply Form Labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const { getIssueLabels } = await import(`${process.env.GITHUB_WORKSPACE}/tooling/issue-labels.mjs`);
+            const labels = getIssueLabels(context.payload.issue.body ?? "");
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({ ...context.issue, labels });
+            }

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,30 @@
+name: Close Issues Awaiting Information
+
+on:
+  schedule:
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close Inactive Issues Awaiting Information
+        uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
+        with:
+          only-issue-labels: "status: needs info"
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-label: stale
+          stale-issue-message: >-
+            This issue is waiting for information requested by a maintainer. It will close in 7 days if no new information is provided.
+          close-issue-message: >-
+            Closing because the requested information was not provided. Add the missing details in a comment and a maintainer can reopen the issue.
+          close-issue-reason: not_planned
+          remove-issue-stale-when-updated: true

--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ Reactive Resume is and always will be free and open-source. If it has helped you
 Other ways to support:
 
 - Star this repository
-- Report bugs and suggest features
+- Report reproducible bugs and suggest actionable features
+- Help other users in [GitHub Discussions](https://github.com/amruthpillai/reactive-resume/discussions/categories/q-a)
 - Improve documentation
 - Help with translations
 
@@ -259,6 +260,10 @@ Contributions make open-source thrive. Whether fixing a typo or adding a feature
 5. Open a Pull Request
 
 See the [development setup guide](https://docs.rxresu.me/contributing/development) for detailed instructions on how to set up the project locally.
+
+Maintainers review the [`status: needs triage` queue](https://github.com/amruthpillai/reactive-resume/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+needs+triage%22)
+weekly. Triaged bugs become `status: confirmed`; feature proposals become `status: accepted`; reports that need details become
+`status: needs info`.
 
 ## License
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -96,7 +96,10 @@ Reactive Resume is built with modern web technologies:
 
 <CardGroup cols={2}>
   <Card title="GitHub" icon="github" href="https://github.com/amruthpillai/reactive-resume">
-    Star the repo, report issues, and contribute to the project.
+    Star the repo, report reproducible bugs, propose features, and contribute to the project.
+  </Card>
+  <Card title="GitHub Discussions" icon="comments" href="https://github.com/amruthpillai/reactive-resume/discussions/categories/q-a">
+    Ask questions about setup, configuration, and using Reactive Resume.
   </Card>
   <Card title="Reddit" icon="reddit" href="https://reddit.com/r/reactiveresume">
     Join our Reddit community to get help and connect with other users.
@@ -110,5 +113,6 @@ Reactive Resume is built with modern web technologies:
 </CardGroup>
 
 <Note>
-  **Need help?** Feel free to reach out via [email](mailto:hello@amruthpillai.com) or open an issue on GitHub.
+  **Need help?** Start a [GitHub Discussion](https://github.com/amruthpillai/reactive-resume/discussions/categories/q-a).
+  GitHub Issues are reserved for reproducible bugs and actionable feature proposals.
 </Note>

--- a/knip.json
+++ b/knip.json
@@ -62,6 +62,9 @@
 				"uuid"
 			]
 		},
+		"tooling": {
+			"entry": ["issue-labels.mjs"]
+		},
 		"packages/api": {
 			"ignoreDependencies": ["ioredis"]
 		}

--- a/tooling/issue-labels.mjs
+++ b/tooling/issue-labels.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+
+const fields = [
+	[
+		"Product variant",
+		{
+			Cloud: "deployment: cloud",
+			"Self-hosted": "deployment: self-hosted",
+		},
+	],
+	[
+		"Area",
+		{
+			"Resume builder & data": "area: builder",
+			"Templates, preview & export": "area: rendering",
+			"Accounts & sharing": "area: account",
+			"AI & Agent": "area: ai",
+			"Language & localization": "area: localization",
+			"Self-hosting": "area: self-hosting",
+			"API & integrations": "area: integrations",
+			"Applications & cover letters": "area: applications",
+		},
+	],
+];
+
+export function getIssueLabels(body) {
+	return fields.flatMap(([heading, labels]) => {
+		const answer = body.match(new RegExp(`^### ${heading}\\r?\\n\\r?\\n([^\\r\\n]+)$`, "m"))?.[1].trim();
+		return answer && labels[answer] ? [labels[answer]] : [];
+	});
+}
+
+if (import.meta.main) {
+	const issueBody = `### Product variant
+
+Self-hosted
+
+### Area
+
+Templates, preview & export`;
+
+	assert.deepEqual(getIssueLabels(issueBody), ["deployment: self-hosted", "area: rendering"]);
+	assert.deepEqual(getIssueLabels("### Area\n\nOther / unsure"), []);
+	assert.deepEqual(getIssueLabels("#### Area\n\nAI & Agent"), []);
+	assert.deepEqual(getIssueLabels("prefix ### Area\n\nAI & Agent"), []);
+}


### PR DESCRIPTION
## Summary

- replace the bug and feature templates with structured, actionable intake forms
- label new issues deterministically by product variant and area
- close only inactive `status: needs info` issues after a 14-day warning and 7-day grace period
- route support questions to GitHub Discussions and security reports to private advisories
- document the weekly maintainer triage queue and status progression

## Why

The existing issue intake mixed support requests with actionable work, auto-assigned every report, and left maintainers without consistent area, deployment, or lifecycle labels. This makes the backlog harder to search and increases manual triage noise.

The new setup keeps automation conservative: form selections drive labels, confirmed work is never closed merely because it is old, and only issues explicitly waiting for requested information enter the stale workflow.

## Existing backlog rollout

The approved dry run was applied separately to the 100 issues that were open before this change:

- 90 remain open: 42 confirmed, 25 need information, 22 need triage, and 1 accepted
- 10 were closed with explicit reasons: 3 completed, 5 duplicates, and 2 support requests
- all 25 `status: needs info` issues received a tailored request before becoming eligible for stale handling

## Validation

- `node tooling/issue-labels.mjs`
- `pnpm exec github-actionlint .github/workflows/label-issues.yml .github/workflows/stale-issues.yml`
- `pnpm exec biome check tooling/issue-labels.mjs`
- `pnpm exec markdownlint-cli2 README.md docs/getting-started.mdx`
- `git diff --check`
- live reconciliation of all 100 migrated issues, including labels, comments, open/closed state, and closure reason

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer bug report and feature request forms with structured fields for product areas, environments, reproduction steps, outcomes, and supporting details.
  * Added contact options for general support and private security reports.
  * Issues can now receive standardized labels automatically.

* **Documentation**
  * Updated support guidance to distinguish Discussions, bug reports, and feature proposals.
  * Added contributor guidance on triage and issue status transitions.

* **Chores**
  * Added automatic handling for unresolved issues: stale after 14 days and closed after an additional 7 days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces structured issue intake and deterministic labeling while limiting stale closure to issues explicitly awaiting information.
- Replaces bug and feature templates with structured forms.
- Adds workflows for issue labeling and conservative stale handling.
- Routes support and security reports to appropriate GitHub channels.
- Documents the maintainer triage lifecycle and registers the labeler as a tooling entry point.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/1-bug-report.yml | Replaces the bug template with required variant, area, environment, reproduction, and outcome fields. |
| .github/ISSUE_TEMPLATE/2-feature-request.yml | Adds structured problem, outcome, alternatives, scope, variant, and area fields for feature proposals. |
| .github/workflows/label-issues.yml | Labels newly opened issues using fixed mappings parsed from issue-form answers. |
| .github/workflows/stale-issues.yml | Restricts stale handling to inactive issues labeled `status: needs info`, with warning and grace periods. |
| tooling/issue-labels.mjs | Parses issue-form variant and area answers into deterministic repository labels. |
| knip.json | Registers the issue-labeling module as an entry point in the tooling workspace. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[New issue] --> B[Structured issue form]
  B --> C[Apply variant and area labels]
  C --> D[status: needs triage]
  D --> E{Maintainer review}
  E -->|Bug verified| F[status: confirmed]
  E -->|Feature accepted| G[status: accepted]
  E -->|Details required| H[status: needs info]
  H -->|14 days inactive| I[Stale warning]
  I -->|7 more days inactive| J[Close as not planned]
  H -->|Reporter updates| E
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): register issue labeler entry"](https://github.com/amruthpillai/reactive-resume/commit/016e1bf0c79a31cfd4efcd6b2d8d3ef9a16036f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53737132)</sub>

<!-- /greptile_comment -->