### PR TITLE
fix(stylesheet): stop item header titles overlapping the date under nowrap

### DIFF
--- a/packages/pdf/src/semantic/item-header-row.test.tsx
+++ b/packages/pdf/src/semantic/item-header-row.test.tsx
@@ -62,7 +62,7 @@ const buildFixture = (): ResumeData => {
 	return data;
 };
 
-const renderTitleRowStyle = async (template: Template, stylesheet?: string) => {
+const renderTitleRowStyles = async (template: Template, stylesheet?: string) => {
 	const data = buildFixture();
 	const semanticRuntime = stylesheet
 		? resolveResumeRuntime({ data, template, mode: "semantic", source: { languageVersion: 1, text: stylesheet } })
@@ -76,9 +76,10 @@ const renderTitleRowStyle = async (template: Template, stylesheet?: string) => {
 	const path = pathTo(document, (node) => nodeText(node).trim() === LONG_TITLE);
 	if (!path) throw new Error("Missing certification title in the rendered document");
 	const row = path.at(-2);
-	if (!row) throw new Error("Missing the row wrapping the certification title");
+	const title = path.at(-1);
+	if (!row || !title) throw new Error("Missing the row wrapping the certification title");
 
-	return mergedStyle(row);
+	return { row: mergedStyle(row), title: mergedStyle(title) };
 };
 
 describe("item-header-row template part", () => {
@@ -112,8 +113,19 @@ describe("item-header-row template part", () => {
 	// The row ships with `flex-wrap: wrap`, which drops a long title's date onto its own line. This
 	// is the whole point of exposing the part, so assert the override reaches the rendered row.
 	it.each(["onyx", "ditgar", "meowth"] as const)("lets %s stylesheets turn off the row wrap", async (template) => {
-		expect(await renderTitleRowStyle(template)).toMatchObject({ flexWrap: "wrap" });
-		expect(await renderTitleRowStyle(template, NOWRAP_STYLESHEET)).toMatchObject({ flexWrap: "nowrap" });
+		expect((await renderTitleRowStyles(template)).row).toMatchObject({ flexWrap: "wrap" });
+		expect((await renderTitleRowStyles(template, NOWRAP_STYLESHEET)).row).toMatchObject({ flexWrap: "nowrap" });
+	});
+
+	// React PDF reuses the line layout a Text was first measured with, so a title Yoga shrinks after
+	// that measurement draws its glyphs over the date. Under `nowrap` the title takes a zero flex
+	// basis instead, which makes its first measurement its final width.
+	it("gives the title a zero flex basis only when the row stops wrapping", async () => {
+		expect((await renderTitleRowStyles("onyx")).title).not.toMatchObject({ flexBasis: 0 });
+		expect((await renderTitleRowStyles("onyx", NOWRAP_STYLESHEET)).title).toMatchObject({
+			flexBasis: 0,
+			flexGrow: 1,
+		});
 	});
 
 	it("reports no diagnostics for the selector", () => {

--- a/packages/pdf/src/templates/shared/sections.test.ts
+++ b/packages/pdf/src/templates/shared/sections.test.ts
@@ -17,9 +17,8 @@ describe("ExperienceSection", () => {
 describe("ItemTitle", () => {
 	it("renders award titles without the bold style", () => {
 		expect(source).toContain("const ItemTitle = ({ children, website, field, bold = true }: ItemTitleProps)");
-		expect(source).toContain(
-			"const title = bold ? <Bold semanticField={field}>{children}</Bold> : <Text semanticField={field}>{children}</Text>;",
-		);
+		expect(source).toContain("const title = bold ? (\n\t\t<Bold style={style} semanticField={field}>");
+		expect(source).toContain("\t) : (\n\t\t<Text style={style} semanticField={field}>");
 		expect(source).toContain('<ItemTitle field="title" website={item.website} bold={false}>');
 	});
 });

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -75,7 +75,7 @@ import { createRtlStyleHelpers } from "./rtl";
 import { getInlineItemWebsiteUrl, shouldRenderSeparateItemWebsite } from "./section-links";
 import { hasSplitRowText } from "./split-row";
 import { getSectionStyleRuleContext } from "./style-rules";
-import { composeStyles } from "./styles";
+import { composeStyles, mergeStyles } from "./styles";
 
 type SectionItemsContextValue = {
 	itemStyle: StyleInput;
@@ -641,10 +641,12 @@ const ItemHeaderRowNowrapContext = createContext(false);
 const ItemHeaderRow = ({ children, style }: ItemHeaderRowProps) => {
 	const ownerNodeKey = useSemanticNodeKey();
 	const resolved = useResolvedNode(semanticTemplatePartNodeKey(ownerNodeKey, ...ITEM_HEADER_ROW_PART_KEYS));
+	// Same order the rendered row composes in, so a template that ships `nowrap` counts too.
+	const { flexWrap } = mergeStyles(style, resolved.style);
 
 	return (
 		<SemanticTemplatePartView partKeys={ITEM_HEADER_ROW_PART_KEYS} style={composeStyles(style)}>
-			<ItemHeaderRowNowrapContext.Provider value={resolved.style?.flexWrap === "nowrap"}>
+			<ItemHeaderRowNowrapContext.Provider value={flexWrap === "nowrap"}>
 				{children}
 			</ItemHeaderRowNowrapContext.Provider>
 		</SemanticTemplatePartView>

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -619,6 +619,18 @@ type ItemHeaderRowProps = {
 };
 
 /**
+ * React PDF lays a `Text` out once, at the width it is first measured at, and reuses those lines
+ * afterwards. `flex-wrap: nowrap` asks Yoga to shrink the title so the date fits beside it, and the
+ * cached lines keep the wider layout, so the title's glyphs run over the date. A zero flex basis
+ * makes the title's first measurement its final width, so it wraps inside its own box instead.
+ */
+const nowrapItemTitleStyle = { flexGrow: 1, flexBasis: 0 } satisfies Style;
+const wrappingItemTitleStyle = {} satisfies Style;
+
+/** True while rendering inside an item header row a stylesheet turned into a single line. */
+const ItemHeaderRowNowrapContext = createContext(false);
+
+/**
  * The title/date row inside a section item header, exposed to Semantic CSS as
  * `template-part[name="item-header-row"]`.
  *
@@ -626,11 +638,18 @@ type ItemHeaderRowProps = {
  * the trailing date onto its own line, and `item-header` selects the box around the row rather than
  * the row itself. The owning item-header key comes from the surrounding provider.
  */
-const ItemHeaderRow = ({ children, style }: ItemHeaderRowProps) => (
-	<SemanticTemplatePartView partKeys={ITEM_HEADER_ROW_PART_KEYS} style={composeStyles(style)}>
-		{children}
-	</SemanticTemplatePartView>
-);
+const ItemHeaderRow = ({ children, style }: ItemHeaderRowProps) => {
+	const ownerNodeKey = useSemanticNodeKey();
+	const resolved = useResolvedNode(semanticTemplatePartNodeKey(ownerNodeKey, ...ITEM_HEADER_ROW_PART_KEYS));
+
+	return (
+		<SemanticTemplatePartView partKeys={ITEM_HEADER_ROW_PART_KEYS} style={composeStyles(style)}>
+			<ItemHeaderRowNowrapContext.Provider value={resolved.style?.flexWrap === "nowrap"}>
+				{children}
+			</ItemHeaderRowNowrapContext.Provider>
+		</SemanticTemplatePartView>
+	);
+};
 
 const SectionItemHeader = ({ children }: SectionItemHeaderProps) => {
 	const itemNodeKey = useSemanticNodeKey();
@@ -687,12 +706,21 @@ const SectionItemHeader = ({ children }: SectionItemHeaderProps) => {
 
 const ItemTitle = ({ children, website, field, bold = true }: ItemTitleProps) => {
 	const inlineWebsiteUrl = getInlineItemWebsiteUrl(website);
-	const title = bold ? <Bold semanticField={field}>{children}</Bold> : <Text semanticField={field}>{children}</Text>;
+	const style = use(ItemHeaderRowNowrapContext) ? nowrapItemTitleStyle : wrappingItemTitleStyle;
+	const title = bold ? (
+		<Bold style={style} semanticField={field}>
+			{children}
+		</Bold>
+	) : (
+		<Text style={style} semanticField={field}>
+			{children}
+		</Text>
+	);
 
 	if (!inlineWebsiteUrl) return title;
 
 	return (
-		<Link semanticRole="inline-website" src={inlineWebsiteUrl}>
+		<Link style={style} semanticRole="inline-website" src={inlineWebsiteUrl}>
 			{title}
 		</Link>
 	);


### PR DESCRIPTION
Follow-up to #3345. `template-part[name="item-header-row"]` was exposed so a stylesheet could write `flex-wrap: nowrap` and keep a section item's date pinned beside its title. Doing that overlapped the two — the title's glyphs ran straight over the date, which is worse than the wrapping it was meant to fix.

## Cause

React PDF measures a `Text` once and reuses those lines for the rest of the layout (`measureText` caches `node.lines`). `nowrap` asks Yoga to shrink the title so the date fits next to it, and that shrink happens after the measurement, so the cached lines keep the wider layout. The box narrows, the glyphs do not.

Azurill sidebar certifications, `flex-wrap: nowrap`, laid-out boxes:

```
TEXT w=147.6  lines=1:198.5  "Unity Certified Expert: Programmer"   <- box 147.6, ink laid out at 198.5
TEXT x=150.2  w=48.3         "March 2022"                           <- overlapped
```

## Fix

Give the title `flex-grow: 1; flex-basis: 0` while the row resolves to `nowrap`. A zero basis makes the title's first measurement its final width, so it wraps inside its own box and the date keeps its place.

```
TEXT w=139.6  lines=2:141.9,139.6   TEXT x=142.2 w=56.3 "March 2022"   <- clear
```

The style is applied only when the resolved row style asks for `nowrap`, passed down through a context local to `sections.tsx`. The default wrap path is untouched, so no template changes behaviour and no snapshot moves.

## Verification

Checked in the running builder on azurill, not just in tests:

- `flex-wrap: nowrap` — the long certification title wraps inside its column and the date stays pinned right, no collision.
- back to a bare `@version 1;` — the date drops to its own line exactly as it does today.

`pnpm --filter @reactive-resume/pdf test` (644 passing), `typecheck`, `turbo boundaries` and `biome check` are all clean. Adds a regression test asserting the zero basis appears only under `nowrap`.

## Note for readers

`flex-wrap: wrap` is already the shipped default for this row (`base-template-styles.ts`), so writing it changes nothing — `nowrap` is the only value on this part that does anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF item headers with long titles to prevent overlap with trailing dates.
  * Headers now wrap titles correctly by default and honor configured no-wrap behavior.
  * Adjusted title sizing and spacing for more consistent layouts in compact headers.
  * Preserved semantic title formatting, including bold and regular text styles and inline website links.
  * Improved layout consistency when headers contain long titles or links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents long PDF item-header titles from overlapping trailing dates when semantic styles disable wrapping.
- Resolves the effective item-header row style and propagates its nowrap state through local context.
- Gives titles a zero flex basis and positive flex growth only on nowrap rows, including inline-linked titles.
- Adds regression coverage for conditional title sizing while preserving default wrapping behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/shared/sections.tsx | Resolves the item-header row's effective wrap mode and conditionally applies title flex sizing to prevent date overlap. |
| packages/pdf/src/semantic/item-header-row.test.tsx | Extends semantic rendering tests to verify zero flex basis and growth are applied only when the row resolves to nowrap. |
| packages/pdf/src/templates/shared/sections.test.ts | Updates source-level assertions for styled bold and regular title branches. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(stylesheet): read the item header ro..."](https://github.com/amruthpillai/reactive-resume/commit/08108018caccdd7f3fbfc0dc7204bf0dad7cef8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54408052)</sub>

<!-- /greptile_comment -->