### PR TITLE
feat(stylesheet): expose the item header row to Semantic CSS

### DIFF
--- a/packages/pdf/src/semantic/__snapshots__/all-templates-presentation.test.ts.snap
+++ b/packages/pdf/src/semantic/__snapshots__/all-templates-presentation.test.ts.snap
@@ -465,6 +465,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved azurill
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/template-part-timeline-content": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/template-part-timeline-marker": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/template-part-timeline-marker/template-part-timeline-dot": {
@@ -480,6 +481,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved azurill
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/template-part-timeline-content": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/template-part-timeline-marker": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/template-part-timeline-marker/template-part-timeline-dot": {
@@ -513,6 +515,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved azurill
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -521,6 +524,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved azurill
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -639,6 +643,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved azurill
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/template-part-timeline-content": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/template-part-timeline-marker": {},
@@ -661,6 +666,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved azurill
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/template-part-timeline-content": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/template-part-timeline-marker": {},
@@ -683,6 +689,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved azurill
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/template-part-timeline-content": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/template-part-timeline-marker": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/template-part-timeline-marker/template-part-timeline-dot": {
@@ -703,6 +710,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved azurill
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/template-part-timeline-content": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/template-part-timeline-marker": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/template-part-timeline-marker/template-part-timeline-dot": {
@@ -718,6 +726,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved azurill
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/template-part-timeline-content": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/template-part-timeline-marker": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/template-part-timeline-marker/template-part-timeline-dot": {
@@ -1173,6 +1182,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved bronzor
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -1181,6 +1191,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved bronzor
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-sidebar%3Acertifications": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-heading": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-heading/icon-section": {},
@@ -1193,6 +1204,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved bronzor
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -1201,6 +1213,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved bronzor
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-sidebar%3Ainterests": {},
   "page-2/region-main/section-sidebar%3Ainterests/section-heading": {},
   "page-2/region-main/section-sidebar%3Ainterests/section-heading/icon-section": {},
@@ -1283,6 +1296,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved bronzor
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -1298,6 +1312,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved bronzor
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -1313,6 +1328,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved bronzor
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-main%3Apublications": {},
   "page-3/region-main/section-main%3Apublications/section-heading": {},
   "page-3/region-main/section-main%3Apublications/section-heading/icon-section": {},
@@ -1325,6 +1341,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved bronzor
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -1333,6 +1350,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved bronzor
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-main%3Avolunteer": {},
   "page-3/region-main/section-main%3Avolunteer/section-heading": {},
   "page-3/region-main/section-main%3Avolunteer/section-heading/icon-section": {},
