### PR TITLE
fix(auth): allow unlinking providers after the session ages past a day

### DIFF
--- a/apps/web/src/libs/error-message.test.ts
+++ b/apps/web/src/libs/error-message.test.ts
@@ -11,8 +11,16 @@ describe("getReadableErrorMessage", () => {
 		expect(getReadableErrorMessage(new Error("boom"), "fallback")).toBe("boom");
 	});
 
+	it("returns the message of a plain error object (Better Auth client errors)", () => {
+		expect(getReadableErrorMessage({ code: "SESSION_NOT_FRESH", message: "Session is not fresh" }, "fallback")).toBe(
+			"Session is not fresh",
+		);
+	});
+
 	it("returns fallback for unknown shapes", () => {
 		expect(getReadableErrorMessage({ random: "object" }, "fallback")).toBe("fallback");
+		expect(getReadableErrorMessage({ message: "" }, "fallback")).toBe("fallback");
+		expect(getReadableErrorMessage({ message: 42 }, "fallback")).toBe("fallback");
 		expect(getReadableErrorMessage(null, "fallback")).toBe("fallback");
 		expect(getReadableErrorMessage(undefined, "fallback")).toBe("fallback");
 		expect(getReadableErrorMessage(42, "fallback")).toBe("fallback");

--- a/apps/web/src/libs/error-message.ts
+++ b/apps/web/src/libs/error-message.ts
@@ -3,6 +3,11 @@ import { ORPCError } from "@orpc/client";
 export function getReadableErrorMessage(error: unknown, fallback: string): string {
 	if (typeof error === "string" && error) return error;
 	if (error instanceof Error && error.message) return error.message;
+	// Better Auth client errors are plain objects ({ code, message, status }), not Error instances.
+	if (typeof error === "object" && error !== null && "message" in error) {
+		const { message } = error as { message?: unknown };
+		if (typeof message === "string" && message) return message;
+	}
 	return fallback;
 }
 

--- a/packages/auth/src/config.test.ts
+++ b/packages/auth/src/config.test.ts
@@ -13,3 +13,9 @@ describe("social provider signup policy", () => {
 		},
 	);
 });
+
+describe("session freshness", () => {
+	it("disables the freshness gate so provider unlinking works for week-old sessions", () => {
+		expect(auth.options.session?.freshAge).toBe(0);
+	});
+});

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -203,6 +203,12 @@ const getAuthConfig = () => {
 			},
 		},
 
+		// Better Auth gates `/unlink-account` (and `/list-sessions`) behind a "fresh"
+		// session, which defaults to one day old. Sessions here live for a week and
+		// there is no re-authentication flow to refresh that timestamp, so disconnecting
+		// a provider failed with `SESSION_NOT_FRESH` for anyone who signed in yesterday.
+		session: { freshAge: 0 },
+
 		account: {
 			accountLinking: {
 				enabled: true,


### PR DESCRIPTION
## Problem

On production, clicking **Disconnect** on a linked social provider always failed with the generic toast "Failed to unlink provider. Please try again."

Two separate bugs:

1. **The request really did fail.** Better Auth guards `/unlink-account` with `freshSessionMiddleware`, which rejects any session whose `createdAt` is older than `freshAge` — one day by default. `packages/auth/src/config.ts` never configured a `session` block, while sessions live for a week with sliding expiry. So on days 2–7 of any login, unlinking is impossible for every user, and there is no re-authentication flow to refresh that timestamp short of signing out and back in.

2. **The error message hid the reason.** `getReadableErrorMessage` only handled `string` and `Error`. Better Auth client errors are plain objects (`{ code, message, status }`), so every auth toast collapsed to its generic fallback.

Reproduced locally against Postgres with a real signed-up user and a linked account row:

```
FRESH RESULT: {"ok":true,"r":{"status":true}}
STALE RESULT: {"ok":false,"status":"FORBIDDEN","body":{"message":"Session is not fresh","code":"SESSION_NOT_FRESH"}}
```

## Fix

- `session: { freshAge: 0 }` in the Better Auth config — the documented way to disable the freshness gate.
- `getReadableErrorMessage` now reads `message` off plain error objects, which fixes the message for every auth toast (link, unlink, passkey, 2FA, password), not just this one.

Verified with the same repro after the change: `STALE AFTER FIX: {"ok":true,...}` on a 7-day-old session.

Unlinking your only remaining account still fails with `FAILED_TO_UNLINK_LAST_ACCOUNT` — intended behavior, and that message now actually reaches the toast.

## Tests

- `packages/auth/src/config.test.ts` — asserts the freshness gate stays disabled.
- `apps/web/src/libs/error-message.test.ts` — plain error objects, empty/non-string messages.
- `pnpm --filter @reactive-resume/auth test` 15 passed, `pnpm --filter web test` 569 passed, typecheck and Biome clean.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR allows provider unlinking throughout a session’s lifetime and improves messages shown for Better Auth failures.
- Disables Better Auth’s global session-freshness gate by setting `freshAge` to zero.
- Extracts nonempty string messages from plain error objects.
- Adds regression tests for session freshness and supported error shapes.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The configuration and message-handling changes match the documented intent, are covered by focused regression tests, and no reachable unintended failure was established.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/auth/src/config.ts | Disables the global freshness threshold so valid older sessions can access freshness-gated Better Auth operations. |
| packages/auth/src/config.test.ts | Adds a regression assertion that session freshness remains disabled. |
| apps/web/src/libs/error-message.ts | Extends readable-message extraction to nonempty string messages on plain objects. |
| apps/web/src/libs/error-message.test.ts | Covers Better Auth-style error objects and rejects empty or non-string message properties. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[User disconnects provider] --> B[Better Auth unlink-account]
  B --> C{Session valid?}
  C -->|No| D[Reject request]
  C -->|Yes| E[Unlink provider]
  D --> F[Plain client error object]
  F --> G[Display its message]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): allow unlinking providers aft..."](https://github.com/amruthpillai/reactive-resume/commit/50015878ae05b54834cfe7db328cc29927047d95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55057807)</sub>

<!-- /greptile_comment -->