### PR TITLE
fix(ai): use current date for resume chronology analysis

### DIFF
--- a/packages/ai/src/prompts/analyze-resume-system.md
+++ b/packages/ai/src/prompts/analyze-resume-system.md
@@ -47,6 +47,7 @@ Do not include markdown, comments, or additional keys.
 4. Never invent candidate achievements or facts.
 5. If data is missing, call it out explicitly in rationale/suggestions.
 6. Keep scorecard dimensions practical and common for resume review.
+7. Use the current date from the analysis context for chronology checks. Do not flag a date on or before that date as future-dated.
 
 ## Suggestions Requirements
 

--- a/packages/api/src/features/ai/service.test.ts
+++ b/packages/api/src/features/ai/service.test.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from "ai";
+import type { ResumeData } from "@reactive-resume/schema/resume/data";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { convertToModelMessages, modelMessageSchema } from "ai";
 
@@ -10,6 +11,7 @@ vi.mock("@reactive-resume/env/server", () => ({ env: envMock }));
 
 afterEach(() => {
 	vi.unstubAllGlobals();
+	vi.useRealTimers();
 });
 
 function stubOpenAICompatibleResponse(response?: { content?: string; finishReason?: string }) {
@@ -67,7 +69,7 @@ function stubRejectedFetch(error: unknown) {
 	return fetchMock;
 }
 
-const { testConnection } = await import("./service");
+const { analyzeResume, testConnection } = await import("./service");
 
 describe("AI provider connection test", () => {
 	it("names the rejected key instead of reporting a transport failure", async () => {
@@ -165,6 +167,26 @@ describe("AI provider connection test", () => {
 			expect(result.message).not.toContain("tok123");
 			expect(result.message).toContain("***");
 		}
+	});
+});
+
+describe("AI resume analysis", () => {
+	it("gives the model the actual current date for chronology checks", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-18T12:00:00Z"));
+
+		const response = stubOpenAICompatibleResponse({
+			content: JSON.stringify({
+				overallScore: 80,
+				scorecard: [{ dimension: "Clarity", score: 80, rationale: "Clear." }],
+				suggestions: [],
+				strengths: ["Clear experience."],
+			}),
+		});
+
+		await analyzeResume({ ...testInput(), resumeData: {} as ResumeData });
+
+		expect(JSON.stringify(response.getRequestBody())).toContain("Current date: 2026-08-18");
 	});
 });
 

--- a/packages/api/src/features/ai/service.ts
+++ b/packages/api/src/features/ai/service.ts
@@ -509,8 +509,9 @@ type AnalyzeResumeInput = z.infer<typeof aiCredentialsSchema> & {
 	resumeData: ResumeData;
 };
 
-function buildAnalyzeResumeSystemPrompt(resumeData: ResumeData): string {
-	return `${analyzeResumeSystemPromptTemplate}\n\n## Resume Data\n\n${JSON.stringify(resumeData, null, 2)}`;
+function buildAnalyzeResumeSystemPrompt(resumeData: ResumeData, now = new Date()): string {
+	const currentDate = now.toISOString().slice(0, 10);
+	return `${analyzeResumeSystemPromptTemplate}\n\n## Analysis Context\n\nCurrent date: ${currentDate} (UTC). Treat dates on or before this date as not future-dated. Flag a date as future-dated only when it is after the current date.\n\n## Resume Data\n\n${JSON.stringify(resumeData, null, 2)}`;
 }
 
 /** Sends resume data to the AI provider and returns a structured analysis, parsing raw JSON from the response text. */


### PR DESCRIPTION
The AI resume-analysis prompt did not include the current date, so models could apply an outdated internal date when reviewing employment chronology. This caused valid dates such as January–March 2026 to be reported as future-dated in August 2026.

This change injects the current UTC date into the analysis context and explicitly instructs the model to flag only dates after that date. It also adds a regression test that freezes the clock and verifies the date is sent in the model request.

Focused tests could not run locally because pnpm dependency verification depends on an unavailable local registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume analysis date handling by including the current date in the evaluation context.
  * Prevented dates on or before the analysis date from being incorrectly flagged as future-dated.

* **Tests**
  * Added coverage to verify that the current date is included in resume-analysis requests.
  * Improved test cleanup for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR supplies the current UTC date to AI resume analysis so employment chronology is evaluated against the actual analysis date.
- Adds explicit chronology guidance to the resume-analysis system prompt.
- Injects a server-derived UTC date into the analysis context.
- Adds a clock-frozen regression test that verifies the date reaches the provider request.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The production analysis path consistently derives the current UTC date, embeds it in the system prompt, and sends that prompt to the configured model provider; the added regression test verifies the outbound request.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ai/src/prompts/analyze-resume-system.md | Adds guidance requiring chronology checks to use the date supplied in the analysis context. |
| packages/api/src/features/ai/service.ts | Generates the current UTC calendar date and includes it in the resume-analysis system prompt. |
| packages/api/src/features/ai/service.test.ts | Freezes time and verifies that the expected UTC date appears in the outbound model request. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ai): provide current date to resume ..."](https://github.com/amruthpillai/reactive-resume/commit/523f88049f756567fa7f2cdd0de3733a90498fbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54338656)</sub>

<!-- /greptile_comment -->