@@ -1799,6 +1817,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved chikori
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -1807,6 +1826,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved chikori
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -1832,6 +1852,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved chikori
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -1840,6 +1861,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved chikori
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -1958,6 +1980,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved chikori
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -1973,6 +1996,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved chikori
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -1988,6 +2012,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved chikori
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -2000,6 +2025,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved chikori
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -2008,6 +2034,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved chikori
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -2474,6 +2501,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditgar 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -2482,6 +2510,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditgar 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -2507,6 +2536,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditgar 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -2515,6 +2545,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditgar 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -2636,6 +2667,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditgar 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -2651,6 +2683,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditgar 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -2666,6 +2699,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditgar 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -2678,6 +2712,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditgar 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -2686,6 +2721,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditgar 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -3149,6 +3185,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditto p
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -3157,6 +3194,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditto p
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -3182,6 +3220,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditto p
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -3190,6 +3229,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditto p
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -3308,6 +3348,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditto p
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -3323,6 +3364,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditto p
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -3338,6 +3380,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditto p
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -3350,6 +3393,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditto p
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -3358,6 +3402,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved ditto p
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -3824,6 +3869,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved gengar 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -3832,6 +3878,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved gengar 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -3857,6 +3904,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved gengar 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -3865,6 +3913,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved gengar 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -3983,6 +4032,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved gengar 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -3998,6 +4048,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved gengar 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -4013,6 +4064,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved gengar 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -4025,6 +4077,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved gengar 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -4033,6 +4086,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved gengar 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -4498,6 +4552,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved glalie 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -4506,6 +4561,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved glalie 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -4531,6 +4587,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved glalie 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -4539,6 +4596,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved glalie 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -4658,6 +4716,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved glalie 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -4673,6 +4732,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved glalie 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -4688,6 +4748,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved glalie 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -4700,6 +4761,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved glalie 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -4708,6 +4770,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved glalie 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -5172,6 +5235,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved kakuna 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -5180,6 +5244,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved kakuna 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -5205,6 +5270,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved kakuna 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -5213,6 +5279,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved kakuna 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -5331,6 +5398,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved kakuna 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -5346,6 +5414,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved kakuna 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -5361,6 +5430,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved kakuna 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -5373,6 +5443,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved kakuna 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -5381,6 +5452,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved kakuna 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -5845,6 +5917,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved lapras 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -5853,6 +5926,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved lapras 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -5878,6 +5952,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved lapras 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -5886,6 +5961,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved lapras 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -6004,6 +6080,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved lapras 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -6019,6 +6096,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved lapras 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -6034,6 +6112,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved lapras 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -6046,6 +6125,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved lapras 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -6054,6 +6134,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved lapras 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -6517,6 +6598,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved leafish
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -6525,6 +6607,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved leafish
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -6550,6 +6633,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved leafish
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -6558,6 +6642,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved leafish
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -6676,6 +6761,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved leafish
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -6691,6 +6777,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved leafish
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -6706,6 +6793,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved leafish
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -6718,6 +6806,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved leafish
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -6726,6 +6815,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved leafish
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -7212,6 +7302,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved meowth 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/template-part-education-grade-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
@@ -7221,6 +7312,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved meowth 
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/template-part-education-grade-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
@@ -7247,6 +7339,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved meowth 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/template-part-education-grade-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
@@ -7256,6 +7349,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved meowth 
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/template-part-education-grade-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
@@ -7379,6 +7473,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved meowth 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/template-part-education-grade-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
@@ -7395,6 +7490,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved meowth 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/template-part-education-grade-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
@@ -7411,6 +7507,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved meowth 
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/template-part-education-grade-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
@@ -7424,6 +7521,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved meowth 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/template-part-education-grade-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
@@ -7433,6 +7531,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved meowth 
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/template-part-education-grade-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
@@ -7906,6 +8005,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved onyx pr
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -7914,6 +8014,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved onyx pr
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -7939,6 +8040,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved onyx pr
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -7947,6 +8049,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved onyx pr
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -8065,6 +8168,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved onyx pr
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -8080,6 +8184,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved onyx pr
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -8095,6 +8200,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved onyx pr
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -8107,6 +8213,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved onyx pr
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -8115,6 +8222,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved onyx pr
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -8576,6 +8684,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved pikachu
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -8584,6 +8693,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved pikachu
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -8609,6 +8719,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved pikachu
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -8617,6 +8728,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved pikachu
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -8735,6 +8847,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved pikachu
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -8750,6 +8863,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved pikachu
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -8765,6 +8879,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved pikachu
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -8777,6 +8892,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved pikachu
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -8785,6 +8901,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved pikachu
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -9255,6 +9372,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved rhyhorn
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -9263,6 +9381,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved rhyhorn
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-awards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar": {},
   "page-2/region-sidebar/section-certifications": {
     "style": {
@@ -9288,6 +9407,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved rhyhorn
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -9296,6 +9416,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved rhyhorn
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-sidebar/section-certifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-sidebar/section-interests": {
     "style": {
       "backgroundColor": "rgba(0,0,0,0.04)",
@@ -9414,6 +9535,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved rhyhorn
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -9429,6 +9551,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved rhyhorn
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -9444,6 +9567,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved rhyhorn
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-projects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications": {},
   "page-3/region-main/section-publications/section-heading": {},
   "page-3/region-main/section-publications/section-heading/icon-section": {},
@@ -9456,6 +9580,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved rhyhorn
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -9464,6 +9589,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved rhyhorn
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-publications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-volunteer": {},
   "page-3/region-main/section-volunteer/section-heading": {},
   "page-3/region-main/section-volunteer/section-heading/icon-section": {},
@@ -9904,6 +10030,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved scizor 
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-awarder": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-date": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/field-title": {},
+  "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8a8bb9fbe182/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/field-description/rich-text-description": {},
@@ -9912,6 +10039,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved scizor 
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-awarder": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-date": {},
   "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/field-title": {},
+  "page-2/region-main/section-main%3Aawards/section-items/item-019bef5a-93e4-7746-ad39-8dd81379c7c9/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-sidebar%3Acertifications": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-heading": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-heading/icon-section": {},
@@ -9924,6 +10052,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved scizor 
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-date": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-issuer": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/field-title": {},
+  "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-91fe8a4dfea6/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/field-description/rich-text-description": {},
@@ -9932,6 +10061,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved scizor 
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-date": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-issuer": {},
   "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/field-title": {},
+  "page-2/region-main/section-sidebar%3Acertifications/section-items/item-019bef5a-93e4-7746-ad39-961afccc2508/item-header/template-part-item-header-row": {},
   "page-2/region-main/section-sidebar%3Ainterests": {},
   "page-2/region-main/section-sidebar%3Ainterests/section-heading": {},
   "page-2/region-main/section-sidebar%3Ainterests/section-heading/icon-section": {},
@@ -10014,6 +10144,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved scizor 
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-name": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/field-period": {},
+  "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-4d2603fe2801/link-website": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff": {
     "style": {
@@ -10029,6 +10160,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved scizor 
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-name": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/field-period": {},
+  "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-524195dd7eff/link-website": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73": {
     "style": {
@@ -10044,6 +10176,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved scizor 
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-name": {},
   "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/field-period": {},
+  "page-3/region-main/section-main%3Aprojects/section-items/item-019bef5a-93e4-7746-ad39-549106273c73/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-main%3Apublications": {},
   "page-3/region-main/section-main%3Apublications/section-heading": {},
   "page-3/region-main/section-main%3Apublications/section-heading/icon-section": {},
@@ -10056,6 +10189,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved scizor 
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-date": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-publisher": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/field-title": {},
+  "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9816f0081895/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/field-description/rich-text-description": {},
@@ -10064,6 +10198,7 @@ exports[`Semantic CSS all-template presentation > snapshots the resolved scizor 
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-date": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-publisher": {},
   "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/field-title": {},
+  "page-3/region-main/section-main%3Apublications/section-items/item-019bef5a-93e4-7746-ad39-9cf55c272c05/item-header/template-part-item-header-row": {},
   "page-3/region-main/section-main%3Avolunteer": {},
   "page-3/region-main/section-main%3Avolunteer/section-heading": {},
   "page-3/region-main/section-main%3Avolunteer/section-heading/icon-section": {},

--- a/packages/pdf/src/semantic/item-header-row.test.tsx
+++ b/packages/pdf/src/semantic/item-header-row.test.tsx
@@ -1,0 +1,130 @@
+import type { SemanticNode } from "@reactive-resume/resume/stylesheet/types";
+import type { ResumeData } from "@reactive-resume/schema/resume/data";
+import type { Template } from "@reactive-resume/schema/templates";
+import { describe, expect, it } from "vitest";
+import { pdf } from "@react-pdf/renderer";
+import { createElement } from "react";
+import { analyzeStylesheet, compileStylesheet } from "@reactive-resume/resume/stylesheet";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../document";
+import { resolveResumeRuntime } from "./resolve";
+import { buildSemanticTree } from "./tree";
+
+type HostNode = { type: string; style?: unknown; value?: string; children?: HostNode[] };
+
+const LONG_TITLE = "Belajar Membuat Aplikasi Android untuk Pemula";
+const NOWRAP_STYLESHEET = `@version 1;\ntemplate-part[name="item-header-row"] { flex-wrap: nowrap; }`;
+
+const mergedStyle = (node: HostNode): Record<string, unknown> =>
+	Object.assign({}, ...(Array.isArray(node.style) ? node.style : node.style ? [node.style] : []));
+const nodeText = (node: HostNode): string => node.value ?? (node.children ?? []).map(nodeText).join("");
+const pathTo = (node: HostNode, predicate: (candidate: HostNode) => boolean): HostNode[] | undefined => {
+	if (predicate(node)) return [node];
+	for (const child of node.children ?? []) {
+		const path = pathTo(child, predicate);
+		if (path) return [node, ...path];
+	}
+};
+const flatten = (node: SemanticNode): SemanticNode[] => [node, ...node.children.flatMap(flatten)];
+
+const buildFixture = (): ResumeData => {
+	const data = structuredClone(defaultResumeData);
+	data.picture.hidden = true;
+	data.sections.certifications.items = [
+		{
+			id: "certification/1",
+			hidden: false,
+			title: LONG_TITLE,
+			issuer: "Dicoding",
+			date: "05 Sep 2023",
+			website: { url: "", label: "", inlineLink: false },
+			description: "",
+		},
+	];
+	data.sections.experience.items = [
+		{
+			id: "experience/1",
+			hidden: false,
+			company: "Braincore",
+			position: "Business Process Automation Engineer",
+			location: "Jakarta, Indonesia",
+			period: "Jan 2024 - Mar 2025",
+			website: { url: "", label: "", inlineLink: false },
+			description: "",
+			roles: [],
+		},
+	];
+	const page = data.metadata.layout.pages[0];
+	if (!page) throw new Error("Missing authored page");
+	page.main = ["certifications", "experience"];
+	page.sidebar = [];
+
+	return data;
+};
+
+const renderTitleRowStyle = async (template: Template, stylesheet?: string) => {
+	const data = buildFixture();
+	const semanticRuntime = stylesheet
+		? resolveResumeRuntime({ data, template, mode: "semantic", source: { languageVersion: 1, text: stylesheet } })
+		: undefined;
+	const element = createElement(ResumeDocument, { data, template, semanticRuntime }) as unknown as Parameters<
+		typeof pdf
+	>[0];
+	const instance = pdf(element);
+	await expect.poll(() => instance.container.document).not.toBeNull();
+	const document = instance.container.document as unknown as HostNode;
+	const path = pathTo(document, (node) => nodeText(node).trim() === LONG_TITLE);
+	if (!path) throw new Error("Missing certification title in the rendered document");
+	const row = path.at(-2);
+	if (!row) throw new Error("Missing the row wrapping the certification title");
+
+	return mergedStyle(row);
+};
+
+describe("item-header-row template part", () => {
+	it("wraps the certification title and date, leaving the issuer outside", () => {
+		const data = buildFixture();
+		const page = data.metadata.layout.pages[0];
+		if (!page) throw new Error("Missing authored page");
+		const tree = buildSemanticTree({ data, template: "onyx", page, pageNumber: 1, showHeader: true });
+		const itemHeader = flatten(tree).find((node) => node.kind === "item-header");
+		if (!itemHeader) throw new Error("Missing item header");
+
+		expect(itemHeader.children.map((child) => [child.kind, child.attributes.name])).toEqual([
+			["template-part", "item-header-row"],
+			["field", "issuer"],
+		]);
+		const [row] = itemHeader.children;
+		expect(row?.children.map((child) => child.attributes.name)).toEqual(["title", "date"]);
+	});
+
+	it("is not routed into the stacked experience header", () => {
+		const data = buildFixture();
+		const page = data.metadata.layout.pages[0];
+		if (!page) throw new Error("Missing authored page");
+		const tree = buildSemanticTree({ data, template: "onyx", page, pageNumber: 1, showHeader: true });
+		const experience = flatten(tree).find((node) => node.kind === "section" && node.attributes.type === "experience");
+		if (!experience) throw new Error("Missing experience section");
+
+		expect(flatten(experience).filter((node) => node.attributes.name === "item-header-row")).toEqual([]);
+	});
+
+	// The row ships with `flex-wrap: wrap`, which drops a long title's date onto its own line. This
+	// is the whole point of exposing the part, so assert the override reaches the rendered row.
+	it.each(["onyx", "ditgar", "meowth"] as const)("lets %s stylesheets turn off the row wrap", async (template) => {
+		expect(await renderTitleRowStyle(template)).toMatchObject({ flexWrap: "wrap" });
+		expect(await renderTitleRowStyle(template, NOWRAP_STYLESHEET)).toMatchObject({ flexWrap: "nowrap" });
+	});
+
+	it("reports no diagnostics for the selector", () => {
+		const data = buildFixture();
+		const page = data.metadata.layout.pages[0];
+		if (!page) throw new Error("Missing authored page");
+		const tree = buildSemanticTree({ data, template: "onyx", page, pageNumber: 1, showHeader: true });
+		const compiled = compileStylesheet({ languageVersion: 1, text: NOWRAP_STYLESHEET });
+		if (!compiled.program) throw new Error("Stylesheet failed to compile");
+
+		expect(compiled.diagnostics).toEqual([]);
+		expect(analyzeStylesheet(compiled.program, tree)).toEqual([]);
+	});
+});

--- a/packages/pdf/src/semantic/shared-parts.ts
+++ b/packages/pdf/src/semantic/shared-parts.ts
@@ -1,0 +1,39 @@
+import type { TemplateSemanticPrimitivePart } from "./template-manifest";
+
+/**
+ * Sections whose item header is a single title/date row rendered by the shared split-row layout.
+ *
+ * Experience, education and volunteer are deliberately excluded: they render two stacked rows, and
+ * on templates with the `inlineItemHeader` feature their header is owned by the
+ * `inline-item-header-*` parts instead, which would compete for the same fields.
+ */
+const ITEM_HEADER_ROW_SECTION_TYPES = ["awards", "certifications", "projects", "publications"] as const;
+
+/**
+ * Exposes the split row inside a section item header so a stylesheet can address it.
+ *
+ * The row carries `flex-wrap: wrap`, so a long title pushes the trailing date onto its own line.
+ * Without this part the row is anonymous — `item-header` selects the box around it, not the row —
+ * leaving no way to write `flex-wrap: nowrap`. Shared by every template because the row comes from
+ * the shared section components rather than from any one template.
+ */
+/** Part key chain passed to `SemanticTemplatePartView`; must match `itemHeaderRowPart.key`. */
+export const ITEM_HEADER_ROW_PART_KEYS = ["item-header-row"] as const;
+
+export const itemHeaderRowPart = {
+	name: "item-header-row",
+	key: "item-header-row",
+	owner: { kind: "item-header", key: "item-header", sectionTypes: ITEM_HEADER_ROW_SECTION_TYPES },
+	binding: { type: "primitive", primitive: "View", source: "existing" },
+	route: {
+		parent: "owner",
+		at: "start",
+		take: [
+			{ kind: "field", name: "title", sectionTypes: ["awards", "certifications", "publications"] },
+			{ kind: "field", name: "date", sectionTypes: ["awards", "certifications", "publications"] },
+			{ kind: "field", name: "name", sectionTypes: ["projects"] },
+			{ kind: "field", name: "period", sectionTypes: ["projects"] },
+			{ kind: "link", sectionTypes: ITEM_HEADER_ROW_SECTION_TYPES },
+		],
+	},
+} as const satisfies TemplateSemanticPrimitivePart;

--- a/packages/pdf/src/semantic/template-manifest.test.ts
+++ b/packages/pdf/src/semantic/template-manifest.test.ts
@@ -14,8 +14,32 @@ import {
 } from "./template-manifest";
 import { buildSemanticTree } from "./tree";
 
+const EXPECTED_ITEM_HEADER_ROW = {
+	"item-header-row": {
+		key: "item-header-row",
+		owner: {
+			kind: "item-header",
+			key: "item-header",
+			sectionTypes: ["awards", "certifications", "projects", "publications"],
+		},
+		binding: { type: "primitive", primitive: "View", source: "existing" },
+		route: {
+			parent: "owner",
+			at: "start",
+			take: [
+				{ kind: "field", name: "title", sectionTypes: ["awards", "certifications", "publications"] },
+				{ kind: "field", name: "date", sectionTypes: ["awards", "certifications", "publications"] },
+				{ kind: "field", name: "name", sectionTypes: ["projects"] },
+				{ kind: "field", name: "period", sectionTypes: ["projects"] },
+				{ kind: "link", sectionTypes: ["awards", "certifications", "projects", "publications"] },
+			],
+		},
+	},
+} as const;
+
 const EXPECTED_PARTS = {
 	azurill: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"timeline-line": {
 			key: "timeline-line",
 			owner: { kind: "section-items", key: "section-items", placement: "main", columns: 1 },
@@ -42,6 +66,7 @@ const EXPECTED_PARTS = {
 		},
 	},
 	bronzor: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"interleaved-section-row": {
 			key: "interleaved-section-row",
 			owner: { kind: "section", key: "section", placement: "main" },
@@ -49,6 +74,7 @@ const EXPECTED_PARTS = {
 		},
 	},
 	chikorita: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"contact-row-primary": {
 			key: "contact-row-primary",
 			owner: { kind: "contact-list", key: "contact-list" },
@@ -78,6 +104,7 @@ const EXPECTED_PARTS = {
 		},
 	},
 	ditgar: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"featured-summary": {
 			key: "featured-summary",
 			owner: { kind: "region", key: "featured" },
@@ -113,6 +140,7 @@ const EXPECTED_PARTS = {
 		},
 	},
 	ditto: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"header-band": {
 			key: "header-band",
 			owner: { kind: "header", key: "header" },
@@ -137,6 +165,7 @@ const EXPECTED_PARTS = {
 		},
 	},
 	gengar: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"featured-summary": {
 			key: "featured-summary",
 			owner: { kind: "region", key: "featured" },
@@ -150,6 +179,7 @@ const EXPECTED_PARTS = {
 		},
 	},
 	glalie: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"sidebar-background": {
 			key: "sidebar-background",
 			owner: { kind: "region", key: "sidebar" },
@@ -157,9 +187,10 @@ const EXPECTED_PARTS = {
 			route: { parent: "owner", at: "start" },
 		},
 	},
-	kakuna: {},
-	lapras: {},
+	kakuna: { ...EXPECTED_ITEM_HEADER_ROW },
+	lapras: { ...EXPECTED_ITEM_HEADER_ROW },
 	leafish: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"header-intro": {
 			key: "header-intro",
 			owner: { kind: "header", key: "header" },
@@ -184,6 +215,7 @@ const EXPECTED_PARTS = {
 		},
 	},
 	meowth: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"inline-item-header-leading": {
 			key: "inline-item-header-leading",
 			owner: {
@@ -247,8 +279,9 @@ const EXPECTED_PARTS = {
 			},
 		},
 	},
-	onyx: {},
+	onyx: { ...EXPECTED_ITEM_HEADER_ROW },
 	pikachu: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"header-divider": {
 			key: "header-divider",
 			owner: { kind: "header", key: "header" },
@@ -257,6 +290,7 @@ const EXPECTED_PARTS = {
 		},
 	},
 	rhyhorn: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"contact-item-content": {
 			key: "contact-item-content",
 			owner: { kind: "contact-item", key: "contact-item" },
@@ -274,6 +308,7 @@ const EXPECTED_PARTS = {
 		},
 	},
 	scizor: {
+		...EXPECTED_ITEM_HEADER_ROW,
 		"header-name-rule": {
 			key: "header-name-rule",
 			owner: { kind: "header", key: "header" },
@@ -456,6 +491,16 @@ const buildFixture = (): ResumeData => {
 			roles: [],
 		},
 	];
+	data.sections.projects.items = [
+		{
+			id: "projects/1",
+			hidden: false,
+			name: "Analytical Engine",
+			period: "1843",
+			website: { url: "https://project.example.com", label: "Project", inlineLink: true },
+			description: "<p>Wrote the first program.</p>",
+		},
+	];
 	data.sections.skills.items = [
 		{
 			id: "skills/1",
@@ -474,7 +519,7 @@ const buildFixture = (): ResumeData => {
 
 const buildFixtureTree = (template: Template, showHeader = true): SemanticNode => {
 	const data = buildFixture();
-	const page = { fullWidth: false, main: ["summary", "experience"], sidebar: ["skills"] };
+	const page = { fullWidth: false, main: ["summary", "experience", "projects"], sidebar: ["skills"] };
 
 	return buildSemanticTree({ data, template, page, pageNumber: 1, showHeader });
 };
@@ -555,7 +600,7 @@ describe("template semantic manifests", () => {
 
 		(unknownRegionPlacement.regions[0] as { placement: string }).placement = "footer";
 		(unknownHeaderPlacement.header as { placement: string }).placement = "footer";
-		const alias = ownerLie.parts[0]?.binding;
+		const alias = ownerLie.parts.find((part) => part.name === "interleaved-section-row")?.binding;
 		if (alias?.type !== "alias") throw new Error("Missing Bronzor alias fixture");
 		(alias as { canonicalKind: string }).canonicalKind = "item";
 		const primitive = synthetic.parts[0]?.binding;
@@ -606,7 +651,7 @@ describe("template semantic manifests", () => {
 			token: "contact-item-content",
 		};
 		delete (content as unknown as { route?: object }).route;
-		const row = aliasToPrimitive.parts[0];
+		const row = aliasToPrimitive.parts.find((part) => part.name === "interleaved-section-row");
 		if (!row) throw new Error("Missing Bronzor row");
 		(row as unknown as { binding: object; route?: object }).binding = {
 			type: "primitive",
@@ -766,9 +811,20 @@ describe("template semantic manifests", () => {
 				description: "",
 			},
 		];
+		data.sections.awards.items = [
+			{
+				id: "award/coverage",
+				hidden: false,
+				title: "Order of Merit",
+				awarder: "Royal Society",
+				date: "1844",
+				website: { url: "", label: "", inlineLink: false },
+				description: "",
+			},
+		];
 		const page = {
 			fullWidth: false,
-			main: ["summary", "experience", "education", "volunteer", "skills"],
+			main: ["summary", "experience", "education", "volunteer", "projects", "awards", "skills"],
 			sidebar: [],
 		};
 		const partNames = new Set<string>();
@@ -803,6 +859,7 @@ describe("template semantic manifests", () => {
 				"inline-item-header-leading",
 				"inline-item-header-middle",
 				"inline-item-header-trailing",
+				"item-header-row",
 				"picture-anchor",
 				"sidebar-background",
 				"timeline-content",
@@ -836,6 +893,8 @@ describe("template semantic manifests", () => {
 				"inline-item-header-middle:field",
 				"inline-item-header-middle:link",
 				"inline-item-header-trailing:field",
+				"item-header-row:field",
+				"item-header-row:link",
 				"picture-anchor:picture",
 				"timeline-content:field",
 				"timeline-content:item",

--- a/packages/pdf/src/templates/azurill/semantic.ts
+++ b/packages/pdf/src/templates/azurill/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const azurillSemanticManifest = {
 	template: "azurill",
@@ -10,6 +11,7 @@ export const azurillSemanticManifest = {
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "timeline-line",
 			key: "timeline-line",

--- a/packages/pdf/src/templates/bronzor/semantic.ts
+++ b/packages/pdf/src/templates/bronzor/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const bronzorSemanticManifest = {
 	template: "bronzor",
@@ -9,6 +10,7 @@ export const bronzorSemanticManifest = {
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "interleaved-section-row",
 			key: "interleaved-section-row",

--- a/packages/pdf/src/templates/chikorita/semantic.ts
+++ b/packages/pdf/src/templates/chikorita/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const chikoritaSemanticManifest = {
 	template: "chikorita",
@@ -10,6 +11,7 @@ export const chikoritaSemanticManifest = {
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "contact-row-primary",
 			key: "contact-row-primary",

--- a/packages/pdf/src/templates/ditgar/semantic.ts
+++ b/packages/pdf/src/templates/ditgar/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 const borderedItemHeaderSectionTypes = [
 	"profiles",
@@ -26,6 +27,7 @@ export const ditgarSemanticManifest = {
 	header: { region: "header", placement: "sidebar" },
 	specialSummary: { region: "featured", placement: "main", source: "main-with-header" },
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "featured-summary",
 			key: "featured-summary",

--- a/packages/pdf/src/templates/ditto/semantic.ts
+++ b/packages/pdf/src/templates/ditto/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const dittoSemanticManifest = {
 	template: "ditto",
@@ -10,6 +11,7 @@ export const dittoSemanticManifest = {
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "header-band",
 			key: "header-band",

--- a/packages/pdf/src/templates/gengar/semantic.ts
+++ b/packages/pdf/src/templates/gengar/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const gengarSemanticManifest = {
 	template: "gengar",
@@ -11,6 +12,7 @@ export const gengarSemanticManifest = {
 	header: { region: "header", placement: "sidebar" },
 	specialSummary: { region: "featured", placement: "main", source: "main-with-header" },
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "featured-summary",
 			key: "featured-summary",

--- a/packages/pdf/src/templates/glalie/semantic.ts
+++ b/packages/pdf/src/templates/glalie/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const glalieSemanticManifest = {
 	template: "glalie",
@@ -10,6 +11,7 @@ export const glalieSemanticManifest = {
 	header: { region: "header", placement: "sidebar" },
 	specialSummary: null,
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "sidebar-background",
 			key: "sidebar-background",

--- a/packages/pdf/src/templates/kakuna/semantic.ts
+++ b/packages/pdf/src/templates/kakuna/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const kakunaSemanticManifest = {
 	template: "kakuna",
@@ -9,5 +10,5 @@ export const kakunaSemanticManifest = {
 	],
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
-	parts: [],
+	parts: [itemHeaderRowPart],
 } as const satisfies TemplateSemanticManifest;

--- a/packages/pdf/src/templates/lapras/semantic.ts
+++ b/packages/pdf/src/templates/lapras/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const laprasSemanticManifest = {
 	template: "lapras",
@@ -9,5 +10,5 @@ export const laprasSemanticManifest = {
 	],
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
-	parts: [],
+	parts: [itemHeaderRowPart],
 } as const satisfies TemplateSemanticManifest;

--- a/packages/pdf/src/templates/leafish/semantic.ts
+++ b/packages/pdf/src/templates/leafish/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const leafishSemanticManifest = {
 	template: "leafish",
@@ -10,6 +11,7 @@ export const leafishSemanticManifest = {
 	header: { region: "header", placement: "main" },
 	specialSummary: { region: "header", placement: "main", source: "always" },
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "header-intro",
 			key: "header-intro",

--- a/packages/pdf/src/templates/meowth/semantic.ts
+++ b/packages/pdf/src/templates/meowth/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 const inlineHeaderSectionTypes = ["experience", "education", "volunteer"] as const;
 
@@ -12,6 +13,7 @@ export const meowthSemanticManifest = {
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "inline-item-header-leading",
 			key: "inline-item-header-leading",

--- a/packages/pdf/src/templates/onyx/semantic.ts
+++ b/packages/pdf/src/templates/onyx/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const onyxSemanticManifest = {
 	template: "onyx",
@@ -9,5 +10,5 @@ export const onyxSemanticManifest = {
 	],
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
-	parts: [],
+	parts: [itemHeaderRowPart],
 } as const satisfies TemplateSemanticManifest;

--- a/packages/pdf/src/templates/pikachu/semantic.ts
+++ b/packages/pdf/src/templates/pikachu/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const pikachuSemanticManifest = {
 	template: "pikachu",
@@ -10,6 +11,7 @@ export const pikachuSemanticManifest = {
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "header-divider",
 			key: "header-divider",

--- a/packages/pdf/src/templates/rhyhorn/semantic.ts
+++ b/packages/pdf/src/templates/rhyhorn/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const rhyhornSemanticManifest = {
 	template: "rhyhorn",
@@ -10,6 +11,7 @@ export const rhyhornSemanticManifest = {
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "contact-item-content",
 			key: "contact-item-content",

--- a/packages/pdf/src/templates/scizor/semantic.ts
+++ b/packages/pdf/src/templates/scizor/semantic.ts
@@ -1,4 +1,5 @@
 import type { TemplateSemanticManifest } from "../../semantic/template-manifest";
+import { itemHeaderRowPart } from "../../semantic/shared-parts";
 
 export const scizorSemanticManifest = {
 	template: "scizor",
@@ -9,6 +10,7 @@ export const scizorSemanticManifest = {
 	header: { region: "header", placement: "main" },
 	specialSummary: null,
 	parts: [
+		itemHeaderRowPart,
 		{
 			name: "header-name-rule",
 			key: "header-name-rule",

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -42,6 +42,7 @@ import {
 	useSemanticSectionNodeKey,
 } from "../../semantic/context";
 import { semanticNodeKeys } from "../../semantic/node-keys";
+import { ITEM_HEADER_ROW_PART_KEYS } from "../../semantic/shared-parts";
 import { getSectionItemRows, getSectionItemsLayout, shouldUseSectionTimeline } from "./columns";
 import { getWebsiteDisplayText } from "./contact";
 import {
@@ -612,6 +613,25 @@ const useSectionSplitRowStyle = () => {
 	);
 };
 
+type ItemHeaderRowProps = {
+	children: ReactNode;
+	style: StyleInput;
+};
+
+/**
+ * The title/date row inside a section item header, exposed to Semantic CSS as
+ * `template-part[name="item-header-row"]`.
+ *
+ * It has to be addressable on its own: the row carries `flex-wrap: wrap`, so a long title pushes
+ * the trailing date onto its own line, and `item-header` selects the box around the row rather than
+ * the row itself. The owning item-header key comes from the surrounding provider.
+ */
+const ItemHeaderRow = ({ children, style }: ItemHeaderRowProps) => (
+	<SemanticTemplatePartView partKeys={ITEM_HEADER_ROW_PART_KEYS} style={composeStyles(style)}>
+		{children}
+	</SemanticTemplatePartView>
+);
+
 const SectionItemHeader = ({ children }: SectionItemHeaderProps) => {
 	const itemNodeKey = useSemanticNodeKey();
 	const itemHeaderNodeKey = itemNodeKey ? semanticNodeKeys.itemHeader(itemNodeKey) : undefined;
@@ -1109,14 +1129,14 @@ const ProjectsSection = ({ sectionId = "projects", sectionData }: ItemSectionPro
 				{items.map((item) => (
 					<SectionItem key={item.id} itemId={item.id}>
 						<SectionItemHeader>
-							<View style={composeStyles(splitRowStyle)}>
+							<ItemHeaderRow style={composeStyles(splitRowStyle)}>
 								<ItemTitle field="name" website={item.website}>
 									{item.name}
 								</ItemTitle>
 								<Text semanticField="period" style={composeStyles(alignEndStyle)}>
 									{item.period}
 								</Text>
-							</View>
+							</ItemHeaderRow>
 						</SectionItemHeader>
 
 						<RichText semanticField="description">{item.description}</RichText>
@@ -1232,14 +1252,14 @@ const AwardsSection = ({ sectionId = "awards", sectionData }: ItemSectionProps<A
 				{items.map((item) => (
 					<SectionItem key={item.id} itemId={item.id}>
 						<SectionItemHeader>
-							<View style={composeStyles(splitRowStyle, awardTitleDateRowStyle)}>
+							<ItemHeaderRow style={composeStyles(splitRowStyle, awardTitleDateRowStyle)}>
 								<ItemTitle field="title" website={item.website} bold={false}>
 									{item.title}
 								</ItemTitle>
 								<Text semanticField="date" style={composeStyles(alignEndStyle)}>
 									{item.date}
 								</Text>
-							</View>
+							</ItemHeaderRow>
 							<Text semanticField="awarder">{item.awarder}</Text>
 						</SectionItemHeader>
 						<RichText semanticField="description">{item.description}</RichText>
@@ -1270,14 +1290,14 @@ const CertificationsSection = ({
 				{items.map((item) => (
 					<SectionItem key={item.id} itemId={item.id}>
 						<SectionItemHeader>
-							<View style={composeStyles(splitRowStyle)}>
+							<ItemHeaderRow style={composeStyles(splitRowStyle)}>
 								<ItemTitle field="title" website={item.website}>
 									{item.title}
 								</ItemTitle>
 								<Text semanticField="date" style={composeStyles(alignEndStyle)}>
 									{item.date}
 								</Text>
-							</View>
+							</ItemHeaderRow>
 							<Text semanticField="issuer">{item.issuer}</Text>
 						</SectionItemHeader>
 
@@ -1306,14 +1326,14 @@ const PublicationsSection = ({ sectionId = "publications", sectionData }: ItemSe
 				{items.map((item) => (
 					<SectionItem key={item.id} itemId={item.id}>
 						<SectionItemHeader>
-							<View style={composeStyles(splitRowStyle)}>
+							<ItemHeaderRow style={composeStyles(splitRowStyle)}>
 								<ItemTitle field="title" website={item.website}>
 									{item.title}
 								</ItemTitle>
 								<Text semanticField="date" style={composeStyles(alignEndStyle)}>
 									{item.date}
 								</Text>
-							</View>
+							</ItemHeaderRow>
 
 							<Text semanticField="publisher">{item.publisher}</Text>
 						</SectionItemHeader>

--- a/packages/resume/src/stylesheet/registry/semantic.test.ts
+++ b/packages/resume/src/stylesheet/registry/semantic.test.ts
@@ -86,6 +86,7 @@ const expectedTemplatePartChildren = {
 	"header-intro": ["template-part"],
 	"header-body": ["picture", "name", "headline", "section"],
 	"header-contact-band": ["contact-list"],
+	"item-header-row": ["field", "link"],
 	"inline-item-header-leading": ["field", "combined-text"],
 	"inline-item-header-middle": ["field", "link"],
 	"inline-item-header-trailing": ["field"],

--- a/packages/resume/src/stylesheet/registry/semantic.ts
+++ b/packages/resume/src/stylesheet/registry/semantic.ts
@@ -193,6 +193,7 @@ const templatePartChildKinds = {
 	"header-intro": ["template-part"],
 	"header-body": ["picture", "name", "headline", "section"],
 	"header-contact-band": ["contact-list"],
+	"item-header-row": ["field", "link"],
 	"inline-item-header-leading": ["field", "combined-text"],
 	"inline-item-header-middle": ["field", "link"],
 	"inline-item-header-trailing": ["field"],


### PR DESCRIPTION
## Summary

Section item headers render an item's title and its trailing date inside a shared split row styled with `flex-wrap: wrap`. When the title is long enough to fill the line, the date wraps onto its own line and left-aligns instead of staying pinned to the right — so a list of certifications ends up with the date in a different place on almost every entry.

That row had no selector in Semantic CSS. It is a bare `View`, so it never appeared in the semantic tree: `item-header` matches the box *around* the row, and `field[name="title"]` / `field[name="date"]` are text nodes that layout properties do not apply to. There was no stylesheet a reader could write to reach it.

This exposes the row as `template-part[name="item-header-row"]`:

```
@version 1;
template-part[name="item-header-row"] { flex-wrap: nowrap; }
```

Reported in #3332, where the dates in a two-column certifications list land inconsistently.

## Changes

- `packages/pdf/src/semantic/shared-parts.ts` — new `itemHeaderRowPart`, declared once and shared by every template, since the row comes from the shared section components rather than from any one template.
- All 15 template manifests include it.
- `packages/pdf/src/templates/shared/sections.tsx` — the four affected sections render an `ItemHeaderRow` (wrapping `SemanticTemplatePartView`) instead of a bare `View`.
- `packages/resume/src/stylesheet/registry/semantic.ts` — registers `field` and `link` as the part's legal children.

## Scope

Covered: **awards, certifications, projects, publications** — the sections whose item header is a single title/date row.

Deliberately excluded: **experience, education, volunteer**. They stack two rows, and on templates with the `inlineItemHeader` feature their headers already belong to the `inline-item-header-*` parts, which would compete for the same fields.

## Verification

- New `packages/pdf/src/semantic/item-header-row.test.tsx` asserts the part wraps title + date and leaves the issuer outside, that the override reaches the rendered row on onyx / ditgar / meowth, that experience is untouched, and that the selector produces no diagnostics. Confirmed this test fails 5/6 against `main` — including `SELECTOR_NO_MATCH`, which is the proof that no selector previously existed.
- The rendered row goes from `flexWrap: "wrap"` to `flexWrap: "nowrap"` with the stylesheet applied, and nothing else in its style changes.
- Checked against actual PDF geometry: without the rule the date renders at `x=14, y=746.99` (its own line, left margin); with it, `x=530.87, y=761.99` — the title's baseline, right margin. With a 165-character title the title text rewraps to two lines and the date stays pinned; no overlap or overflow.
- All 15 templates behave the same way; `ditgar`'s extra `mainItemHeaderBorder` wrapper does not intercept the part.
- Full suite, typecheck, `turbo boundaries`, `biome check` and `knip` are clean. Snapshot churn is 135 added lines, all of them the new node key.

## Known issue, not fixed here

`SectionItemHeader`'s `bindFirstExistingView` calls `isValidElement(children)`, which is `false` whenever the header has more than one child — JSX passes an array. So on the 14 templates where `mainItemHeaderBorder` is off, `item-header { … }` is silently dropped for certifications, publications, awards, volunteer and projects. Worth its own PR; fixing it changes which element item-header styles land on across many templates, which deserves separate review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added semantic support for independently styling item header rows across awards, certifications, projects, and publications.
  * Exposed title, date, name, period, and link content for targeted styling.
  * Enabled the new semantic part across supported resume templates.

* **Bug Fixes**
  * Improved consistency of semantic structure and stylesheet overrides across templates.

* **Tests**
  * Added coverage for rendering, routing, style overrides, compilation, and semantic validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR exposes the shared title/date row in awards, certifications, projects, and publications as a Semantic CSS template part.
- Adds a shared `item-header-row` manifest part to all 15 templates.
- Replaces the affected bare row views with `SemanticTemplatePartView` wrappers.
- Registers the part’s legal semantic children and adds tree, selector, rendering, manifest, and snapshot coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no unacknowledged actionable defects identified.

The new part is consistently declared, routed, registered, rendered, and tested across all templates; the remaining project item-header binding limitation is explicitly documented and deferred by the PR.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/pdf/src/semantic/shared-parts.ts | Defines the shared item-header-row ownership, binding, and routing contract for the four supported section types. |
| packages/pdf/src/templates/shared/sections.tsx | Exposes the four title/date rows through SemanticTemplatePartView while preserving their existing base styles; the documented project item-header limitation remains. |
| packages/resume/src/stylesheet/registry/semantic.ts | Registers field and link as valid direct children of the new template part. |
| packages/pdf/src/semantic/item-header-row.test.tsx | Verifies semantic tree placement, section exclusions, selector diagnostics, and rendered flex-wrap overrides across representative templates. |
| packages/pdf/src/semantic/template-manifest.test.ts | Extends manifest and reachability expectations for the shared part across every template. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Section item header] --> B[template-part: item-header-row]
  B --> C[Title or project name]
  B --> D[Date or project period]
  B --> E[Optional inline link]
  F[Semantic CSS selector] --> B
  B --> G[Resolved PDF row styles]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(stylesheet): expose the item header..."](https://github.com/amruthpillai/reactive-resume/commit/bb1bb228b5bab1fe3e09a26e75c629a86a619abc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54145857)</sub>

<!-- /greptile_comment -->